### PR TITLE
Remove usages of System.Reflection from the ApiListing model

### DIFF
--- a/src/Microsoft.AspNetCore.BuildTools.ApiCheck/ApiListing/ApiListing.cs
+++ b/src/Microsoft.AspNetCore.BuildTools.ApiCheck/ApiListing/ApiListing.cs
@@ -4,8 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
-using Newtonsoft.Json;
 
 namespace ApiCheck.Description
 {
@@ -14,9 +12,6 @@ namespace ApiCheck.Description
         public string AssemblyIdentity { get; set; }
 
         public IList<TypeDescriptor> Types { get; } = new List<TypeDescriptor>();
-
-        [JsonIgnore]
-        public IEnumerable<Func<MemberInfo, bool>> SourceFilters { get; set; }
 
         public TypeDescriptor FindType(string name)
         {

--- a/src/Microsoft.AspNetCore.BuildTools.ApiCheck/ApiListing/GenericParameterDescriptor.cs
+++ b/src/Microsoft.AspNetCore.BuildTools.ApiCheck/ApiListing/GenericParameterDescriptor.cs
@@ -1,9 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
-using System.Reflection;
 using Newtonsoft.Json;
 
 namespace ApiCheck.Description
@@ -12,9 +10,6 @@ namespace ApiCheck.Description
     {
         [JsonIgnore]
         public override string Id => HasConstraints() ? $"T{ParameterPosition}" + " : " + GetConstraints() : ParameterName;
-
-        [JsonIgnore]
-        public TypeInfo Source { get; set; }
 
         public string ParameterName { get; set; }
 

--- a/src/Microsoft.AspNetCore.BuildTools.ApiCheck/ApiListing/MemberDescriptor.cs
+++ b/src/Microsoft.AspNetCore.BuildTools.ApiCheck/ApiListing/MemberDescriptor.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using System.Text;
 using Newtonsoft.Json;
 
@@ -13,9 +12,6 @@ namespace ApiCheck.Description
     {
         [JsonIgnore]
         public override string Id => string.Join(" ", GetComponents());
-
-        [JsonIgnore]
-        public MemberInfo Source { get; set; }
 
         public MemberKind Kind { get; set; }
 
@@ -178,18 +174,6 @@ namespace ApiCheck.Description
 
             builder.Append(")");
             return builder.ToString();
-        }
-
-        public static string GetMemberNameFor(MethodBase member, bool includeGenericParameters = true)
-        {
-            if (!member.IsGenericMethod || !includeGenericParameters)
-            {
-                return member.Name;
-            }
-
-            var genericParameters = string.Join(", ", member.GetGenericArguments().Select(ga => TypeDescriptor.GetTypeNameFor(ga.GetTypeInfo())));
-
-            return $"{member.Name}<{genericParameters}>";
         }
     }
 }

--- a/src/Microsoft.AspNetCore.BuildTools.ApiCheck/ApiListing/ParameterDescriptor.cs
+++ b/src/Microsoft.AspNetCore.BuildTools.ApiCheck/ApiListing/ParameterDescriptor.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using System.Reflection;
 using Newtonsoft.Json;
 
 namespace ApiCheck.Description
@@ -11,9 +10,6 @@ namespace ApiCheck.Description
     {
         [JsonIgnore]
         public override string Id => string.Join(" ", GetComponents());
-
-        [JsonIgnore]
-        public ParameterInfo Source { get; set; }
 
         public string Name { get; set; }
 

--- a/src/Microsoft.AspNetCore.BuildTools.ApiCheck/ApiListing/TypeDescriptor.cs
+++ b/src/Microsoft.AspNetCore.BuildTools.ApiCheck/ApiListing/TypeDescriptor.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using Newtonsoft.Json;
 
 namespace ApiCheck.Description
@@ -13,9 +12,6 @@ namespace ApiCheck.Description
     {
         [JsonIgnore]
         public override string Id => string.Join(" ", GetSignatureComponents());
-
-        [JsonIgnore]
-        public TypeInfo Source { get; set; }
 
         public string Name { get; set; }
 
@@ -138,139 +134,6 @@ namespace ApiCheck.Description
                     yield return @interface;
                 }
             }
-        }
-
-        public static string GetTypeNameFor(TypeInfo type)
-        {
-            string typeName = type.FullName ?? type.Name;
-
-            if (type.IsGenericParameter)
-            {
-                typeName = $"T{type.GenericParameterPosition}";
-            }
-
-            if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>))
-            {
-                var underlyingTypeName = GetTypeNameFor(type.GetGenericArguments().Single().GetTypeInfo());
-                typeName = underlyingTypeName + "?";
-            }
-
-            if (type.IsGenericType)
-            {
-                if (type.DeclaringType == null || type.DeclaringType.GetTypeInfo() == type)
-                {
-                    var name = type.GetGenericTypeDefinition().FullName;
-                    typeName = name.Substring(0, name.IndexOf('`'));
-                    typeName = $"{typeName}<{string.Join(", ", type.GetGenericArguments().Select(ga => GetTypeNameFor(ga.GetTypeInfo())))}>";
-                }
-                else
-                {
-                    var container = type.DeclaringType.GetTypeInfo();
-                    var prefix = GetTypeNameFor(container);
-                    var name = type.GetGenericTypeDefinition().FullName;
-                    var currentTypeGenericArguments = type.GetGenericTypeDefinition().GetGenericArguments()
-                    .Where(p => !container.GetGenericArguments().Any(cp => cp.Name == p.Name))
-                    .Select(p => type.GetGenericArguments()[p.GenericParameterPosition])
-                    .ToArray();
-
-                    if (currentTypeGenericArguments.Length == 0)
-                    {
-                        var nestedClassSeparatorIndex = name.LastIndexOf("+");
-                        name = name.Substring(nestedClassSeparatorIndex + 1, name.Length - nestedClassSeparatorIndex - 1);
-                    }
-                    else
-                    {
-                        var lastGenericArityIndex = name.LastIndexOf('`');
-                        var nestedClassSeparatorIndex = name.LastIndexOf("+");
-                        name = name.Substring(nestedClassSeparatorIndex + 1, lastGenericArityIndex - nestedClassSeparatorIndex - 1);
-                        name = $"{name}<{string.Join(", ", currentTypeGenericArguments.Select(ga => GetTypeNameFor(ga.GetTypeInfo())))}>";
-                    }
-
-                    typeName = $"{prefix}+{name}";
-                }
-            }
-
-            if (type.IsArray)
-            {
-                var name = GetTypeNameFor(type.GetElementType().GetTypeInfo());
-                typeName = $"{name}[]";
-            }
-
-            if (type.IsByRef)
-            {
-                typeName = GetTypeNameFor(type.GetElementType().GetTypeInfo());
-            }
-
-            // Parameters passed by reference through out or ref modifiers have an & at the end of their
-            // name to indicate they are pointers to a given type.
-            typeName = typeName.TrimEnd('&');
-
-            return typeName;
-        }
-
-        public static IEnumerable<TypeInfo> GetImplementedInterfacesFor(TypeInfo type)
-        {
-            if (type.IsGenericParameter)
-            {
-                var interfaces = type.ImplementedInterfaces.ToArray();
-                for (var i = 0; i < interfaces.Length; i++)
-                {
-                    var implementedInterface = interfaces[i].GetTypeInfo();
-                    var implementedOnBaseType = type.BaseType != null &&
-                        InterfaceIsImplementedOnBaseType(type.BaseType.GetTypeInfo(), implementedInterface);
-
-                    if (!implementedOnBaseType && !InterfaceIsTransitivelyImplemented(type, implementedInterface))
-                    {
-                        yield return implementedInterface;
-                    }
-                }
-            }
-            else if (!type.IsInterface)
-            {
-                var interfaces = type.ImplementedInterfaces.ToArray();
-                for (var i = 0; i < interfaces.Length; i++)
-                {
-                    var implementedInterface = interfaces[i].GetTypeInfo();
-                    if ((!InterfaceIsImplementedOnBaseType(type.BaseType.GetTypeInfo(), implementedInterface) &&
-                        !InterfaceIsTransitivelyImplemented(type, implementedInterface)) ||
-                        InterfaceIsReimplementedOnCurrentType(type, implementedInterface))
-                    {
-                        yield return implementedInterface;
-                    }
-                }
-            }
-            else
-            {
-                var interfaces = type.ImplementedInterfaces.ToArray();
-                for (var i = 0; i < interfaces.Length; i++)
-                {
-                    var implementedInterface = interfaces[i].GetTypeInfo();
-                    if (!InterfaceIsTransitivelyImplemented(type, implementedInterface))
-                    {
-                        yield return implementedInterface;
-                    }
-                }
-            }
-        }
-
-        private static bool InterfaceIsReimplementedOnCurrentType(TypeInfo type, TypeInfo implementedInterface)
-        {
-            var mapping = type.GetRuntimeInterfaceMap(implementedInterface.AsType());
-            return InterfaceIsImplementedOnBaseType(type.BaseType.GetTypeInfo(), implementedInterface) &&
-                mapping.TargetMethods.Any(tm => tm.DeclaringType.GetTypeInfo().Equals(type) &&
-                (tm.IsPrivate || tm.Equals(tm.GetBaseDefinition())));
-        }
-
-        private static bool InterfaceIsTransitivelyImplemented(TypeInfo type, TypeInfo implementedInterface)
-        {
-            return type.ImplementedInterfaces
-                .SelectMany(ii => ii.GetTypeInfo().ImplementedInterfaces)
-                .Any(bii => bii.GetTypeInfo().Equals(implementedInterface));
-        }
-
-        private static bool InterfaceIsImplementedOnBaseType(TypeInfo typeInfo, TypeInfo implementedInterface)
-        {
-            return typeInfo.ImplementedInterfaces.Any(ii => ii.Equals(implementedInterface));
         }
     }
 }

