### PR TITLE
:arrow_up: NugetPackageVerifier to 1.0.2

### DIFF
--- a/src/NuGetPackageVerifier/project.json
+++ b/src/NuGetPackageVerifier/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.1-*",
+  "version": "1.0.2-*",
   "description": "Verifies Asp.Net Core NuGet packages.",
   "buildOptions": {
     "emitEntryPoint": true,


### PR DESCRIPTION
Requires explicit opt in to the change from net451 to netcoreapp1.0.

cc @pranavkm @ajaybhargavb everyone was broken because KoreBuild needs updating and the netcoreapp1.0 version has issues