### PR TITLE
Disallow new `abstract` type members

### DIFF
--- a/src/Microsoft.AspNetCore.BuildTools.ApiCheck/ApiListingComparer.cs
+++ b/src/Microsoft.AspNetCore.BuildTools.ApiCheck/ApiListingComparer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -68,9 +68,20 @@ namespace ApiCheck
                 }
             }
 
-            if (type.Kind == TypeKind.Interface && newMembers.Count > 0)
+            if (newMembers.Count > 0)
             {
-                breakingChanges.AddRange(newMembers.Select(member => new BreakingChange(newType.Id, member.Id, ChangeKind.Addition)));
+                if (type.Kind == TypeKind.Interface)
+                {
+                    breakingChanges.AddRange(newMembers.Select(member => new BreakingChange(newType.Id, member.Id, ChangeKind.Addition)));
+                }
+                else
+                {
+                    var disallowedNewMembers = newMembers.Where(member => member.Abstract).ToArray();
+                    if (disallowedNewMembers.Length > 0)
+                    {
+                        breakingChanges.AddRange(disallowedNewMembers.Select(member => new BreakingChange(newType.Id, member.Id, ChangeKind.Addition)));
+                    }
+                }
             }
         }
 

--- a/src/Microsoft.AspNetCore.BuildTools.ApiCheck/ApiListingGenerator.cs
+++ b/src/Microsoft.AspNetCore.BuildTools.ApiCheck/ApiListingGenerator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -220,6 +220,7 @@ namespace ApiCheck
                     }
 
                     return constructorDescriptor;
+
                 case MemberTypes.Method:
                     var method = (MethodInfo)member;
                     if (!method.IsPublic && !method.IsFamily && !method.IsFamilyOrAssembly)
@@ -274,6 +275,7 @@ namespace ApiCheck
                     methodDescriptor.ReturnType = TypeDescriptor.GetTypeNameFor(method.ReturnType.GetTypeInfo());
 
                     return methodDescriptor;
+
                 case MemberTypes.Field:
                     var field = (FieldInfo)member;
                     if (!field.IsPublic && !field.IsFamily && !field.IsFamilyOrAssembly)
@@ -318,12 +320,14 @@ namespace ApiCheck
                     // All these cases are covered by the methods they implicitly define on the class
                     // (Properties and Events) and when we enumerate all the types in an assembly (Nested types).
                     return null;
+
                 case MemberTypes.TypeInfo:
-                // There should not be any member passsed into this method that is not a top level type.
+                    // There should not be any member passed into this method that is not a top level type.
                 case MemberTypes.Custom:
-                // We don't know about custom member types, so better throw if we find something we don't understand.
+                    // We don't know about custom member types, so better throw if we find something we don't understand.
                 case MemberTypes.All:
                     throw new InvalidOperationException($"'{type.MemberType}' [{member}] is not supported.");
+
                 default:
                     return null;
             }

--- a/test/ApiCheckBaseline.V1/ComparisonScenarios.cs
+++ b/test/ApiCheckBaseline.V1/ComparisonScenarios.cs
@@ -1,7 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
-
-
 
 // V1
 namespace ComparisonScenarios
