### PR TITLE
NuGetPackageVerifier as an MSBuild target

### DIFF
--- a/BuildTools.sln
+++ b/BuildTools.sln
@@ -30,6 +30,8 @@ Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "ApiCheck.Test", "test\ApiCh
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.AspNetCore.BuildTools.ApiCheck", "src\Microsoft.AspNetCore.BuildTools.ApiCheck\Microsoft.AspNetCore.BuildTools.ApiCheck.xproj", "{AEFC7985-27C8-468E-8EF8-E1D589C9053F}"
 EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "NuGetPackageVerifier.Task", "src\NuGetPackageVerifier.Task\NuGetPackageVerifier.Task.xproj", "{EF38C1CA-8A2E-4C8E-B478-7072C0140514}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -72,6 +74,10 @@ Global
 		{AEFC7985-27C8-468E-8EF8-E1D589C9053F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{AEFC7985-27C8-468E-8EF8-E1D589C9053F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{AEFC7985-27C8-468E-8EF8-E1D589C9053F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EF38C1CA-8A2E-4C8E-B478-7072C0140514}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EF38C1CA-8A2E-4C8E-B478-7072C0140514}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EF38C1CA-8A2E-4C8E-B478-7072C0140514}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EF38C1CA-8A2E-4C8E-B478-7072C0140514}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -86,5 +92,6 @@ Global
 		{ECA89839-3332-43F3-B1B1-9C2D91B7285E} = {60A938B2-D95A-403C-AA7A-3683AD64DFA0}
 		{D61A892B-D214-44AB-9652-334C4338377B} = {60A938B2-D95A-403C-AA7A-3683AD64DFA0}
 		{AEFC7985-27C8-468E-8EF8-E1D589C9053F} = {A4F4353B-C3D2-40B0-909A-5B48A748EA76}
+		{EF38C1CA-8A2E-4C8E-B478-7072C0140514} = {A4F4353B-C3D2-40B0-909A-5B48A748EA76}
 	EndGlobalSection
 EndGlobal

--- a/samples/NuGetPackageVerifier.Sample/NuGetPackageVerifier.Sample.proj
+++ b/samples/NuGetPackageVerifier.Sample/NuGetPackageVerifier.Sample.proj
@@ -1,0 +1,13 @@
+﻿<Project ToolsVersion="15.0">
+  <PropertyGroup>
+    <RestoreSources>$(MSBuildThisFileDirectory)..\..\artifacts\build\</RestoreSources>
+    <TargetFramework>netcoreapp1.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="NuGetPackageVerifier" Version="1.0.1-*" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.Common.Targets" />
+  <Target Name="Build">
+    <VerifyPackages ArtifactDirectory="..\..\artifacts\build" RuleFile="rule.json" />
+  </Target>
+</Project>

--- a/samples/NuGetPackageVerifier.Sample/rule.json
+++ b/samples/NuGetPackageVerifier.Sample/rule.json
@@ -1,0 +1,5 @@
+{
+    "all": {
+        "rules": [ "DefaultCompositeRule" ]
+    }
+}

