### PR TITLE
Add a GetDotNetHost task to locate the "dotnet.exe" path

### DIFF
--- a/src/Internal.AspNetCore.BuildTools.Tasks/FileHelpers.cs
+++ b/src/Internal.AspNetCore.BuildTools.Tasks/FileHelpers.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO;
+
+namespace Microsoft.AspNetCore.BuildTools
+{
+    internal class FileHelpers
+    {
+        public static string EnsureTrailingSlash(string path)
+            => !HasTrailingSlash(path)
+                ? path + Path.DirectorySeparatorChar
+                : path;
+
+        public static bool HasTrailingSlash(string path)
+            => string.IsNullOrEmpty(path)
+                ? false
+                : path[path.Length - 1] == Path.DirectorySeparatorChar
+                    || path[path.Length - 1] == Path.AltDirectorySeparatorChar;
+    }
+}

--- a/src/Internal.AspNetCore.BuildTools.Tasks/GetDotNetHost.cs
+++ b/src/Internal.AspNetCore.BuildTools.Tasks/GetDotNetHost.cs
@@ -1,0 +1,83 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#if NETSTANDARD1_6
+
+using System;
+using System.Runtime.InteropServices;
+using System.IO;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace Microsoft.AspNetCore.BuildTools
+{
+    /// <summary>
+    /// <para>
+    /// Uses the current runtime information to find the "dotnet.exe" path.
+    /// This requires that MSBuild itself execute on top of Microsoft.NETCore.App.
+    /// </para>
+    /// <para>
+    /// This code is modeled of this API: https://github.com/dotnet/cli/blob/rel/1.0.0/src/Microsoft.DotNet.Cli.Utils/Muxer.cs.
+    /// We don't use this API directly as using Microsoft.DotNet.Cli.Utils with MSBuild causes assembly loading issues.
+    /// </para>
+    /// <para>
+    /// Also, this task may be not be necessary in future releases. At the time of writing, however, this
+    /// feature does not exist in MSBuild of the .NET Core SDK. See https://github.com/Microsoft/msbuild/issues/1669
+    /// and https://github.com/dotnet/sdk/issues/20
+    /// </para>
+    /// </summary>
+    public class GetDotNetHost : Task
+    {
+        private const string MuxerName = "dotnet";
+
+        /// <summary>
+        /// The full path to "dotnet.exe"
+        /// </summary>
+        [Output]
+        public string ExecutablePath { get; set; }
+
+        /// <summary>
+        /// The folder containing "dotnet.exe". This is the directory also contains shared frameworks and SDKs.
+        /// </summary>
+        [Output]
+        public string DotNetDirectory { get; set; }
+
+        public override bool Execute()
+        {
+            var fileName = MuxerName;
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                fileName += ".exe";
+            }
+
+            var fxDepsFile = AppContext.GetData("FX_DEPS_FILE") as string;
+
+            if (string.IsNullOrEmpty(fxDepsFile))
+            {
+                Log.LogError("AppContext did not have 'FX_DEPS_FILE' set.");
+                return false;
+            }
+
+            var muxerDir = new FileInfo(fxDepsFile) // Microsoft.NETCore.App.deps.json
+                .Directory? // (version)
+                .Parent? // Microsoft.NETCore.App
+                .Parent? // shared
+                .Parent; // DOTNET_HOME
+
+            if (muxerDir == null)
+            {
+                Log.LogError("Failed to find the .NET Core installation starting from '{0}'", fxDepsFile);
+                return false;
+            }
+
+            ExecutablePath = Path.Combine(muxerDir.FullName, fileName);
+            DotNetDirectory = FileHelpers.EnsureTrailingSlash(muxerDir.FullName);
+
+            Log.LogMessage(MessageImportance.Low, "Found dotnet muxer in '{0}'", DotNetDirectory);
+
+            return File.Exists(ExecutablePath);
+        }
+    }
+}
+
+#endif

