### PR TITLE
Re-enabling AssemblyIsBuiltInReleaseConfigurationRule

### DIFF
--- a/src/NuGetPackageVerifier/CompositeRules/SigningVerificationCompositeRule.cs
+++ b/src/NuGetPackageVerifier/CompositeRules/SigningVerificationCompositeRule.cs
@@ -9,7 +9,7 @@ namespace NuGetPackageVerifier.Rules
     {
         private readonly IPackageVerifierRule[] _rules = {
             new AssemblyHasCommitHashAttributeRule(),
-            // new AssemblyIsBuiltInReleaseConfigurationRule(),
+            new AssemblyIsBuiltInReleaseConfigurationRule(),
             new AuthenticodeSigningRule(),
             new PowerShellScriptIsSignedRule(),
             new RequiredNuSpecInfoRule(),

--- a/src/NuGetPackageVerifier/NuGetPackageVerifier.csproj
+++ b/src/NuGetPackageVerifier/NuGetPackageVerifier.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <Description>Verifies Asp.Net Core NuGet packages.</Description>
     <VersionPrefix>1.0.2</VersionPrefix>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <AssemblyName>NuGetPackageVerifier</AssemblyName>
     <OutputType>exe</OutputType>
     <PackageTargetFallback>$(PackageTargetFallback);portable-net45+wp8</PackageTargetFallback>

--- a/src/NuGetPackageVerifier/Rules/AssemblyHasAttributeRuleBase.cs
+++ b/src/NuGetPackageVerifier/Rules/AssemblyHasAttributeRuleBase.cs
@@ -34,7 +34,6 @@ namespace NuGetPackageVerifier.Rules
                         {
                             using (var assembly = AssemblyDefinition.ReadAssembly(assemblyPath))
                             {
-
                                 var asmAttrs = assembly.CustomAttributes;
 
                                 return ValidateAttribute(currentFile, assembly, asmAttrs);

--- a/src/NuGetPackageVerifier/Rules/AssemblyIsBuiltInReleaseConfigurationRule.cs
+++ b/src/NuGetPackageVerifier/Rules/AssemblyIsBuiltInReleaseConfigurationRule.cs
@@ -28,6 +28,7 @@ namespace NuGetPackageVerifier.Rules
                         using (var packageFileStream = context.PackageReader.GetStream(currentFile))
                         using (var stream = new MemoryStream())
                         {
+                            // packageFileStream is not a seekable stream. So wrap it in a memory stream for PEReader to consume.
                             packageFileStream.CopyTo(stream);
                             stream.Position = 0;
                             using (var peReader = new PEReader(stream))

--- a/src/NuGetPackageVerifier/Rules/AssemblyIsBuiltInReleaseConfigurationRule.cs
+++ b/src/NuGetPackageVerifier/Rules/AssemblyIsBuiltInReleaseConfigurationRule.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -68,7 +68,7 @@ namespace NuGetPackageVerifier.Rules
 
         private class NullProvider : ICustomAttributeTypeProvider<object>
         {
-            public static NullProvider Instance => new NullProvider();
+            public static NullProvider Instance { get; } = new NullProvider();
 
             public object GetPrimitiveType(PrimitiveTypeCode typeCode) => null;
             public object GetSystemType() => null;

--- a/src/NuGetPackageVerifier/Rules/AssemblyIsBuiltInReleaseConfigurationRule.cs
+++ b/src/NuGetPackageVerifier/Rules/AssemblyIsBuiltInReleaseConfigurationRule.cs
@@ -1,45 +1,90 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
-using Mono.Cecil;
-using Mono.Collections.Generic;
-using NuGetPackageVerifier.Logging;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
 
 namespace NuGetPackageVerifier.Rules
 {
-    public class AssemblyIsBuiltInReleaseConfigurationRule : AssemblyHasAttributeRuleBase
+    public class AssemblyIsBuiltInReleaseConfigurationRule : IPackageVerifierRule
     {
-        // TODO remove
-        public override IEnumerable<PackageVerifierIssue> Validate(PackageAnalysisContext context)
+        // TODO: Revert to using Mono.Cecil when https://github.com/jbevain/cecil/issues/306 is fixed.
+        public IEnumerable<PackageVerifierIssue> Validate(PackageAnalysisContext context)
         {
-            // todo remove "Cecil throws ArgumentException when evaluating constructor arguments"
-            context.Logger.Log(LogLevel.Info, $"{nameof(AssemblyIsBuiltInReleaseConfigurationRule)} skipped");
-            return Enumerable.Empty<PackageVerifierIssue>();
-        }
-
-        public override IEnumerable<PackageVerifierIssue> ValidateAttribute(string currentFilePath, AssemblyDefinition assembly, Collection<CustomAttribute> assemblyAttributes)
-        {
-            if (!HasReleaseConfiguration(assemblyAttributes))
+            foreach (var currentFile in context.PackageReader.GetFiles())
             {
-                yield return PackageIssueFactory.AssemblyHasIncorrectBuildConfiguration(currentFilePath);
+                var extension = Path.GetExtension(currentFile);
+                if (extension.Equals(".dll", StringComparison.OrdinalIgnoreCase) ||
+                    extension.Equals(".exe", StringComparison.OrdinalIgnoreCase))
+                {
+                    var assemblyPath = Path.ChangeExtension(
+                        Path.Combine(Path.GetTempPath(), Path.GetTempFileName()), extension);
+
+                    try
+                    {
+                        using (var packageFileStream = context.PackageReader.GetStream(currentFile))
+                        using (var fileStream = new FileStream(assemblyPath, FileMode.Create))
+                        {
+                            packageFileStream.CopyTo(fileStream);
+                        }
+
+                        if (AssemblyHelpers.IsAssemblyManaged(assemblyPath))
+                        {
+                            using (var stream = File.OpenRead(assemblyPath))
+                            using (var peReader = new PEReader(stream))
+                            {
+                                var reader = peReader.GetMetadataReader();
+                                foreach (var handle in reader.CustomAttributes)
+                                {
+                                    var customAttribute = reader.GetCustomAttribute(handle);
+                                    var ctor = reader.GetMemberReference((MemberReferenceHandle)customAttribute.Constructor);
+                                    var type = reader.GetTypeReference((TypeReferenceHandle)ctor.Parent);
+                                    var typeName = reader.GetString(type.Name);
+                                    if (string.Equals(typeof(DebuggableAttribute).Name, typeName, StringComparison.Ordinal))
+                                    {
+                                        var attribute = customAttribute.DecodeValue(NullProvider.Instance);
+
+                                        var debuggingMode = (DebuggableAttribute.DebuggingModes)attribute.FixedArguments.Single().Value;
+                                        if (debuggingMode.HasFlag(DebuggableAttribute.DebuggingModes.Default) ||
+                                            debuggingMode.HasFlag(DebuggableAttribute.DebuggingModes.DisableOptimizations))
+                                        {
+                                            yield return PackageIssueFactory.AssemblyHasIncorrectBuildConfiguration(currentFile);
+                                        };
+
+                                        break;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    finally
+                    {
+                        if (File.Exists(assemblyPath))
+                        {
+                            File.Delete(assemblyPath);
+                        }
+                    }
+                }
             }
         }
 
-        private static bool HasReleaseConfiguration(Collection<CustomAttribute> assemblyAttributes)
+        private class NullProvider : ICustomAttributeTypeProvider<object>
         {
-            var foundAttr = assemblyAttributes.SingleOrDefault(attr => attr.AttributeType.FullName == typeof(DebuggableAttribute).FullName);
-            if (foundAttr == null)
-            {
-                return false;
-            }
+            public static NullProvider Instance => new NullProvider();
 
-            var foundAttrArg = foundAttr.ConstructorArguments.SingleOrDefault();
-            var attrValue = (DebuggableAttribute.DebuggingModes)foundAttrArg.Value;
-            return !attrValue.HasFlag(DebuggableAttribute.DebuggingModes.Default) &&
-                   !attrValue.HasFlag(DebuggableAttribute.DebuggingModes.DisableOptimizations);
+            public object GetPrimitiveType(PrimitiveTypeCode typeCode) => null;
+            public object GetSystemType() => null;
+            public object GetSZArrayType(object elementType) => null;
+            public object GetTypeFromDefinition(MetadataReader reader, TypeDefinitionHandle handle, byte rawTypeKind) => null;
+            public object GetTypeFromReference(MetadataReader reader, TypeReferenceHandle handle, byte rawTypeKind) => null;
+            public object GetTypeFromSerializedName(string name) => null;
+            public PrimitiveTypeCode GetUnderlyingEnumType(object type) => PrimitiveTypeCode.Int32;
+            public bool IsSystemType(object type) => false;
         }
     }
 }


### PR DESCRIPTION
Issue - #140 

@pranavkm @Eilon @pakrym 

Needed to target netcoreapp2.0 here because `ICustomAttributeTypeProvider` was internal for 1.0
