### PR TITLE
Turn on TreatWarningsAsErrors

### DIFF
--- a/src/Internal.AspNetCore.Sdk/targets/Common.props
+++ b/src/Internal.AspNetCore.Sdk/targets/Common.props
@@ -9,14 +9,14 @@ Usage: this should be imported once via NuGet at the top of the file.
 
   <!-- common package options -->
   <PropertyGroup>
-    <IncludeSymbols Condition="'$(IncludeSymbols)'==''">true</IncludeSymbols>
-    <NeutralLanguage Condition="'$(NeutralLanguage)'==''">en-US</NeutralLanguage>
-    <Company Condition="'$(Company)'==''">Microsoft Corporation.</Company>
-    <Authors Condition="'$(Authors)'==''">Microsoft</Authors>
-    <Copyright Condition="'$(Copyright)'==''">© Microsoft Corporation. All rights reserved.</Copyright>
-    <ProjectUrl Condition="'$(ProjectUrl)'==''">https://asp.net</ProjectUrl>
-    <RequireLicenseAcceptance Condition="'$(RequireLicenseAcceptance)'==''">true</RequireLicenseAcceptance>
-    <Serviceable Condition="'$(Configuration)' == 'Release' AND '$(Serviceable)'==''">true</Serviceable>
+    <IncludeSymbols>true</IncludeSymbols>
+    <NeutralLanguage>en-US</NeutralLanguage>
+    <Company>Microsoft Corporation.</Company>
+    <Authors>Microsoft</Authors>
+    <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
+    <ProjectUrl>https://asp.net</ProjectUrl>
+    <RequireLicenseAcceptance>true</RequireLicenseAcceptance>
+    <Serviceable Condition="'$(Configuration)' == 'Release'">true</Serviceable>
   </PropertyGroup>
 
   <!-- common build options -->

--- a/src/Internal.AspNetCore.Sdk/targets/Common.props
+++ b/src/Internal.AspNetCore.Sdk/targets/Common.props
@@ -22,7 +22,7 @@ Usage: this should be imported once via NuGet at the top of the file.
   <!-- common build options -->
   <PropertyGroup>
     <!-- make disabling warnings opt-out -->
-    <TreatWarningsAsErrors Condition="'$(TreatWarningsAsErrors)'==''">true</TreatWarningsAsErrors>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
https://github.com/dotnet/sdk/blob/67783a8d39e1cfb0cc44252a28cb10a7bae1c63b/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.props#L103 sets it to false (by default). This props file is processed after, consequently it doesn't set it to true. We verified adding `<TreatWarningsAsErrors>false</TreatWarningsAsErrors>` in the csproj allows disabling it at a project level.