### PR TITLE
Unify tools version to 1.0.2

### DIFF
--- a/makefile.shade
+++ b/makefile.shade
@@ -21,7 +21,7 @@ k-standard-goals
       { "PackageCacheUploader", new [] { "netcoreapp1.0" } },
       { "DependenciesPackager", new [] { "netcoreapp1.0" } },
       { "NuGetPackageVerifier", new [] { "netcoreapp1.0" } },
-      { "SplitPackages", new [] { "net451" } },
+      { "SplitPackages", new [] { "netcoreapp1.0" } },
     };
 
     var outputDir = Path.Combine(TARGET_DIR, "build");

--- a/src/DependenciesPackager/DependenciesPackager.csproj
+++ b/src/DependenciesPackager/DependenciesPackager.csproj
@@ -4,7 +4,6 @@
 
   <PropertyGroup>
     <Description>Creates a zip package with the expanded version of our nuget packages that can be used as a local cache</Description>
-    <VersionPrefix>1.0.1</VersionPrefix>
     <TargetFramework>netcoreapp1.0</TargetFramework>
     <OutputType>exe</OutputType>
   </PropertyGroup>

--- a/src/Microsoft.AspNetCore.BuildTools.ApiCheck/Microsoft.AspNetCore.BuildTools.ApiCheck.csproj
+++ b/src/Microsoft.AspNetCore.BuildTools.ApiCheck/Microsoft.AspNetCore.BuildTools.ApiCheck.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
-    <VersionPrefix>1.0.1</VersionPrefix>
     <TargetFrameworks>netcoreapp1.0;net451</TargetFrameworks>
     <RuntimeIdentifier Condition=" '$(TargetFramework)'!='netcoreapp1.0' ">win7-x64</RuntimeIdentifier>
     <Platform>AnyCPU</Platform>

--- a/src/NuGetPackageVerifier/NuGetPackageVerifier.csproj
+++ b/src/NuGetPackageVerifier/NuGetPackageVerifier.csproj
@@ -4,7 +4,6 @@
 
   <PropertyGroup>
     <Description>Verifies Asp.Net Core NuGet packages.</Description>
-    <VersionPrefix>1.0.2</VersionPrefix>
     <TargetFramework>netcoreapp1.0</TargetFramework>
     <AssemblyName>NuGetPackageVerifier</AssemblyName>
     <OutputType>exe</OutputType>

--- a/src/PackageCacheUploader/PackageCacheUploader.csproj
+++ b/src/PackageCacheUploader/PackageCacheUploader.csproj
@@ -4,7 +4,6 @@
 
   <PropertyGroup>
     <Description>Creates a zip package with the expanded version of our nuget packages that can be used as a local cache</Description>
-    <VersionPrefix>1.0.1</VersionPrefix>
     <TargetFramework>netcoreapp1.0</TargetFramework>
     <OutputType>exe</OutputType>
     <PackageTargetFallback>$(PackageTargetFallback);portable-win8+net45</PackageTargetFallback>

--- a/src/PackageCacheUploader/PackageCacheUploader.nuspec
+++ b/src/PackageCacheUploader/PackageCacheUploader.nuspec
@@ -7,6 +7,6 @@
     <description>Upload package cache to Azure Storage</description>
   </metadata>
   <files>
-    <file src="netcoreapp1.0\" target="/" />
+    <file src="netcoreapp1.0\" target="tools/netcoreapp1.0/" />
   </files>
 </package>

--- a/src/PackageClassifier/PackageClassifier.csproj
+++ b/src/PackageClassifier/PackageClassifier.csproj
@@ -4,8 +4,7 @@
 
   <PropertyGroup>
     <Description>Classifies a set of packages from several directories based on information from a csv file</Description>
-    <VersionPrefix>1.0.1</VersionPrefix>
-    <TargetFrameworks>netstandard1.6;net451</TargetFrameworks>
+    <TargetFrameworks>netstandard1.6</TargetFrameworks>
     <OutputType>library</OutputType>
   </PropertyGroup>
 
@@ -19,10 +18,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="1.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-    <PackageReference Include="NuGet.Client" Version="3.5.0-*" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
+    <PackageReference Include="NuGet.Client" Version="3.5.0" />
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.1.1" />
   </ItemGroup>
 

--- a/src/SplitPackages/SplitPackages.csproj
+++ b/src/SplitPackages/SplitPackages.csproj
@@ -2,9 +2,7 @@
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
     <Description>Copies NuGet packages form a given source folder into a specific set of folders based on a CSV file.</Description>
-    <VersionPrefix>1.0.1</VersionPrefix>
-    <TargetFrameworks>netcoreapp1.0;net451</TargetFrameworks>
-    <RuntimeIdentifier Condition=" '$(TargetFramework)'!='netcoreapp1.0' ">win7-x64</RuntimeIdentifier>
+    <TargetFrameworks>netcoreapp1.0</TargetFrameworks>
     <DebugType>portable</DebugType>
     <OutputType>exe</OutputType>
   </PropertyGroup>
@@ -15,36 +13,13 @@
   <ItemGroup>
     <ProjectReference Include="..\PackageClassifier\PackageClassifier.csproj" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
-    <Reference Include="Microsoft.CSharp">
-      <FromP2P>true</FromP2P>
-    </Reference>
-    <Reference Include="System.Collections">
-      <FromP2P>true</FromP2P>
-    </Reference>
-    <Reference Include="System.Xml.Linq">
-      <FromP2P>true</FromP2P>
-    </Reference>
-    <Reference Include="System.Threading">
-      <FromP2P>true</FromP2P>
-    </Reference>
-    <Reference Include="System.IO.Compression.FileSystem">
-      <FromP2P>true</FromP2P>
-    </Reference>
-    <Reference Include="System.Runtime.Serialization.Primitives">
-      <FromP2P>true</FromP2P>
-    </Reference>
-    <Reference Include="System" />
-  </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.CommandLineUtils" Version="1.0.0-*" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="1.0.0-*" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.0.0-*" />
+    <PackageReference Include="Microsoft.Extensions.CommandLineUtils" Version="1.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="1.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-    <PackageReference Include="NuGet.Client" Version="3.5.0-*" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">
-    <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.1.1-*" />
-    <PackageReference Include="Microsoft.NETCore.App" Version="1.0.0-*" />
+    <PackageReference Include="NuGet.Client" Version="3.5.0" />
+    <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.1.1" />
+    <PackageReference Include="Microsoft.NETCore.App" Version="1.0.0" />
   </ItemGroup>
 </Project>

--- a/src/SplitPackages/SplitPackages.nuspec
+++ b/src/SplitPackages/SplitPackages.nuspec
@@ -7,6 +7,6 @@
     <description>Splits Asp.Net Core packages.</description>
   </metadata>
   <files>
-    <file src="net451\" target="/" />
+    <file src="netcoreapp1.0\" target="tools/netcoreapp1.0/" />
   </files>
 </package>

--- a/version.props
+++ b/version.props
@@ -1,6 +1,7 @@
 <!-- This file may be overwritten by automation. Only values allowed here are VersionPrefix and VersionSuffix.  -->
 <Project>
     <PropertyGroup>
+        <VersionPrefix>1.0.2</VersionPrefix>
         <VersionSuffix>rc2</VersionSuffix>
     </PropertyGroup>
 </Project>


### PR DESCRIPTION
Stop cross-compiling SplitPackages for net451.

Will require some changes to KoreBuild to consume newer versions and change the invocation for netcoreapp1.0 tools.

Follow up to #138 

cc @jbagga 