--- a/src/NuGetPackageVerifier.Task/NuGetPackageVerifier.Task.xproj
+++ b/src/NuGetPackageVerifier.Task/NuGetPackageVerifier.Task.xproj
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0.25420" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0.25420</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>ef38c1ca-8a2e-4c8e-b478-7072c0140514</ProjectGuid>
+    <RootNamespace>NuGetPackageVerifier.Task</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/src/NuGetPackageVerifier.Task/VerifyPackages.cs
+++ b/src/NuGetPackageVerifier.Task/VerifyPackages.cs
@@ -1,0 +1,71 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using Microsoft.Build.Framework;
+using MSBuildTask = Microsoft.Build.Utilities.Task;
+
+namespace NuGetPackagerVerifier
+{
+    /// <summary>
+    /// An MSBuild task that acts as a shim into NuGetPackageVerifier.dll
+    /// </summary>
+    public class VerifyPackages : MSBuildTask
+    {
+        [Required]
+        public string RuleFile { get; set; }
+
+        [Required]
+        public string ArtifactDirectory { get; set; }
+
+        public override bool Execute()
+        {
+            if (string.IsNullOrEmpty(RuleFile) || !File.Exists(RuleFile))
+            {
+                Log.LogError("RuleFile '{RuleFile}' does not exist");
+                return false;
+            }
+
+            // prevent trailing slash from breaking the surrounding quotes
+            ArtifactDirectory = ArtifactDirectory?.TrimEnd(new [] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar });
+
+            if (string.IsNullOrEmpty(ArtifactDirectory) || !Directory.Exists(ArtifactDirectory))
+            {
+                Log.LogError("ArtifactDirectory '{ArtifactDirectory}' does not exist");
+                return false;
+            }
+
+            var exeExtension = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                ? ".exe"
+                : string.Empty;
+
+            var taskAssemblyFolder = Path.GetDirectoryName(GetType().GetTypeInfo().Assembly.Location);
+            var toolPath = Path.Combine(taskAssemblyFolder, "../../NuGetPackageVerifier.dll");
+            var dotnetPath = new FileInfo(AppContext.GetData("FX_DEPS_FILE") as string)
+                .Directory? // 1.0.1
+                .Parent? // Microsoft.NETCore.App
+                .Parent? // shared
+                .Parent? // DOTNET_HOME
+                .GetFiles("dotnet" + exeExtension)
+                .SingleOrDefault();
+
+            var psi = new ProcessStartInfo
+            {
+                FileName = dotnetPath?.Exists == true
+                    ? dotnetPath.FullName
+                    : "dotnet",  // Fallback to system PATH and hope for the best
+                Arguments = $"\"{toolPath}\" \"{ArtifactDirectory}\" \"{RuleFile}\""
+            };
+
+            Log.LogMessage($"Executing '{psi.FileName} {psi.Arguments}'");
+            var process = Process.Start(psi);
+            process.WaitForExit();
+            return process.ExitCode == 0;
+        }
+    }
+}

--- a/src/NuGetPackageVerifier.Task/project.json
+++ b/src/NuGetPackageVerifier.Task/project.json
@@ -1,0 +1,14 @@
+{
+  "buildOptions": {
+    "warningsAsErrors": true,
+    "copyToOutput": "build/**/*.targets"
+  },
+  "dependencies": {
+    "Microsoft.Build.Framework": "15.1.0-preview-000370-00",
+    "Microsoft.Build.Tasks.Core": "15.1.0-preview-000370-00",
+    "Microsoft.Build.Utilities.Core": "15.1.0-preview-000370-00"
+  },
+  "frameworks": {
+    "netstandard1.6": {}
+  }
+}

--- a/src/NuGetPackageVerifier/NuGetPackageVerifier.nuspec
+++ b/src/NuGetPackageVerifier/NuGetPackageVerifier.nuspec
@@ -8,5 +8,6 @@
   </metadata>
   <files>
     <file src="netcoreapp1.0\" target="/" />
+    <file src="..\..\build\NuGetPackageVerifier.Task\$configuration$\netstandard1.6\NuGetPackageVerifier.Task.dll" target="tools/netstandard1.6/" />
   </files>
 </package>

--- a/src/NuGetPackageVerifier/build/NuGetPackageVerifier.targets
+++ b/src/NuGetPackageVerifier/build/NuGetPackageVerifier.targets
@@ -1,0 +1,4 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <UsingTask AssemblyFile="$(MSBuildThisFileDirectory)..\tools\netstandard1.6\NuGetPackageVerifier.Task.dll"
+               TaskName="NuGetPackagerVerifier.VerifyPackages" />
+</Project>

--- a/src/NuGetPackageVerifier/project.json
+++ b/src/NuGetPackageVerifier/project.json
@@ -5,6 +5,9 @@
     "emitEntryPoint": true,
     "embed": [ "already-owned-packages.txt" ]
   },
+  "publishOptions": {
+    "include": "build/*.targets"
+  },
   "dependencies": {
     "HtmlAgilityPack": "1.4.9",
     "Newtonsoft.Json": "9.0.1",


### PR DESCRIPTION
Wrap NuGetPackageVerifier  in an MSBuild target so it can be included in a build project as a post-pack step.

~~Also upgrades to NuGet 4.0 to support new metadata elements such as `<repository>`~~

cc @pranavkm @ajaybhargavb 