### PR TITLE
Add BuildItemsRule

### DIFF
--- a/src/NuGetPackageVerifier/CompositeRules/DefaultCompositeRule.cs
+++ b/src/NuGetPackageVerifier/CompositeRules/DefaultCompositeRule.cs
@@ -25,6 +25,7 @@ namespace NuGetPackageVerifier.Rules
             new DependenciesVersionRangeBoundsRule(),
             new DotNetCliToolPackageRule(),
             new PackageVersionMatchesAssemblyVersionRule(),
+            new BuildItemsRule(),
         };
 
         public IEnumerable<PackageVerifierIssue> Validate(PackageAnalysisContext context)

--- a/src/NuGetPackageVerifier/PackageAnalysisContext.cs
+++ b/src/NuGetPackageVerifier/PackageAnalysisContext.cs
@@ -1,17 +1,36 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.IO;
 using NuGet.Packaging;
 using NuGetPackageVerifier.Logging;
 
 namespace NuGetPackageVerifier
 {
-    public class PackageAnalysisContext
+    public class PackageAnalysisContext : IDisposable
     {
+        private PackageArchiveReader _reader;
+
         public FileInfo PackageFileInfo { get; set; }
         public IPackageMetadata Metadata { get; set; }
         public PackageVerifierOptions Options { get; set; }
         public IPackageVerifierLogger Logger { get; set; }
+        public PackageArchiveReader PackageReader
+        {
+            get
+            {
+                if (_reader == null)
+                {
+                    _reader = new PackageArchiveReader(PackageFileInfo.FullName);
+                }
+                return _reader;
+            }
+        }
+
+        public void Dispose()
+        {
+            _reader?.Dispose();
+        }
     }
 }

--- a/src/NuGetPackageVerifier/PackageIssueFactory.cs
+++ b/src/NuGetPackageVerifier/PackageIssueFactory.cs
@@ -315,5 +315,10 @@ namespace NuGetPackageVerifier
 
         public static PackageVerifierIssue DotNetCliToolMustTargetFramework(NuGetFramework framework)
             => new PackageVerifierIssue("DOTNETCLITOOL_FRAMEWORK", $"DotnetCliTool package must target {framework}", PackageIssueLevel.Error);
+
+        public static PackageVerifierIssue BuildItemsDoNotMatchFrameworks(string id, NuGetFramework framework)
+            => new PackageVerifierIssue("BUILD_ITEMS_FRAMEWORK",
+                $"'{id}' contains an MSBuild item for {framework} even though the package does not define a dependency group for this framework.",
+                PackageIssueLevel.Warning);
     }
 }

--- a/src/NuGetPackageVerifier/Program.cs
+++ b/src/NuGetPackageVerifier/Program.cs
@@ -162,15 +162,17 @@ namespace NuGetPackageVerifier
                             var package = packagePair.Key;
                             logger.LogInfo("Analyzing {0} ({1})", package.Id, package.Version);
 
