### PR TITLE
Add package type verifier rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,4 @@ node_modules
 project.lock.json
 .build
 .vs/
-
+.vscode/

--- a/src/NuGetPackageVerifier/CompositeRules/AdxVerificationCompositeRule.cs
+++ b/src/NuGetPackageVerifier/CompositeRules/AdxVerificationCompositeRule.cs
@@ -2,9 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using System.IO;
-using NuGet.Packaging;
-using NuGetPackageVerifier.Logging;
 
 namespace NuGetPackageVerifier.Rules
 {
@@ -24,18 +21,16 @@ namespace NuGetPackageVerifier.Rules
             new AssemblyHasVersionAttributesRule(),
             new AssemblyStrongNameRule(),
             new PackageAuthorRule(),
+            new PackageTypesRule(),
             new SatellitePackageRule(),
             new StrictSemanticVersionValidationRule(),
         };
 
-        public IEnumerable<PackageVerifierIssue> Validate(
-            FileInfo nupkgFile,
-            IPackageMetadata package,
-            IPackageVerifierLogger logger)
+        public IEnumerable<PackageVerifierIssue> Validate(PackageAnalysisContext context)
         {
             foreach (var rule in _rules)
             {
-                foreach (var issue in rule.Validate(nupkgFile, package, logger))
+                foreach (var issue in rule.Validate(context))
                 {
                     yield return issue;
                 }

--- a/src/NuGetPackageVerifier/CompositeRules/DefaultCompositeRule.cs
+++ b/src/NuGetPackageVerifier/CompositeRules/DefaultCompositeRule.cs
@@ -2,9 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using System.IO;
-using NuGet.Packaging;
-using NuGetPackageVerifier.Logging;
 
 namespace NuGetPackageVerifier.Rules
 {
@@ -28,14 +25,11 @@ namespace NuGetPackageVerifier.Rules
             new StrictSemanticVersionValidationRule(),
         };
 
-        public IEnumerable<PackageVerifierIssue> Validate(
-            FileInfo nupkgFile,
-            IPackageMetadata package,
-            IPackageVerifierLogger logger)
+        public IEnumerable<PackageVerifierIssue> Validate(PackageAnalysisContext context)
         {
             foreach (var rule in _rules)
             {
-                foreach (var issue in rule.Validate(nupkgFile, package, logger))
+                foreach (var issue in rule.Validate(context))
                 {
                     yield return issue;
                 }

--- a/src/NuGetPackageVerifier/CompositeRules/NonAdxVerificationCompositeRule.cs
+++ b/src/NuGetPackageVerifier/CompositeRules/NonAdxVerificationCompositeRule.cs
@@ -2,9 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using System.IO;
-using NuGet.Packaging;
-using NuGetPackageVerifier.Logging;
 
 namespace NuGetPackageVerifier.Rules
 {
@@ -15,14 +12,11 @@ namespace NuGetPackageVerifier.Rules
             new AuthenticodeSigningRule(),
         };
 
-        public IEnumerable<PackageVerifierIssue> Validate(
-            FileInfo nupkgFile,
-            IPackageMetadata package,
-            IPackageVerifierLogger logger)
+        public IEnumerable<PackageVerifierIssue> Validate(PackageAnalysisContext context)
         {
             foreach (var rule in _rules)
             {
-                foreach (var issue in rule.Validate(nupkgFile, package, logger))
+                foreach (var issue in rule.Validate(context))
                 {
                     yield return issue;
                 }

--- a/src/NuGetPackageVerifier/CompositeRules/SigningVerificationCompositeRule.cs
+++ b/src/NuGetPackageVerifier/CompositeRules/SigningVerificationCompositeRule.cs
@@ -2,9 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using System.IO;
-using NuGet.Packaging;
-using NuGetPackageVerifier.Logging;
 
 namespace NuGetPackageVerifier.Rules
 {
@@ -19,14 +16,11 @@ namespace NuGetPackageVerifier.Rules
             new DefaultCompositeRule(),
         };
 
-        public IEnumerable<PackageVerifierIssue> Validate(
-            FileInfo nupkgFile,
-            IPackageMetadata package,
-            IPackageVerifierLogger logger)
+        public IEnumerable<PackageVerifierIssue> Validate(PackageAnalysisContext context)
         {
             foreach (var rule in _rules)
             {
-                foreach (var issue in rule.Validate(nupkgFile, package, logger))
+                foreach (var issue in rule.Validate(context))
                 {
                     yield return issue;
                 }

--- a/src/NuGetPackageVerifier/IPackageVerifierRule.cs
+++ b/src/NuGetPackageVerifier/IPackageVerifierRule.cs
@@ -2,19 +2,12 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using System.IO;
-using NuGet;
-using NuGet.Packaging;
-using NuGetPackageVerifier.Logging;
 
 namespace NuGetPackageVerifier
 {
     public interface IPackageVerifierRule
     {
-        IEnumerable<PackageVerifierIssue> Validate(
-            FileInfo nupkgFile,
-            IPackageMetadata package,
-            IPackageVerifierLogger logger);
+        IEnumerable<PackageVerifierIssue> Validate(PackageAnalysisContext context);
     }
 }
 

--- a/src/NuGetPackageVerifier/PackageAnalysisContext.cs
+++ b/src/NuGetPackageVerifier/PackageAnalysisContext.cs
@@ -1,0 +1,17 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO;
+using NuGet.Packaging;
+using NuGetPackageVerifier.Logging;
+
+namespace NuGetPackageVerifier
+{
+    public class PackageAnalysisContext
+    {
+        public FileInfo PackageFileInfo { get; set; }
+        public IPackageMetadata Metadata { get; set; }
+        public PackageVerifierOptions Options { get; set; }
+        public IPackageVerifierLogger Logger { get; set; }
+    }
+}

--- a/src/NuGetPackageVerifier/PackageAnalyzer.cs
+++ b/src/NuGetPackageVerifier/PackageAnalyzer.cs
@@ -2,10 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using NuGet.Packaging;
-using NuGetPackageVerifier.Logging;
 
 namespace NuGetPackageVerifier
 {
@@ -21,15 +18,12 @@ namespace NuGetPackageVerifier
             }
         }
 
-        public IEnumerable<PackageVerifierIssue> AnalyzePackage(
-            FileInfo nupkgFile,
-            IPackageMetadata package,
-            IPackageVerifierLogger logger)
+        public IEnumerable<PackageVerifierIssue> AnalyzePackage(PackageAnalysisContext context)
         {
             var packageIssues = new List<PackageVerifierIssue>();
             foreach (var rule in Rules)
             {
-                var issues = rule.Validate(nupkgFile, package, logger).ToList();
+                var issues = rule.Validate(context).ToList();
                 packageIssues = packageIssues.Concat(issues).ToList();
             }
 

--- a/src/NuGetPackageVerifier/PackageIssueFactory.cs
+++ b/src/NuGetPackageVerifier/PackageIssueFactory.cs
@@ -8,6 +8,24 @@ namespace NuGetPackageVerifier
 {
     public static class PackageIssueFactory
     {
+        public static PackageVerifierIssue PackageTypeMissing(string packageType)
+        {
+            return new PackageVerifierIssue(
+                "PACKAGE_TYPE_MISSING",
+                string.Format("Package type '{0}' not found in package metadata.", packageType),
+                PackageIssueLevel.Error
+            );
+        }
+
+        public static PackageVerifierIssue PackageTypeUnexpected(string packageType)
+        {
+            return new PackageVerifierIssue(
+                "PACKAGE_TYPE_UNEXPECTED",
+                string.Format("Unexpected package type '{0}' found in package metadata.", packageType),
+                PackageIssueLevel.Warning
+            );
+        }
+
         public static PackageVerifierIssue AssemblyMissingServicingAttribute(string assemblyPath)
         {
             return new PackageVerifierIssue(

--- a/src/NuGetPackageVerifier/PackageSet.cs
+++ b/src/NuGetPackageVerifier/PackageSet.cs
@@ -12,6 +12,6 @@ namespace NuGetPackageVerifier
 
         // List of packages(key), each with a set of rules to ignore(key), each with a set of instances(key),
         // each of which has a justification(value)
-        public IDictionary<string, IDictionary<string, IDictionary<string, string>>> Packages { get; set; }
+        public IDictionary<string, PackageVerifierOptions> Packages { get; set; }
     }
 }

--- a/src/NuGetPackageVerifier/PackageVerifierOptions.cs
+++ b/src/NuGetPackageVerifier/PackageVerifierOptions.cs
@@ -1,0 +1,19 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace NuGetPackageVerifier
+{
+    public class PackageVerifierOptions
+    {
+        // ignored warnings (with a justification)
+        // key = issueid
+        // values = <filename, justification>
+        public IDictionary<string, IDictionary<string, string>> NoWarn { get; set; }
+            = new Dictionary<string, IDictionary<string, string>>(StringComparer.OrdinalIgnoreCase);
+
+        public IList<string> PackageTypes { get; set; }
+    }
+}

--- a/src/NuGetPackageVerifier/README.md
+++ b/src/NuGetPackageVerifier/README.md
@@ -1,0 +1,21 @@
+NuGetPackageVerifier
+--------------------
+
+Internal tool for verifying a nupkg meets certain requirements.
+
+NuGetPackageVerifier.json schema
+```js
+{
+    "$ruleSetName$": { /* if $ruleSetName$ == 'Default', the ruleset is run for packages not listed in any other ruleset */
+        "rules": [ "$ruleNameToRun$" ],
+        "packages": {
+            "$packageId$": {
+                "nowarn": {
+                    "$warningId$": "$justification$"
+                },
+                "packageTypes": [ "$packageType$" ] /* Optional. For validating http://docs.nuget.org/create/package-types */
+            }
+        }
+    }
+}
+```

--- a/src/NuGetPackageVerifier/Rules/AssemblyHasAttributeRuleBase.cs
+++ b/src/NuGetPackageVerifier/Rules/AssemblyHasAttributeRuleBase.cs
@@ -7,18 +7,14 @@ using System.IO;
 using System.Linq;
 using Mono.Cecil;
 using NuGet.Packaging;
-using NuGetPackageVerifier.Logging;
 
 namespace NuGetPackageVerifier.Rules
 {
     public abstract class AssemblyHasAttributeRuleBase : IPackageVerifierRule
     {
-        public IEnumerable<PackageVerifierIssue> Validate(
-            FileInfo nupkgFile,
-            IPackageMetadata package,
-            IPackageVerifierLogger logger)
+        public IEnumerable<PackageVerifierIssue> Validate(PackageAnalysisContext context)
         {
-            using (var reader = new PackageArchiveReader(nupkgFile.FullName))
+            using (var reader = new PackageArchiveReader(context.PackageFileInfo.FullName))
             {
                 foreach (var currentFile in reader.GetFiles())
                 {

--- a/src/NuGetPackageVerifier/Rules/AssemblyHasCorrectJsonNetVersionRule.cs
+++ b/src/NuGetPackageVerifier/Rules/AssemblyHasCorrectJsonNetVersionRule.cs
@@ -2,10 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using NuGet.Packaging;
-using NuGetPackageVerifier.Logging;
 
 namespace NuGetPackageVerifier.Rules
 {
@@ -13,18 +10,15 @@ namespace NuGetPackageVerifier.Rules
     {
         private static readonly string ExpectedJsonNetVersion = "9.0.1";
 
-        public IEnumerable<PackageVerifierIssue> Validate(
-            FileInfo nupkgFile,
-            IPackageMetadata package,
-            IPackageVerifierLogger logger)
+        public IEnumerable<PackageVerifierIssue> Validate(PackageAnalysisContext context)
         {
-            foreach (var dependencySet in package.DependencyGroups)
+            foreach (var dependencySet in context.Metadata.DependencyGroups)
             {
                 var jsonDependency = dependencySet.Packages.FirstOrDefault(d => d.Id == "Newtonsoft.Json");
                 if (jsonDependency != null && !string.Equals(jsonDependency.VersionRange.MinVersion.ToString(), ExpectedJsonNetVersion))
                 {
                     yield return PackageIssueFactory.AssemblyHasWrongJsonNetVersion(
-                        package.Id,
+                        context.Metadata.Id,
                         dependencySet.TargetFramework.DotNetFrameworkName,
                         jsonDependency.VersionRange.MinVersion.ToString(),
                         ExpectedJsonNetVersion);

--- a/src/NuGetPackageVerifier/Rules/AssemblyHasDocumentFileRule.cs
+++ b/src/NuGetPackageVerifier/Rules/AssemblyHasDocumentFileRule.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using NuGetPackageVerifier.Logging;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
 
@@ -13,12 +12,9 @@ namespace NuGetPackageVerifier.Rules
 {
     public class AssemblyHasDocumentFileRule : IPackageVerifierRule
     {
-        public IEnumerable<PackageVerifierIssue> Validate(
-            FileInfo nupkgFile,
-            IPackageMetadata package,
-            IPackageVerifierLogger logger)
+        public IEnumerable<PackageVerifierIssue> Validate(PackageAnalysisContext context)
         {
-            using (var reader = new PackageArchiveReader(nupkgFile.FullName))
+            using (var reader = new PackageArchiveReader(context.PackageFileInfo.FullName))
             {
                 PackageIdentity identity;
                 string packageLanguage;

--- a/src/NuGetPackageVerifier/Rules/AssemblyStrongNameRule.cs
+++ b/src/NuGetPackageVerifier/Rules/AssemblyStrongNameRule.cs
@@ -16,12 +16,9 @@ namespace NuGetPackageVerifier.Rules
     {
         private static string _publicKeyToken = "ADB9793829DDAE60";
 
-        public IEnumerable<PackageVerifierIssue> Validate(
-            FileInfo nupkgFile,
-            IPackageMetadata package,
-            IPackageVerifierLogger logger)
+        public IEnumerable<PackageVerifierIssue> Validate(PackageAnalysisContext context)
         {
-            using (var reader = new PackageArchiveReader(nupkgFile.FullName))
+            using (var reader = new PackageArchiveReader(context.PackageFileInfo.FullName))
             {
                 foreach (var currentFile in reader.GetFiles())
                 {
@@ -69,7 +66,7 @@ namespace NuGetPackageVerifier.Rules
                         }
                         catch (Exception ex)
                         {
-                            logger.LogError(
+                            context.Logger.LogError(
                                 "Error while verifying strong name signature for {0}: {1}", currentFile, ex.Message);
                         }
                         finally

--- a/src/NuGetPackageVerifier/Rules/AuthenticodeSigningRule.cs
+++ b/src/NuGetPackageVerifier/Rules/AuthenticodeSigningRule.cs
@@ -12,16 +12,13 @@ namespace NuGetPackageVerifier.Rules
 {
     public class AuthenticodeSigningRule : IPackageVerifierRule
     {
-        public IEnumerable<PackageVerifierIssue> Validate(
-            FileInfo nupkgFile,
-            IPackageMetadata package,
-            IPackageVerifierLogger logger)
+        public IEnumerable<PackageVerifierIssue> Validate(PackageAnalysisContext context)
         {
             var extractPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
             try
             {
-                UnzipPackage(nupkgFile, extractPath);
-                using (var reader = new PackageArchiveReader(nupkgFile.FullName))
+                UnzipPackage(context.PackageFileInfo, extractPath);
+                using (var reader = new PackageArchiveReader(context.PackageFileInfo.FullName))
                 {
                     foreach (var current in reader.GetFiles())
                     {
@@ -39,7 +36,7 @@ namespace NuGetPackageVerifier.Rules
                                 realAssemblyPath = pathOfFileToScan.Replace("+", "%2B").Replace("#", "%23");
                                 if (!File.Exists(realAssemblyPath))
                                 {
-                                    logger.LogError(
+                                    context.Logger.LogError(
                                         "The assembly '{0}' in this package can't be found (a bug in this tool, most likely).",
                                         current);
 
@@ -58,7 +55,7 @@ namespace NuGetPackageVerifier.Rules
             }
             finally
             {
-                CleanUpFolder(extractPath, logger);
+                CleanUpFolder(extractPath, context.Logger);
             }
 
             yield break;

--- a/src/NuGetPackageVerifier/Rules/PackageAuthorRule.cs
+++ b/src/NuGetPackageVerifier/Rules/PackageAuthorRule.cs
@@ -2,10 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using NuGet.Packaging;
-using NuGetPackageVerifier.Logging;
 
 namespace NuGetPackageVerifier.Rules
 {
@@ -13,25 +10,22 @@ namespace NuGetPackageVerifier.Rules
     {
         private const string _expectedAuthor = "Microsoft";
 
-        public IEnumerable<PackageVerifierIssue> Validate(
-            FileInfo nupkgFile,
-            IPackageMetadata package,
-            IPackageVerifierLogger logger)
+        public IEnumerable<PackageVerifierIssue> Validate(PackageAnalysisContext context)
         {
-            if (package.Authors == null || package.Authors.Count() < 1)
+            if (context.Metadata.Authors == null || context.Metadata.Authors.Count() < 1)
             {
                 yield return PackageIssueFactory.RequiredAuthor();
             }
 
-            if (package.Authors.Count() > 1)
+            if (context.Metadata.Authors.Count() > 1)
             {
-                yield return PackageIssueFactory.SingleAuthorOnly(package.Id);
+                yield return PackageIssueFactory.SingleAuthorOnly(context.Metadata.Id);
             }
 
-            var author = package.Authors.First();
+            var author = context.Metadata.Authors.First();
             if (!string.Equals(author, _expectedAuthor, System.StringComparison.Ordinal))
             {
-                yield return PackageIssueFactory.AuthorIsIncorrect(package.Id, _expectedAuthor, author);
+                yield return PackageIssueFactory.AuthorIsIncorrect(context.Metadata.Id, _expectedAuthor, author);
             }
         }
     }

--- a/src/NuGetPackageVerifier/Rules/PackageTypesRule.cs
+++ b/src/NuGetPackageVerifier/Rules/PackageTypesRule.cs
@@ -1,0 +1,27 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace NuGetPackageVerifier.Rules
+{
+    public class PackageTypesRule : IPackageVerifierRule
+    {
+        public IEnumerable<PackageVerifierIssue> Validate(PackageAnalysisContext context)
+        {
+            var discoveredTypes = context.Metadata.PackageTypes.Select(t => t.Name);
+            var expectedTypes = context.Options.PackageTypes ?? Enumerable.Empty<string>();
+
+            foreach (var missing in expectedTypes.Except(discoveredTypes))
+            {
+                yield return PackageIssueFactory.PackageTypeMissing(missing);
+            }
+
+            foreach (var unexpected in discoveredTypes.Except(expectedTypes))
+            {
+                yield return PackageIssueFactory.PackageTypeUnexpected(unexpected);
+            }
+        }
+    }
+}

--- a/src/NuGetPackageVerifier/Rules/PowerShellScriptIsSignedRule.cs
+++ b/src/NuGetPackageVerifier/Rules/PowerShellScriptIsSignedRule.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using NuGetPackageVerifier.Logging;
 using NuGet.Packaging;
 
 namespace NuGetPackageVerifier.Rules
@@ -20,12 +19,9 @@ namespace NuGetPackageVerifier.Rules
             ".ps1xml"
         };
 
-        public IEnumerable<PackageVerifierIssue> Validate(
-            FileInfo nupkgFile,
-            IPackageMetadata package,
-            IPackageVerifierLogger logger)
+        public IEnumerable<PackageVerifierIssue> Validate(PackageAnalysisContext context)
         {
-            using (var reader = new PackageArchiveReader(nupkgFile.FullName))
+            using (var reader = new PackageArchiveReader(context.PackageFileInfo.FullName))
             {
                 foreach (var current in reader.GetFiles())
                 {

--- a/src/NuGetPackageVerifier/Rules/RequiredNuSpecInfoRule.cs
+++ b/src/NuGetPackageVerifier/Rules/RequiredNuSpecInfoRule.cs
@@ -2,36 +2,30 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using System.IO;
-using NuGet.Packaging;
-using NuGetPackageVerifier.Logging;
 
 namespace NuGetPackageVerifier.Rules
 {
     public class RequiredNuSpecInfoRule : IPackageVerifierRule
     {
-        public IEnumerable<PackageVerifierIssue> Validate(
-            FileInfo nupkgFile,
-            IPackageMetadata package,
-            IPackageVerifierLogger logger)
+        public IEnumerable<PackageVerifierIssue> Validate(PackageAnalysisContext context)
         {
-            if (string.IsNullOrEmpty(package.Copyright))
+            if (string.IsNullOrEmpty(context.Metadata.Copyright))
             {
                 yield return PackageIssueFactory.RequiredCopyright();
             }
-            if (package.LicenseUrl == null)
+            if (context.Metadata.LicenseUrl == null)
             {
                 yield return PackageIssueFactory.RequiredLicenseUrl();
             }
-            if (package.IconUrl == null)
+            if (context.Metadata.IconUrl == null)
             {
                 yield return PackageIssueFactory.RequiredIconUrl();
             }
-            if (package.ProjectUrl == null)
+            if (context.Metadata.ProjectUrl == null)
             {
                 yield return PackageIssueFactory.RequiredProjectUrl();
             }
-            if (!package.RequireLicenseAcceptance)
+            if (!context.Metadata.RequireLicenseAcceptance)
             {
                 yield return PackageIssueFactory.RequiredRequireLicenseAcceptanceTrue();
             }

--- a/src/NuGetPackageVerifier/Rules/RequiredPackageMetadataRule.cs
+++ b/src/NuGetPackageVerifier/Rules/RequiredPackageMetadataRule.cs
@@ -2,28 +2,22 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using System.IO;
-using NuGet.Packaging;
-using NuGetPackageVerifier.Logging;
 
 namespace NuGetPackageVerifier.Rules
 {
     public class RequiredPackageMetadataRule : IPackageVerifierRule
     {
-        public IEnumerable<PackageVerifierIssue> Validate(
-            FileInfo nupkgFile,
-            IPackageMetadata package,
-            IPackageVerifierLogger logger)
+        public IEnumerable<PackageVerifierIssue> Validate(PackageAnalysisContext context)
         {
-            if (string.IsNullOrEmpty(package.Summary))
+            if (string.IsNullOrEmpty(context.Metadata.Summary))
             {
                 yield return PackageIssueFactory.RequiredSummary();
             }
-            if (string.IsNullOrEmpty(package.Tags))
+            if (string.IsNullOrEmpty(context.Metadata.Tags))
             {
                 yield return PackageIssueFactory.RequiredTags();
             }
-            if (string.IsNullOrEmpty(package.Title))
+            if (string.IsNullOrEmpty(context.Metadata.Title))
             {
                 yield return PackageIssueFactory.RequiredTitle();
             }

--- a/src/NuGetPackageVerifier/Rules/SatellitePackageRule.cs
+++ b/src/NuGetPackageVerifier/Rules/SatellitePackageRule.cs
@@ -2,35 +2,30 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using System.IO;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
-using NuGetPackageVerifier.Logging;
 
 namespace NuGetPackageVerifier.Rules
 {
     public class SatellitePackageRule : IPackageVerifierRule
     {
-        public IEnumerable<PackageVerifierIssue> Validate(
-            FileInfo nupkgFile,
-            IPackageMetadata package,
-            IPackageVerifierLogger logger)
+        public IEnumerable<PackageVerifierIssue> Validate(PackageAnalysisContext context)
         {
-            using (var reader = new PackageArchiveReader(nupkgFile.FullName))
+            using (var reader = new PackageArchiveReader(context.PackageFileInfo.FullName))
             {
                 PackageIdentity identity;
                 string packageLanguage;
                 if (PackageHelper.IsSatellitePackage(reader, out identity, out packageLanguage))
                 {
-                    if (package.Summary.Contains("{"))
+                    if (context.Metadata.Summary.Contains("{"))
                     {
                         yield return PackageIssueFactory.Satellite_PackageSummaryNotLocalized();
                     }
-                    if (package.Title.Contains("{"))
+                    if (context.Metadata.Title.Contains("{"))
                     {
                         yield return PackageIssueFactory.Satellite_PackageTitleNotLocalized();
                     }
-                    if (package.Description.Contains("{"))
+                    if (context.Metadata.Description.Contains("{"))
                     {
                         yield return PackageIssueFactory.Satellite_PackageDescriptionNotLocalized();
                     }

--- a/src/NuGetPackageVerifier/Rules/StrictSemanticVersionValidationRule.cs
+++ b/src/NuGetPackageVerifier/Rules/StrictSemanticVersionValidationRule.cs
@@ -2,28 +2,22 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using System.IO;
-using NuGet.Packaging;
 using NuGet.Versioning;
-using NuGetPackageVerifier.Logging;
 
 namespace NuGetPackageVerifier.Rules
 {
     public class StrictSemanticVersionValidationRule : IPackageVerifierRule
     {
-        public IEnumerable<PackageVerifierIssue> Validate(
-            FileInfo nupkgFile,
-            IPackageMetadata package,
-            IPackageVerifierLogger logger)
+        public IEnumerable<PackageVerifierIssue> Validate(PackageAnalysisContext context)
         {
             SemanticVersion semanticVersion;
-            if (SemanticVersion.TryParse(package.Version.ToString(), out semanticVersion))
+            if (SemanticVersion.TryParse(context.Metadata.Version.ToString(), out semanticVersion))
             {
                 yield break;
             }
             else
             {
-                yield return PackageIssueFactory.NotSemanticVersion(package.Version);
+                yield return PackageIssueFactory.NotSemanticVersion(context.Metadata.Version);
             }
         }
     }


### PR DESCRIPTION
Adds rule to verify package type. http://docs.nuget.org/create/package-types

Breaks the the format of NuGetPackageVerifier.json schema. But this only affect one usage which is going to be updated to this anyways. (Updated here: https://github.com/aspnet/EntityFramework.Tools/pull/1)

Old:
```
"Microsoft.EntityFrameworkCore.Tools.DotNet": {
    "DOC_MISSING": {
        "lib/netcoreapp1.0/dotnet-ef.dll": "Not a class library. Docs not required for CLI tools"
    }
},
```

New:
```
"Microsoft.EntityFrameworkCore.Tools.DotNet": {
	"nowarn": {
	    "DOC_MISSING": {
	        "lib/netcoreapp1.0/dotnet-ef.dll": "Not a class library. Docs not required for CLI tools"
	    }
	},
    "packageTypes": [ "DotnetCliTool" ]
},
```
