### PR TITLE
Correctly parse dependencies under each TFM

### DIFF
--- a/src/VersionTool/Program.cs
+++ b/src/VersionTool/Program.cs
@@ -256,12 +256,15 @@ namespace VersionTool
             var frameworks = root.Property("frameworks")?.Value as JObject;
             if (frameworks != null)
             {
-                var frameworkDependencies = frameworks.Property("dependencies")?.Value as JObject;
-                if (frameworkDependencies != null)
+                foreach (var tfm in frameworks.Properties())
                 {
-                    foreach (var dependency in frameworkDependencies.Properties())
+                    var frameworkDependencies = (tfm?.Value as JObject)?.Property("dependencies")?.Value as JObject;
+                    if (frameworkDependencies != null)
                     {
-                        yield return dependency;
+                        foreach (var dependency in frameworkDependencies.Properties())
+                        {
+                            yield return dependency;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
@pranavkm While updating packages for the 1.0.3 patch I found that dependencies under specific TFMs were not being updated by the version tool. I think the tool is looking for the dependencies in the wrong place?

Also, not sure what runtime dependencies look like so I'm not sure if this applies.