### PR TITLE
Switch tools to AssetTargetFallback instead of PTF

### DIFF
--- a/src/NuGetPackageVerifier/NuGetPackageVerifier.csproj
+++ b/src/NuGetPackageVerifier/NuGetPackageVerifier.csproj
@@ -8,7 +8,6 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <AssemblyName>NuGetPackageVerifier</AssemblyName>
     <OutputType>exe</OutputType>
-    <PackageTargetFallback>$(PackageTargetFallback);portable-net45+wp8</PackageTargetFallback>
   </PropertyGroup>
 
   <ItemGroup>
@@ -20,11 +19,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="HtmlAgilityPack" Version="1.4.9" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.5.0-beta8" />
     <PackageReference Include="Mono.Cecil" Version="0.10.0-beta1-v2" />
     <PackageReference Include="Newtonsoft.Json" Version="$(JsonNetVersion)" />
     <PackageReference Include="NuGet.Packaging" Version="$(NuGetPackagesVersion)" />
-    <PackageReference Include="System.Runtime.Loader" Version="4.0.0" />
   </ItemGroup>
 
  <!-- packaging settings -->

--- a/src/SplitPackages/CsprojFileBuilder.cs
+++ b/src/SplitPackages/CsprojFileBuilder.cs
@@ -140,9 +140,9 @@ namespace SplitPackages
                 {
                     var importNames = string.Join(";", imports.Select(Frameworks.GetMoniker));
                     projectDefinitionPropertyGroup.Add(
-                        new XElement("PackageTargetFallback",
+                        new XElement("AssetTargetFallback",
                         new XAttribute("Condition", $" '$(TargetFramework)' == '{monikerName}'"),
-                        $"$(PackageTargetFallback);{importNames}"));
+                        $"$(AssetTargetFallback);{importNames}"));
                 }
             }
 

--- a/src/SplitPackages/SplitPackages.csproj
+++ b/src/SplitPackages/SplitPackages.csproj
@@ -3,11 +3,15 @@
 
   <PropertyGroup>
     <Description>Copies NuGet packages form a given source folder into a specific set of folders based on a CSV file.</Description>
-    <VersionPrefix>1.0.2</VersionPrefix>
+    <VersionPrefix>1.0.3</VersionPrefix>
     <TargetFramework>netcoreapp1.0</TargetFramework>
     <DebugType>portable</DebugType>
     <OutputType>exe</OutputType>
   </PropertyGroup>
+
+  <ItemGroup>
+    <Content Include="build\*.props" CopyToPublishDirectory="PreserveNewest" />
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\PackageClassifier\PackageClassifier.csproj" />

--- a/src/SplitPackages/build/SplitPackages.props
+++ b/src/SplitPackages/build/SplitPackages.props
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup>
+    <SplitPackagesNetCoreAppPath>$(MSBuildThisFileDirectory)..\SplitPackages.dll</SplitPackagesNetCoreAppPath>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
React to changes in NuGet
- SplitPackages generates AssetTargetFallback
- Updated dependency of NGPV to a version that doesn't require framework fallbacks