### PR TITLE
Upgrade NuGetPackageVerifier to NuGet 4.0.0-rc-2048

### DIFF
--- a/src/NuGetPackageVerifier/project.json
+++ b/src/NuGetPackageVerifier/project.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "HtmlAgilityPack": "1.4.9",
     "Newtonsoft.Json": "9.0.1",
-    "NuGet.Packaging": "3.5.0-beta2-*",
+    "NuGet.Packaging": "4.0.0-rc-2048",
     "Mono.Cecil": "0.9.5.4"
   },
   "frameworks": {


### PR DESCRIPTION
NuGet 3.5.0-beta2 fails if the metadata includes the new `<repository>` element that will be added to the nuspec when using NuGet 4 pack targets (aka dotnet-CLI for MSBuild).

cc @prafullbhosale @pranavkm 