### PR TITLE
Create zip entries with forward slashes

### DIFF
--- a/src/Internal.AspNetCore.BuildTools.Tasks/ZipArchive.cs
+++ b/src/Internal.AspNetCore.BuildTools.Tasks/ZipArchive.cs
@@ -79,7 +79,7 @@ namespace Microsoft.AspNetCore.BuildTools
             {
                 foreach (var file in SourceFiles)
                 {
-                    zip.CreateEntryFromFile(file.ItemSpec, file.GetMetadata("Link").Replace(Path.DirectorySeparatorChar, '/'));
+                    zip.CreateEntryFromFile(file.ItemSpec, file.GetMetadata("Link").Replace('\\', '/'));
                     Log.LogMessage("Added '{0}' to archive", file.ItemSpec);
                 }
             }

--- a/src/Internal.AspNetCore.BuildTools.Tasks/ZipArchive.cs
+++ b/src/Internal.AspNetCore.BuildTools.Tasks/ZipArchive.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.IO;
@@ -79,7 +79,7 @@ namespace Microsoft.AspNetCore.BuildTools
             {
                 foreach (var file in SourceFiles)
                 {
-                    zip.CreateEntryFromFile(file.ItemSpec, file.GetMetadata("Link"));
+                    zip.CreateEntryFromFile(file.ItemSpec, file.GetMetadata("Link").Replace(Path.DirectorySeparatorChar, '/'));
                     Log.LogMessage("Added '{0}' to archive", file.ItemSpec);
                 }
             }

--- a/test/BuildTools.Tasks.Tests/ZipArchiveTest.cs
+++ b/test/BuildTools.Tasks.Tests/ZipArchiveTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -88,7 +88,7 @@ namespace BuildTools.Tasks.Tests
                 Assert.Collection(zipStream.Entries,
                     a => Assert.Equal("a.txt", a.FullName),
                     b => Assert.Equal("dir/b.txt", b.FullName),
-                    c => Assert.Equal($"dir{Path.DirectorySeparatorChar}c.txt", c.FullName));
+                    c => Assert.Equal("dir/c.txt", c.FullName));
             }
         }
 


### PR DESCRIPTION
Backslashes are invalid as directory separators for zip entries.