--- a/src/Internal.AspNetCore.BuildTools.Tasks/GetGitCommitInfo.cs
+++ b/src/Internal.AspNetCore.BuildTools.Tasks/GetGitCommitInfo.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.IO;
-using System.Linq;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 
@@ -41,7 +40,7 @@ namespace Microsoft.AspNetCore.BuildTools
 
         public override bool Execute()
         {
-            RepositoryRootPath = GetRepositoryRoot(WorkingDirectory);
+            RepositoryRootPath = FileHelpers.EnsureTrailingSlash(GetRepositoryRoot(WorkingDirectory));
             if (RepositoryRootPath == null)
             {
                 Log.LogError("Could not find the git directory for '{0}'", WorkingDirectory);

--- a/src/Internal.AspNetCore.BuildTools.Tasks/Internal.AspNetCore.BuildTools.Tasks.csproj
+++ b/src/Internal.AspNetCore.BuildTools.Tasks/Internal.AspNetCore.BuildTools.Tasks.csproj
@@ -9,12 +9,12 @@
       The netstandard1.0 TFM doesn't actually compile tasks.
       It's just there so Internal.AspNetCore.Sdk gets a dependency to this project.
     -->
-    <TargetFrameworks>netstandard1.3;net46;netstandard1.0</TargetFrameworks>
+    <TargetFrameworks>netstandard1.6;net46;netstandard1.0</TargetFrameworks>
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
     <RootNamespace>Microsoft.AspNetCore.BuildTools</RootNamespace>
     <NoPackageAnalysis>true</NoPackageAnalysis>
     <!-- don't try to compile the *.cs files on netstandard1.0 -->
-    <EnableDefaultItems Condition="'$(TargetFramework)' != 'netstandard1.3' AND '$(TargetFramework)' != 'net46'">false</EnableDefaultItems>
+    <EnableDefaultItems Condition="'$(TargetFramework)' != 'netstandard1.6' AND '$(TargetFramework)' != 'net46'">false</EnableDefaultItems>
   </PropertyGroup>
 
   <ItemGroup>
@@ -27,7 +27,7 @@
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.1.0-*" PrivateAssets="All" />
   </ItemGroup>
   
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3' ">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.6' ">
     <PackageReference Include="System.Xml.XmlDocument" Version="4.0.1" PrivateAssets="All" />
     <PackageReference Include="System.Xml.XPath.XmlDocument" Version="4.0.1" PrivateAssets="All" />
   </ItemGroup>

--- a/src/Internal.AspNetCore.BuildTools.Tasks/Internal.AspNetCore.BuildTools.Tasks.nuspec
+++ b/src/Internal.AspNetCore.BuildTools.Tasks/Internal.AspNetCore.BuildTools.Tasks.nuspec
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>Internal.AspNetCore.BuildTools.Tasks</id>
@@ -13,7 +13,7 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="bin\$configuration$\netstandard1.3\$assemblyname$.dll" target="tools\netstandard1.3\$assemblyname$.dll" />
+    <file src="bin\$configuration$\netstandard1.6\$assemblyname$.dll" target="tools\netstandard1.6\$assemblyname$.dll" />
     <file src="bin\$configuration$\net46\$assemblyname$.dll" target="tools\net46\$assemblyname$.dll" />
     <file src="build\*.tasks" target="build\" />
     <file src="build\*.props" target="build\" />

--- a/src/Internal.AspNetCore.BuildTools.Tasks/build/Tasks.tasks
+++ b/src/Internal.AspNetCore.BuildTools.Tasks/build/Tasks.tasks
@@ -1,12 +1,14 @@
 ﻿<Project>
 
   <PropertyGroup>
-    <_BuildToolsAssemblyTfm Condition="'$(MSBuildRuntimeType)' == 'Core'">netstandard1.3</_BuildToolsAssemblyTfm>
+    <_BuildToolsAssemblyTfm Condition="'$(MSBuildRuntimeType)' == 'Core'">netstandard1.6</_BuildToolsAssemblyTfm>
     <_BuildToolsAssemblyTfm Condition="'$(MSBuildRuntimeType)' != 'Core'">net46</_BuildToolsAssemblyTfm>
     <_BuildToolsAssembly>$(MSBuildThisFileDirectory)..\tools\$(_BuildToolsAssemblyTfm)\Internal.AspNetCore.BuildTools.Tasks.dll</_BuildToolsAssembly>
   </PropertyGroup>
 
   <UsingTask TaskName="Microsoft.AspNetCore.BuildTools.GetGitCommitInfo" AssemblyFile="$(_BuildToolsAssembly)" />
+  <UsingTask TaskName="Microsoft.AspNetCore.BuildTools.GetDotNetHost" AssemblyFile="$(_BuildToolsAssembly)"
+             Condition="'$(MSBuildRuntimeType)' == 'Core'"/>
   <UsingTask TaskName="Microsoft.AspNetCore.BuildTools.GetOSPlatform" AssemblyFile="$(_BuildToolsAssembly)" />
   <UsingTask TaskName="Microsoft.AspNetCore.BuildTools.SetEnvironmentVariable" AssemblyFile="$(_BuildToolsAssembly)" />
   <UsingTask TaskName="Microsoft.AspNetCore.BuildTools.WaitForDebugger" AssemblyFile="$(_BuildToolsAssembly)" />


### PR DESCRIPTION
This task helps locate the dotnet.exe file using MSBuild's runtime.

Required lifting the .NET core task version to netstandard1.6 so that we could use AppContext.GetData.

Compensates for https://github.com/dotnet/sdk/issues/20