@@ -16,6 +14,56 @@ namespace ComparisonScenarios
 
     public struct StructToMakeGeneric
     {
+    }
+
+    public struct StructToRemoveFieldsFrom
+    {
+        public StructToRemoveFieldsFrom(int fieldToIgnore)
+        {
+            FieldToIgnore = 0;
+            FieldToMakeReadonly = 3;
+            FieldToRemove = 4;
+            FieldToMakeWritable = 5;
+        }
+
+        internal int FieldToIgnore;
+
+        public const int ConstToChangeValue = 1;
+
+        public const int ConstToMakeField = 2;
+
+        public int FieldToMakeReadonly;
+
+        public int FieldToRemove;
+
+        public readonly int FieldToMakeWritable;
+
+        public static int StaticFieldToMakeReadonly = 6;
+
+        public static readonly int StaticFieldToMakeConst = 7;
+
+        public static readonly int StaticFieldToMakeWritable = 8;
+    }
+
+    public class ClassToRemoveFieldsFrom
+    {
+        internal int FieldToIgnore = 0;
+
+        public const int ConstToChangeValue = 1;
+
+        public const int ConstToMakeField = 2;
+
+        public int FieldToMakeReadonly = 3;
+
+        public int FieldToRemove = 4;
+
+        public readonly int FieldToMakeWritable = 5;
+
+        public static int StaticFieldToMakeReadonly = 6;
+
+        public static readonly int StaticFieldToMakeConst = 7;
+
+        public static readonly int StaticFieldToMakeWritable = 8;
     }
 
     public class ClassToChangeNamespaces
@@ -48,6 +96,15 @@ namespace ComparisonScenarios
 
     public class TypeWithExtraInterface
     {
+    }
+
+    public abstract class AbstractClassToAddMethodsTo
+    {
+    }
+
+    public abstract class AbstractClassToAddPropertiesTo
+    {
+        public abstract int PropertyToAddSetterTo { get; }
     }
 
     public interface IInterfaceToAddMembersTo

--- a/test/ApiCheckBaseline.V2/ComparisonScenarios.cs
+++ b/test/ApiCheckBaseline.V2/ComparisonScenarios.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
@@ -16,6 +16,46 @@ namespace ComparisonScenarios
 
     public struct StructToMakeGeneric<TGenericType>
     {
+    }
+
+    public struct StructToRemoveFieldsFrom
+    {
+        public StructToRemoveFieldsFrom(int fieldToIgnore)
+        {
+            FieldToMakeReadonly = 3;
+            FieldToMakeWritable = 5;
+        }
+
+        public const int ConstToChangeValue = 0;
+
+        public static readonly int ConstToMakeField = 2;
+
+        public readonly int FieldToMakeReadonly;
+
+        public int FieldToMakeWritable;
+
+        public static readonly int StaticFieldToMakeReadonly = 6;
+
+        public const int StaticFieldToMakeConst = 7;
+
+        public static int StaticFieldToMakeWritable = 8;
+    }
+
+    public class ClassToRemoveFieldsFrom
+    {
+        public const int ConstToChangeValue = 0;
+
+        public static readonly int ConstToMakeField = 2;
+
+        public readonly int FieldToMakeReadonly = 3;
+
+        public int FieldToMakeWritable = 5;
+
+        public static readonly int StaticFieldToMakeReadonly = 6;
+
+        public const int StaticFieldToMakeConst = 7;
+
+        public static int StaticFieldToMakeWritable = 8;
     }
 
     public class ClassToNestContainer
@@ -50,6 +90,30 @@ namespace ComparisonScenarios
     public interface IExtraInterface
     {
         int Property { get; set; }
+    }
+
+    public abstract class AbstractClassToAddMethodsTo
+    {
+        public abstract void NewAbstractMethod();
+
+        public virtual void NewVirtualMethod() { }
+
+        public void NewMethod() { }
+
+        internal abstract void NewInternalMethod();
+    }
+
+    public abstract class AbstractClassToAddPropertiesTo
+    {
+        public abstract int NewAbstractProperty { get; }
+
+        public abstract int PropertyToAddSetterTo { get; set; }
+
+        public int NewProperty => 0;
+
+        public virtual int NewVirtualProperty => 0;
+
+        internal abstract int NewInternalProperty { get; }
     }
 
     public interface IInterfaceToAddMembersTo


### PR DESCRIPTION
- #146
- also add tests of field removals

nits:
- whitespace cleanup in `ApiListingGenerator` and `ApiListingComparerTests`
- remove unused `additionalFilters` parameter from `ApiListingComparerTests.CreateApiListingDocument()`