-                            var context = new PackageAnalysisContext
+                            List<PackageVerifierIssue> issues;
+                            using (var context = new PackageAnalysisContext
                             {
                                 PackageFileInfo = packagePair.Value,
                                 Metadata = package,
                                 Logger = logger,
                                 Options = packageInfo.Value
-                            };
-
-                            var issues = analyzer.AnalyzePackage(context).ToList();
+                            })
+                            {
+                                issues = analyzer.AnalyzePackage(context).ToList();
+                            }
 
                             var packageErrorsAndWarnings = ProcessPackageIssues(
                                 ignoreAssistanceMode,
@@ -223,14 +225,16 @@ namespace NuGetPackageVerifier
                 {
                     logger.LogInfo("Analyzing {0} ({1})", unlistedPackage.Id, unlistedPackage.Version);
 
-                    var context = new PackageAnalysisContext
+                    List<PackageVerifierIssue> issues;
+                    using (var context = new PackageAnalysisContext
                     {
                         PackageFileInfo = packages[unlistedPackage],
                         Metadata = unlistedPackage,
                         Logger = logger
-                    };
-
-                    var issues = analyzer.AnalyzePackage(context).ToList();
+                    })
+                    {
+                        issues = analyzer.AnalyzePackage(context).ToList();
+                    }
 
                     var packageErrorsAndWarnings = ProcessPackageIssues(
                         ignoreAssistanceMode,

--- a/src/NuGetPackageVerifier/Rules/AssemblyStrongNameRule.cs
+++ b/src/NuGetPackageVerifier/Rules/AssemblyStrongNameRule.cs
@@ -5,9 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Runtime.Loader;
 using Mono.Cecil;
-using NuGet.Packaging;
 using NuGetPackageVerifier.Logging;
 
 namespace NuGetPackageVerifier.Rules
@@ -18,75 +16,72 @@ namespace NuGetPackageVerifier.Rules
 
         public IEnumerable<PackageVerifierIssue> Validate(PackageAnalysisContext context)
         {
-            using (var reader = new PackageArchiveReader(context.PackageFileInfo.FullName))
+            foreach (var currentFile in context.PackageReader.GetFiles())
             {
-                foreach (var currentFile in reader.GetFiles())
+                var extension = Path.GetExtension(currentFile);
+                if (extension.Equals(".dll", StringComparison.OrdinalIgnoreCase) ||
+                    extension.Equals(".exe", StringComparison.OrdinalIgnoreCase))
                 {
-                    var extension = Path.GetExtension(currentFile);
-                    if (extension.Equals(".dll", StringComparison.OrdinalIgnoreCase) ||
-                        extension.Equals(".exe", StringComparison.OrdinalIgnoreCase))
+                    var assemblyPath = Path.ChangeExtension(
+                        Path.Combine(Path.GetTempPath(), Path.GetTempFileName()), extension);
+
+                    var isManagedCode = false;
+                    var isStrongNameSigned = false;
+                    var hasCorrectPublicKeyToken = false;
+                    var hresult = 0;
+
+                    try
                     {
-                        var assemblyPath = Path.ChangeExtension(
-                            Path.Combine(Path.GetTempPath(), Path.GetTempFileName()), extension);
-
-                        var isManagedCode = false;
-                        var isStrongNameSigned = false;
-                        var hasCorrectPublicKeyToken = false;
-                        var hresult = 0;
-
-                        try
+                        using (var packageFileStream = context.PackageReader.GetStream(currentFile))
+                        using (var fileStream = File.OpenWrite(assemblyPath))
                         {
-                            using (var packageFileStream = reader.GetStream(currentFile))
-                            using (var fileStream = File.OpenWrite(assemblyPath))
-                            {
-                                packageFileStream.CopyTo(fileStream);
-                            }
+                            packageFileStream.CopyTo(fileStream);
+                        }
 
-                            if (AssemblyHelpers.IsAssemblyManaged(assemblyPath))
+                        if (AssemblyHelpers.IsAssemblyManaged(assemblyPath))
+                        {
+                            isManagedCode = true;
+                            using (var assembly = AssemblyDefinition.ReadAssembly(assemblyPath))
                             {
-                                isManagedCode = true;
-                                using (var assembly = AssemblyDefinition.ReadAssembly(assemblyPath))
+                                if (assembly.Modules.Any())
                                 {
-                                    if (assembly.Modules.Any())
-                                    {
-                                        isStrongNameSigned = assembly.Modules.All(
-                                            module => module.Attributes.HasFlag(ModuleAttributes.StrongNameSigned));
-                                    }
-                                    else
-                                    {
-                                        throw new InvalidOperationException("The managed assembly does not contain any modules.");
-                                    }
+                                    isStrongNameSigned = assembly.Modules.All(
+                                        module => module.Attributes.HasFlag(ModuleAttributes.StrongNameSigned));
+                                }
+                                else
+                                {
+                                    throw new InvalidOperationException("The managed assembly does not contain any modules.");
+                                }
 
-                                    var tokenHexString = BitConverter.ToString(assembly.Name.PublicKeyToken).Replace("-", "");
-                                    if (_publicKeyToken.Equals(tokenHexString, StringComparison.OrdinalIgnoreCase))
-                                    {
-                                        hasCorrectPublicKeyToken = true;
-                                    }
+                                var tokenHexString = BitConverter.ToString(assembly.Name.PublicKeyToken).Replace("-", "");
+                                if (_publicKeyToken.Equals(tokenHexString, StringComparison.OrdinalIgnoreCase))
+                                {
+                                    hasCorrectPublicKeyToken = true;
                                 }
                             }
                         }
-                        catch (Exception ex)
+                    }
+                    catch (Exception ex)
+                    {
+                        context.Logger.LogError(
+                            "Error while verifying strong name signature for {0}: {1}", currentFile, ex.Message);
+                    }
+                    finally
+                    {
+                        if (File.Exists(assemblyPath))
                         {
-                            context.Logger.LogError(
-                                "Error while verifying strong name signature for {0}: {1}", currentFile, ex.Message);
+                            File.Delete(assemblyPath);
                         }
-                        finally
-                        {
-                            if (File.Exists(assemblyPath))
-                            {
-                                File.Delete(assemblyPath);
-                            }
-                        }
+                    }
 
-                        if (isManagedCode && !isStrongNameSigned)
-                        {
-                            yield return PackageIssueFactory.AssemblyNotStrongNameSigned(currentFile, hresult);
-                        }
+                    if (isManagedCode && !isStrongNameSigned)
+                    {
+                        yield return PackageIssueFactory.AssemblyNotStrongNameSigned(currentFile, hresult);
+                    }
 
-                        if (isManagedCode && !hasCorrectPublicKeyToken)
-                        {
-                            yield return PackageIssueFactory.AssemblyHasWrongPublicKeyToken(currentFile, _publicKeyToken);
-                        }
+                    if (isManagedCode && !hasCorrectPublicKeyToken)
+                    {
+                        yield return PackageIssueFactory.AssemblyHasWrongPublicKeyToken(currentFile, _publicKeyToken);
                     }
                 }
             }

--- a/src/NuGetPackageVerifier/Rules/BuildItemsRule.cs
+++ b/src/NuGetPackageVerifier/Rules/BuildItemsRule.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using NuGet.Frameworks;
+
+namespace NuGetPackageVerifier.Rules
+{
+    public class BuildItemsRule : IPackageVerifierRule
+    {
+        public IEnumerable<PackageVerifierIssue> Validate(PackageAnalysisContext context)
+        {
+            var dependencyFrameworks = new HashSet<NuGetFramework>(
+                context.Metadata.DependencyGroups.Select(g => g.TargetFramework));
+
+            var buildItems = context
+                .PackageReader
+                .GetBuildItems()
+                .Where(f => f.Items.Any(i => IsCandidateMSBuildItem(i, context.Metadata.Id)));
+
+            foreach (var buildItem in buildItems)
+            {
+                if (!dependencyFrameworks.Contains(buildItem.TargetFramework))
+                {
+                    yield return PackageIssueFactory
+                        .BuildItemsDoNotMatchFrameworks(context.Metadata.Id, buildItem.TargetFramework);
+                }
+            }
+        }
+
+        private bool IsCandidateMSBuildItem(string file, string packageId)
+        {
+            if (!packageId.Equals(Path.GetFileNameWithoutExtension(file),
+                StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            var ext = Path.GetExtension(file);
+            return ".props".Equals(ext, StringComparison.OrdinalIgnoreCase)
+                || ".targets".Equals(ext, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/src/NuGetPackageVerifier/Rules/PowerShellScriptIsSignedRule.cs
+++ b/src/NuGetPackageVerifier/Rules/PowerShellScriptIsSignedRule.cs
@@ -21,17 +21,14 @@ namespace NuGetPackageVerifier.Rules
 
         public IEnumerable<PackageVerifierIssue> Validate(PackageAnalysisContext context)
         {
-            using (var reader = new PackageArchiveReader(context.PackageFileInfo.FullName))
+            foreach (var current in context.PackageReader.GetFiles())
             {
-                foreach (var current in reader.GetFiles())
+                var extension = Path.GetExtension(current);
+                if (PowerShellExtensions.Contains(extension, StringComparer.OrdinalIgnoreCase))
                 {
-                    var extension = Path.GetExtension(current);
-                    if (PowerShellExtensions.Contains(extension, StringComparer.OrdinalIgnoreCase))
+                    if (!VerifySigned(context.PackageReader, current))
                     {
-                        if (!VerifySigned(reader, current))
-                        {
-                            yield return PackageIssueFactory.PowerShellScriptNotSigned(current);
-                        }
+                        yield return PackageIssueFactory.PowerShellScriptNotSigned(current);
                     }
                 }
             }

--- a/src/NuGetPackageVerifier/Rules/SatellitePackageRule.cs
+++ b/src/NuGetPackageVerifier/Rules/SatellitePackageRule.cs
@@ -11,24 +11,21 @@ namespace NuGetPackageVerifier.Rules
     {
         public IEnumerable<PackageVerifierIssue> Validate(PackageAnalysisContext context)
         {
-            using (var reader = new PackageArchiveReader(context.PackageFileInfo.FullName))
+            PackageIdentity identity;
+            string packageLanguage;
+            if (PackageHelper.IsSatellitePackage(context.PackageReader, out identity, out packageLanguage))
             {
-                PackageIdentity identity;
-                string packageLanguage;
-                if (PackageHelper.IsSatellitePackage(reader, out identity, out packageLanguage))
+                if (context.Metadata.Summary.Contains("{"))
                 {
-                    if (context.Metadata.Summary.Contains("{"))
-                    {
-                        yield return PackageIssueFactory.Satellite_PackageSummaryNotLocalized();
-                    }
-                    if (context.Metadata.Title.Contains("{"))
-                    {
-                        yield return PackageIssueFactory.Satellite_PackageTitleNotLocalized();
-                    }
-                    if (context.Metadata.Description.Contains("{"))
-                    {
-                        yield return PackageIssueFactory.Satellite_PackageDescriptionNotLocalized();
-                    }
+                    yield return PackageIssueFactory.Satellite_PackageSummaryNotLocalized();
+                }
+                if (context.Metadata.Title.Contains("{"))
+                {
+                    yield return PackageIssueFactory.Satellite_PackageTitleNotLocalized();
+                }
+                if (context.Metadata.Description.Contains("{"))
+                {
+                    yield return PackageIssueFactory.Satellite_PackageDescriptionNotLocalized();
                 }
             }
 


### PR DESCRIPTION
Add PackageArchiveReader to analysis context. Avoids creating redundant read streams when running multiple rules.

Adds a rule to check if MSBuild items in a package match the target frameworks listed in metadata. Resolves #168