### PR TITLE
Add XmlPoke2 task as a substitute for XmlPoke on .NET Core

### DIFF
--- a/src/Internal.AspNetCore.BuildTools.Tasks/Internal.AspNetCore.BuildTools.Tasks.csproj
+++ b/src/Internal.AspNetCore.BuildTools.Tasks/Internal.AspNetCore.BuildTools.Tasks.csproj
@@ -24,6 +24,11 @@
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="15.1.0-*" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.1.0-*" PrivateAssets="All" />
   </ItemGroup>
+  
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3' ">
+    <PackageReference Include="System.Xml.XmlDocument" Version="4.0.1" PrivateAssets="All" />
+    <PackageReference Include="System.Xml.XPath.XmlDocument" Version="4.0.1" PrivateAssets="All" />
+  </ItemGroup>
 
  <Target Name="SetPackageProperties" BeforeTargets="GenerateNuspec">
     <PropertyGroup>

--- a/src/Internal.AspNetCore.BuildTools.Tasks/XmlPoke2.cs
+++ b/src/Internal.AspNetCore.BuildTools.Tasks/XmlPoke2.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO;
+using System.Xml;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+// TODO remove when XmlPoke is restored to MSBuild 15.2
+namespace Microsoft.AspNetCore.BuildTools
+{
+    /// <summary>
+    /// Similar behavior as MSBuild's XmlPoke task, but for .NET Core.
+    /// </summary>
+    public class XmlPoke2 : Task
+    {
+        [Required]
+        public ITaskItem XmlInputPath { get; set; }
+
+        [Required]
+        public string Query { get; set; }
+
+        [Required]
+        public ITaskItem Value { get; set; }
+
+        public override bool Execute()
+        {
+            var xmlDoc = new XmlDocument();
+            var xrs = new XmlReaderSettings()
+            {
+                DtdProcessing = DtdProcessing.Ignore
+            };
+
+            using (var sr = XmlReader.Create(XmlInputPath.ItemSpec, xrs))
+            {
+                xmlDoc.Load(sr);
+            }
+
+            var nav = xmlDoc.CreateNavigator();
+            var expr = nav.Compile(Query);
+            var iter = nav.Select(expr);
+            while (iter.MoveNext())
+            {
+                iter.Current.InnerXml = Value.ItemSpec;
+            }
+
+            if (iter.Count > 0)
+            {
+                using (var file = new FileStream(XmlInputPath.ItemSpec, FileMode.Create))
+                {
+                    Log.LogMessage(MessageImportance.Normal, "Updating {0}", XmlInputPath.ItemSpec);
+                    xmlDoc.Save(file);
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/Internal.AspNetCore.BuildTools.Tasks/build/Tasks.tasks
+++ b/src/Internal.AspNetCore.BuildTools.Tasks/build/Tasks.tasks
@@ -1,5 +1,5 @@
 ﻿<Project>
-  
+
   <PropertyGroup>
     <_BuildToolsAssemblyTfm Condition="'$(MSBuildRuntimeType)' == 'Core'">netstandard1.3</_BuildToolsAssemblyTfm>
     <_BuildToolsAssemblyTfm Condition="'$(MSBuildRuntimeType)' != 'Core'">net46</_BuildToolsAssemblyTfm>
@@ -10,5 +10,8 @@
   <UsingTask TaskName="Microsoft.AspNetCore.BuildTools.GetOSPlatform" AssemblyFile="$(_BuildToolsAssembly)" />
   <UsingTask TaskName="Microsoft.AspNetCore.BuildTools.SetEnvironmentVariable" AssemblyFile="$(_BuildToolsAssembly)" />
   <UsingTask TaskName="Microsoft.AspNetCore.BuildTools.WaitForDebugger" AssemblyFile="$(_BuildToolsAssembly)" />
-  
+
+  <!-- Note: use 'XmlPoke' where possible. We plan to remove this. See https://github.com/aspnet/BuildTools/issues/180 -->
+  <UsingTask TaskName="Microsoft.AspNetCore.BuildTools.XmlPoke2" AssemblyFile="$(_BuildToolsAssembly)" />
+
 </Project>


### PR DESCRIPTION
This task makes it easy to replace single values in an XML file using XPath.

Workaround https://github.com/Microsoft/msbuild/issues/1731