--- a/src/Microsoft.AspNetCore.BuildTools.ApiCheck/Microsoft.AspNetCore.BuildTools.ApiCheck.csproj
+++ b/src/Microsoft.AspNetCore.BuildTools.ApiCheck/Microsoft.AspNetCore.BuildTools.ApiCheck.csproj
@@ -1,20 +1,27 @@
-﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  
   <Import Project="..\..\build\common.props" />
+  
   <PropertyGroup>
     <VersionPrefix>1.0.1</VersionPrefix>
     <TargetFrameworks>netcoreapp1.1;net452</TargetFrameworks>
     <OutputType>exe</OutputType>
+    <RootNamespace>ApiCheck</RootNamespace>
   </PropertyGroup>
+  
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.CommandLineUtils" Version="1.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="$(JsonNetVersion)" />
   </ItemGroup>
+  
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
   </ItemGroup>
+  
   <ItemGroup>
     <ProjectReference Include="..\NugetReferenceResolver\NugetReferenceResolver.csproj" />
   </ItemGroup>
+  
   <!-- packaging settings-->
   <PropertyGroup>
     <NoPackageAnalysis>true</NoPackageAnalysis>

--- a/src/Microsoft.AspNetCore.BuildTools.ApiCheck/Utilities/ReflectionHelper.cs
+++ b/src/Microsoft.AspNetCore.BuildTools.ApiCheck/Utilities/ReflectionHelper.cs
@@ -1,0 +1,158 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace ApiCheck.Utilities
+{
+    public static class ReflectionHelper
+    {
+        public static string GetMemberNameFor(MethodBase member, bool includeGenericParameters = true)
+        {
+            if (!member.IsGenericMethod || !includeGenericParameters)
+            {
+                return member.Name;
+            }
+
+            var genericParameters = string.Join(", ", member.GetGenericArguments().Select(ga => GetTypeNameFor(ga.GetTypeInfo())));
+
+            return $"{member.Name}<{genericParameters}>";
+        }
+
+        public static string GetTypeNameFor(TypeInfo type)
+        {
+            string typeName = type.FullName ?? type.Name;
+
+            if (type.IsGenericParameter)
+            {
+                typeName = $"T{type.GenericParameterPosition}";
+            }
+
+            if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>))
+            {
+                var underlyingTypeName = GetTypeNameFor(type.GetGenericArguments().Single().GetTypeInfo());
+                typeName = underlyingTypeName + "?";
+            }
+
+            if (type.IsGenericType)
+            {
+                if (type.DeclaringType == null || type.DeclaringType.GetTypeInfo() == type)
+                {
+                    var name = type.GetGenericTypeDefinition().FullName;
+                    typeName = name.Substring(0, name.IndexOf('`'));
+                    typeName = $"{typeName}<{string.Join(", ", type.GetGenericArguments().Select(ga => GetTypeNameFor(ga.GetTypeInfo())))}>";
+                }
+                else
+                {
+                    var container = type.DeclaringType.GetTypeInfo();
+                    var prefix = GetTypeNameFor(container);
+                    var name = type.GetGenericTypeDefinition().FullName;
+                    var currentTypeGenericArguments = type.GetGenericTypeDefinition().GetGenericArguments()
+                    .Where(p => !container.GetGenericArguments().Any(cp => cp.Name == p.Name))
+                    .Select(p => type.GetGenericArguments()[p.GenericParameterPosition])
+                    .ToArray();
+
+                    if (currentTypeGenericArguments.Length == 0)
+                    {
+                        var nestedClassSeparatorIndex = name.LastIndexOf("+");
+                        name = name.Substring(nestedClassSeparatorIndex + 1, name.Length - nestedClassSeparatorIndex - 1);
+                    }
+                    else
+                    {
+                        var lastGenericArityIndex = name.LastIndexOf('`');
+                        var nestedClassSeparatorIndex = name.LastIndexOf("+");
+                        name = name.Substring(nestedClassSeparatorIndex + 1, lastGenericArityIndex - nestedClassSeparatorIndex - 1);
+                        name = $"{name}<{string.Join(", ", currentTypeGenericArguments.Select(ga => GetTypeNameFor(ga.GetTypeInfo())))}>";
+                    }
+
+                    typeName = $"{prefix}+{name}";
+                }
+            }
+
+            if (type.IsArray)
+            {
+                var name = GetTypeNameFor(type.GetElementType().GetTypeInfo());
+                typeName = $"{name}[]";
+            }
+
+            if (type.IsByRef)
+            {
+                typeName = GetTypeNameFor(type.GetElementType().GetTypeInfo());
+            }
+
+            // Parameters passed by reference through out or ref modifiers have an & at the end of their
+            // name to indicate they are pointers to a given type.
+            typeName = typeName.TrimEnd('&');
+
+            return typeName;
+        }
+
+        public static IEnumerable<TypeInfo> GetImplementedInterfacesFor(TypeInfo type)
+        {
+            if (type.IsGenericParameter)
+            {
+                var interfaces = type.ImplementedInterfaces.ToArray();
+                for (var i = 0; i < interfaces.Length; i++)
+                {
+                    var implementedInterface = interfaces[i].GetTypeInfo();
+                    var implementedOnBaseType = type.BaseType != null &&
+                        InterfaceIsImplementedOnBaseType(type.BaseType.GetTypeInfo(), implementedInterface);
+
+                    if (!implementedOnBaseType && !InterfaceIsTransitivelyImplemented(type, implementedInterface))
+                    {
+                        yield return implementedInterface;
+                    }
+                }
+            }
+            else if (!type.IsInterface)
+            {
+                var interfaces = type.ImplementedInterfaces.ToArray();
+                for (var i = 0; i < interfaces.Length; i++)
+                {
+                    var implementedInterface = interfaces[i].GetTypeInfo();
+                    if ((!InterfaceIsImplementedOnBaseType(type.BaseType.GetTypeInfo(), implementedInterface) &&
+                        !InterfaceIsTransitivelyImplemented(type, implementedInterface)) ||
+                        InterfaceIsReimplementedOnCurrentType(type, implementedInterface))
+                    {
+                        yield return implementedInterface;
+                    }
+                }
+            }
+            else
+            {
+                var interfaces = type.ImplementedInterfaces.ToArray();
+                for (var i = 0; i < interfaces.Length; i++)
+                {
+                    var implementedInterface = interfaces[i].GetTypeInfo();
+                    if (!InterfaceIsTransitivelyImplemented(type, implementedInterface))
+                    {
+                        yield return implementedInterface;
+                    }
+                }
+            }
+        }
+
+        private static bool InterfaceIsReimplementedOnCurrentType(TypeInfo type, TypeInfo implementedInterface)
+        {
+            var mapping = type.GetRuntimeInterfaceMap(implementedInterface.AsType());
+            return InterfaceIsImplementedOnBaseType(type.BaseType.GetTypeInfo(), implementedInterface) &&
+                mapping.TargetMethods.Any(tm => tm.DeclaringType.GetTypeInfo().Equals(type) &&
+                (tm.IsPrivate || tm.Equals(tm.GetBaseDefinition())));
+        }
+
+        private static bool InterfaceIsTransitivelyImplemented(TypeInfo type, TypeInfo implementedInterface)
+        {
+            return type.ImplementedInterfaces
+                .SelectMany(ii => ii.GetTypeInfo().ImplementedInterfaces)
+                .Any(bii => bii.GetTypeInfo().Equals(implementedInterface));
+        }
+
+        private static bool InterfaceIsImplementedOnBaseType(TypeInfo typeInfo, TypeInfo implementedInterface)
+        {
+            return typeInfo.ImplementedInterfaces.Any(ii => ii.Equals(implementedInterface));
+        }
+    }
+}


### PR DESCRIPTION
Follow up to https://github.com/aspnet/BuildTools/pull/203.

The 'ApiListing' classes and related types are the model of an assembly's exported types. This model currently leaks into using System.Reflection.{TypeInfo, MemberInfo, and ParameterInfo}, which should not be used as it ties the model to the reflection-based implementation of API check. System.Reflection should be treated as the source of model, but not the model itself. 

Removing these types should not affect existing baseline.json files as they were not serialized. Also, in a few cases the reflection types were set in the model, but never read by the ApiListingComparer step.

Changes:
 - Removes usages System.Reflection from the API model
 - Moves static helper methods for constructing the API model from reflection info into 'ReflectionHelper'