### PR TITLE
Remove version restriction on DotNetCliTool package verification

### DIFF
--- a/src/NuGetPackageVerifier/PackageIssueFactory.cs
+++ b/src/NuGetPackageVerifier/PackageIssueFactory.cs
@@ -322,8 +322,8 @@ namespace NuGetPackageVerifier
         public static PackageVerifierIssue DotNetCliToolMissingDotnetAssembly()
             => new PackageVerifierIssue("DOTNETCLITOOL_MISSING_EXECUTABLE", "DotnetCliTool package must contain assembly that starts with 'dotnet-'", PackageIssueLevel.Error);
 
-        public static PackageVerifierIssue DotNetCliToolMustTargetFramework(NuGetFramework framework)
-            => new PackageVerifierIssue("DOTNETCLITOOL_FRAMEWORK", $"DotnetCliTool package must target {framework}", PackageIssueLevel.Error);
+        public static PackageVerifierIssue DotNetCliToolMustTargetNetCoreApp()
+            => new PackageVerifierIssue("DOTNETCLITOOL_FRAMEWORK", $"DotnetCliTool package must target a '{FrameworkConstants.FrameworkIdentifiers.NetCoreApp}' framework", PackageIssueLevel.Error);
 
         public static PackageVerifierIssue BuildItemsDoNotMatchFrameworks(string id, NuGetFramework framework)
             => new PackageVerifierIssue("BUILD_ITEMS_FRAMEWORK",

--- a/src/NuGetPackageVerifier/Rules/DotNetCliToolPackageRule.cs
+++ b/src/NuGetPackageVerifier/Rules/DotNetCliToolPackageRule.cs
@@ -11,8 +11,6 @@ namespace NuGetPackageVerifier.Rules
 {
     public class DotNetCliToolPackageRule : IPackageVerifierRule
     {
-        private static readonly NuGetFramework _expectedFramework = FrameworkConstants.CommonFrameworks.NetCoreApp10;
-
         public IEnumerable<PackageVerifierIssue> Validate(PackageAnalysisContext context)
         {
             if (context.Metadata.PackageTypes.All(p => p != PackageType.DotnetCliTool))
@@ -22,11 +20,11 @@ namespace NuGetPackageVerifier.Rules
 
             var libItems = context.PackageReader
                 .GetLibItems()
-                .FirstOrDefault(f => f.TargetFramework == _expectedFramework);
+                .FirstOrDefault(f => f.TargetFramework.Framework == FrameworkConstants.FrameworkIdentifiers.NetCoreApp);
 
             if (libItems == null)
             {
-                yield return PackageIssueFactory.DotNetCliToolMustTargetFramework(_expectedFramework);
+                yield return PackageIssueFactory.DotNetCliToolMustTargetNetCoreApp();
                 yield break;
             }
 


### PR DESCRIPTION
Unblock work to lift dotnet-user-secrets to .NET Core 2.0.