### PR TITLE
Make xUnit1004 a warning even when WarningsAsErrors is true

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -5,10 +5,10 @@
     <DotNetCliUtilsVersion>1.0.1</DotNetCliUtilsVersion>
     <DotNetProjectModelVersion>1.0.0-rc3-1-003177</DotNetProjectModelVersion>
     <JsonNetVersion>10.0.1</JsonNetVersion>
-    <MsBuildPackageVersions>15.1.548</MsBuildPackageVersions>
+    <MsBuildPackageVersions>15.1.1012</MsBuildPackageVersions>
     <NetStandardPackageVersion>1.6.1</NetStandardPackageVersion>
     <NuGetPackagesVersion>4.0.0</NuGetPackagesVersion>
-    <TestSdkVersion>15.0.0</TestSdkVersion>
-    <XunitVersion>2.2.0</XunitVersion>
+    <TestSdkVersion>15.3.0-*</TestSdkVersion>
+    <XunitVersion>2.3.0-beta2-*</XunitVersion>
   </PropertyGroup>
 </Project>

--- a/src/Internal.AspNetCore.Sdk/targets/Common.props
+++ b/src/Internal.AspNetCore.Sdk/targets/Common.props
@@ -25,6 +25,8 @@ Usage: this should be imported once via NuGet at the top of the file.
   <PropertyGroup>
     <!-- make disabling warnings opt-out -->
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <!-- xUnit1004 = warns about skipped tests. Make this a non-fatal build warning. -->
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);xUnit1004</WarningsNotAsErrors>
     <_TwoDigitYear>$([MSBuild]::Subtract($([System.DateTime]::UtcNow.Year), 2000))</_TwoDigitYear>
     <_ThreeDigitDayOfYear>$([System.DateTime]::UtcNow.DayOfYear.ToString().PadLeft(3, '0'))</_ThreeDigitDayOfYear>
     <AssemblyRevision>$(_TwoDigitYear)$(_ThreeDigitDayOfYear)</AssemblyRevision>


### PR DESCRIPTION
Upgrading to xunit 2.3.0-beta2 introduces xunit.analyzers which includes a build warning xUnit1004 anytime code has `[Fact(Skip = "reason")]` or `[Theory(Skip = "reason")]`. Because we also set WarningsAsErrors = true by default, this would cause builds to fail anytime a test is skipped.

Adding xUnit1004 to the WarningsNotAsErrors list makes this still show up as a warning, but doesn't cause builds to fail.

cc @Eilon 