### PR TITLE
Some bug fixes to the baseline generation and breaking change detection logic

### DIFF
--- a/src/Microsoft.AspNetCore.BuildTools.ApiCheck/ApiListing/ApiListing.cs
+++ b/src/Microsoft.AspNetCore.BuildTools.ApiCheck/ApiListing/ApiListing.cs
@@ -4,13 +4,17 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 
 namespace ApiCheck.Description
 {
     public class ApiListing
     {
         public string AssemblyIdentity { get; set; }
+
         public IList<TypeDescriptor> Types { get; } = new List<TypeDescriptor>();
+
+        public IEnumerable<Func<MemberInfo, bool>> SourceFilters { get; set; }
 
         public TypeDescriptor FindType(string name)
         {

--- a/src/Microsoft.AspNetCore.BuildTools.ApiCheck/ApiListingComparer.cs
+++ b/src/Microsoft.AspNetCore.BuildTools.ApiCheck/ApiListingComparer.cs
@@ -100,10 +100,16 @@ namespace ApiCheck
                     }
                 }
 
-                candidate = candidate.BaseType == null ? null : newApiListing.FindType(candidate.BaseType);
+                candidate = candidate.BaseType == null ? null : FindOrGenerateDescriptorForBaseType(newApiListing, candidate);
             }
 
             return acceptable;
+        }
+
+        private static TypeDescriptor FindOrGenerateDescriptorForBaseType(ApiListing newApiListing, TypeDescriptor candidate)
+        {
+            return newApiListing.FindType(candidate.BaseType) ??
+                ApiListingGenerator.GenerateTypeDescriptor(candidate.Source.BaseType.GetTypeInfo(), newApiListing.SourceFilters);
         }
 
         private bool SameSignature(MemberDescriptor original, MemberDescriptor candidate)
@@ -190,7 +196,7 @@ namespace ApiCheck
                 case TypeKind.Class:
                     return ImplementsAllInterfaces(oldType, newType) &&
                         (!newType.Sealed || oldType.Sealed == newType.Sealed) &&
-                        (!newType.Abstract || oldType.Sealed == newType.Abstract) &&
+                        (!newType.Abstract || oldType.Abstract == newType.Abstract) &&
                         newType.Static == oldType.Static &&
                         (oldType.BaseType == null || newType.BaseType == oldType.BaseType);
                 case TypeKind.Interface:

--- a/test/ApiCheck.Test/ApiListingGenerationTests.cs
+++ b/test/ApiCheck.Test/ApiListingGenerationTests.cs
@@ -400,6 +400,37 @@ namespace ApiCheck.Test
         }
 
         [Fact]
+        public void DetectsGenericInterfaceNestedWithinGenericClass()
+        {
+            // Arrange
+            var generator = CreateGenerator(V1Assembly);
+
+            // Act
+            var report = generator.GenerateApiListing();
+
+            // Assert
+            Assert.NotNull(report);
+            Assert.NotNull(report.Types);
+            var type = Assert.Single(report.Types, t => t.Id == "public interface Scenarios.GenericsAndNestedTypes<T0, T1>+IntermediateNonGenericNestedClass+AnotherNestedGenericClass<T2, T3>+ILeafGenericInterface<T4, T5>");
+        }
+
+        [Fact]
+        public void DetectsInstantiatedNestedGenericsCorrectly()
+        {
+            // Arrange
+            var generator = CreateGenerator(V1Assembly);
+
+            // Act
+            var report = generator.GenerateApiListing();
+
+            // Assert
+            Assert.NotNull(report);
+            Assert.NotNull(report.Types);
+            var type = Assert.Single(report.Types, t => t.Id == "public interface Scenarios.GenericsAndNestedTypes<T0, T1>+IntermediateNonGenericNestedClass+AnotherNestedGenericClass<T2, T3>+ILeafGenericInterface<T4, T5>");
+            var method = Assert.Single(type.Members, m => m.Id == "Scenarios.GenericsAndNestedTypes<T0, T1>+IntermediateNonGenericNestedClass+AnotherNestedGenericClass<T2, T3>+ILeafGenericInterface<System.Int32, System.Boolean> MultipleLevelGenericReturnType(Scenarios.GenericsAndNestedTypes<T0, T1>+IntermediateNonGenericNestedClass intermediate, Scenarios.GenericsAndNestedTypes<T0, T1>+IntermediateNonGenericNestedClass+AnotherNestedGenericClass<System.Boolean, System.Int32> another)");
+        }
+
+        [Fact]
         public void DetectsAbstractVoidMethod()
         {
             // Arrange

--- a/test/ApiCheckBaseline.V1/Scenarios.cs
+++ b/test/ApiCheckBaseline.V1/Scenarios.cs
@@ -454,6 +454,23 @@ namespace Scenarios
     {
         bool Accept();
     }
+
+    public class GenericsAndNestedTypes<T, K>
+    {
+        public class IntermediateNonGenericNestedClass
+        {
+            public class AnotherNestedGenericClass<V, W>
+            {
+                public interface ILeafGenericInterface<A,B>
+                {
+                    void GenericMethod<Z>();
+                    void NonGenericMethod<C>();
+
+                    ILeafGenericInterface<int, bool> MultipleLevelGenericReturnType(IntermediateNonGenericNestedClass intermediate, AnotherNestedGenericClass<bool, int> another);
+                }
+            }
+        }
+    }
 }
 
 namespace Scenarios.Internal


### PR DESCRIPTION
Fixed bug with nested generics.
Fixed bug about abstract classes changing to non abstract being detected as a breaking change.
Fixed bug about members moving up in a class hierarchy where the base class is on a different assembly.