### PR TITLE
Add JsonPeek task and make WaitForDebugger cancelable

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -1,10 +1,13 @@
-﻿<Project>
+<Project>
   <PropertyGroup>
     <CommandLineUtilsVersion>1.2.0-*</CommandLineUtilsVersion>
     <CoreFxVersion>4.3.0</CoreFxVersion>
     <DotNetCliUtilsVersion>1.0.1</DotNetCliUtilsVersion>
     <DotNetProjectModelVersion>1.0.0-rc3-1-003177</DotNetProjectModelVersion>
+    <!-- This one is OK for console tools that bundle their own version of JSON.NET -->
     <JsonNetVersion>10.0.1</JsonNetVersion>
+    <!-- Use this for anything that runs as an MSBuild task. Should match this: https://github.com/dotnet/sdk/blob/master/build/DependencyVersions.props#L14 -->
+    <JsonNetInMSBuildVersion>9.0.1</JsonNetInMSBuildVersion>
     <MsBuildPackageVersions>15.1.1012</MsBuildPackageVersions>
     <NetStandardPackageVersion>1.6.1</NetStandardPackageVersion>
     <NuGetPackagesVersion>4.0.0</NuGetPackagesVersion>

--- a/src/Internal.AspNetCore.BuildTools.Tasks/Internal.AspNetCore.BuildTools.Tasks.csproj
+++ b/src/Internal.AspNetCore.BuildTools.Tasks/Internal.AspNetCore.BuildTools.Tasks.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MsBuildPackageVersions)" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MsBuildPackageVersions)" />
     <PackageReference Include="Microsoft.Extensions.CommandLineUtils.Sources" Version="$(CommandLineUtilsVersion)" />
+    <PackageReference Include="Newtonsoft.Json" Version="$(JsonNetInMSBuildVersion)" />
     <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
     <PackageReference Include="System.Reflection.Metadata" Version="1.4.2" />
   </ItemGroup>

--- a/src/Internal.AspNetCore.BuildTools.Tasks/JsonPeek.cs
+++ b/src/Internal.AspNetCore.BuildTools.Tasks/JsonPeek.cs
@@ -1,0 +1,96 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.AspNetCore.BuildTools
+{
+#if SDK
+    public class Sdk_JsonPeek : Task
+#elif BuildTools
+    public class JsonPeek : Task
+#else
+#error This must be built either for an SDK or for BuildTools
+#endif
+
+    {
+        /// <summary>
+        /// Specifies the JSONPath query.
+        /// </summary>
+        [Required]
+        public string Query { get; set; }
+
+        /// <summary>
+        /// Specifies the JSON input as a file path.
+        /// </summary>
+        public string JsonInputPath { get; set; }
+
+        /// <summary>
+        /// Specifies the JSON input as a string.
+        /// </summary>
+        public string JsonContent { get; set; }
+
+        /// <summary>
+        /// Contains the results that are returned by this task.
+        /// </summary>
+        [Output]
+        public ITaskItem[] Result { get; set; }
+
+        public override bool Execute()
+        {
+            // pre-set the result in case we exit early
+            Result = Array.Empty<ITaskItem>();
+
+            if (!string.IsNullOrEmpty(JsonInputPath) && !string.IsNullOrEmpty(JsonContent))
+            {
+                Log.LogError($"Cannot specify both {nameof(JsonInputPath)} and {nameof(JsonContent)}.");
+                return false;
+            }
+
+            try
+            {
+                JToken token;
+                if (!string.IsNullOrEmpty(JsonContent))
+                {
+                    token = JToken.Parse(JsonContent);
+                }
+                else
+                {
+                    if (!File.Exists(JsonInputPath))
+                    {
+                        Log.LogError("File does not exist: {path}", JsonInputPath);
+                        return false;
+                    }
+
+                    using (var stream = File.OpenRead(JsonInputPath))
+                    using (var reader = new StreamReader(stream))
+                    using (var json = new JsonTextReader(reader))
+                    {
+                        token = JToken.ReadFrom(json);
+                    }
+                }
+
+                var results = new List<ITaskItem>();
+                foreach (var result in token.SelectTokens(Query))
+                {
+                    var item = new TaskItem(result.ToString());
+                    item.SetMetadata("Type", result.Type.ToString());
+                    results.Add(item);
+                }
+                Result = results.ToArray();
+                return true;
+            }
+            catch (JsonException ex)
+            {
+                Log.LogErrorFromException(ex, showStackTrace: false);
+                return false;
+            }
+        }
+    }
+}

--- a/src/Internal.AspNetCore.BuildTools.Tasks/WaitForDebugger.cs
+++ b/src/Internal.AspNetCore.BuildTools.Tasks/WaitForDebugger.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Diagnostics;
@@ -9,13 +9,20 @@ using Microsoft.Build.Utilities;
 namespace Microsoft.AspNetCore.BuildTools
 {
 #if SDK
-    public class Sdk_WaitForDebugger : Task
+    public class Sdk_WaitForDebugger : Task, ICancelableTask
 #elif BuildTools
     public class WaitForDebugger : Task
 #else
 #error This must be built either for an SDK or for BuildTools
 #endif
     {
+        private bool _canceled;
+
+        public void Cancel()
+        {
+            _canceled = true;
+        }
+
         public override bool Execute()
         {
             Log.LogMessage(MessageImportance.High, $"Waiting for debugger. Process ID: {Process.GetCurrentProcess().Id}");
@@ -24,13 +31,13 @@ namespace Microsoft.AspNetCore.BuildTools
             var maxTimeout = 30 * 1000;
             var step = 150;
 
-            while (!Debugger.IsAttached && maxTimeout > 0)
+            while (!Debugger.IsAttached && maxTimeout > 0 && !_canceled)
             {
                 Thread.Sleep(step);
                 maxTimeout -= step;
             }
 
-            if (!Debugger.IsAttached)
+            if (!Debugger.IsAttached && !_canceled)
             {
                 Log.LogMessage(MessageImportance.High, "Waiting for debugger timed out. Continuing execution.");
             }

--- a/src/Internal.AspNetCore.BuildTools.Tasks/build/Tasks.tasks
+++ b/src/Internal.AspNetCore.BuildTools.Tasks/build/Tasks.tasks
@@ -1,4 +1,4 @@
-﻿<Project>
+<Project>
 
   <PropertyGroup>
     <_BuildToolsAssemblyTfm Condition="'$(MSBuildRuntimeType)' == 'Core'">netcoreapp2.0</_BuildToolsAssemblyTfm>
@@ -12,6 +12,7 @@
   <UsingTask TaskName="Microsoft.AspNetCore.BuildTools.$(_BuildTasksPrefix)GetDotNetHost" AssemblyFile="$(_BuildToolsAssembly)"
     Condition="'$(MSBuildRuntimeType)' == 'Core'"/>
   <UsingTask TaskName="Microsoft.AspNetCore.BuildTools.$(_BuildTasksPrefix)GetOSPlatform" AssemblyFile="$(_BuildToolsAssembly)" />
+  <UsingTask TaskName="Microsoft.AspNetCore.BuildTools.$(_BuildTasksPrefix)JsonPeek" AssemblyFile="$(_BuildToolsAssembly)" />
   <UsingTask TaskName="Microsoft.AspNetCore.BuildTools.$(_BuildTasksPrefix)SetEnvironmentVariable" AssemblyFile="$(_BuildToolsAssembly)" />
   <UsingTask TaskName="Microsoft.AspNetCore.BuildTools.$(_BuildTasksPrefix)UpdatePackageSource" AssemblyFile="$(_BuildToolsAssembly)" />
   <UsingTask TaskName="Microsoft.AspNetCore.BuildTools.$(_BuildTasksPrefix)WaitForDebugger" AssemblyFile="$(_BuildToolsAssembly)" />

--- a/src/Internal.AspNetCore.Sdk/Internal.AspNetCore.Sdk.csproj
+++ b/src/Internal.AspNetCore.Sdk/Internal.AspNetCore.Sdk.csproj
@@ -24,6 +24,7 @@
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MsBuildPackageVersions)" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MsBuildPackageVersions)" />
     <PackageReference Include="Microsoft.Extensions.CommandLineUtils.Sources" Version="$(CommandLineUtilsVersion)" />
+    <PackageReference Include="Newtonsoft.Json" Version="$(JsonNetInMSBuildVersion)" />
     <PackageReference Include="System.Collections.Immutable" Version="1.3.1" PrivateAssets="All" />
     <PackageReference Include="System.Reflection.Metadata" Version="1.4.2" PrivateAssets="All" />
   </ItemGroup>

--- a/test/BuildTools.Tasks.Tests/JsonPeekTests.cs
+++ b/test/BuildTools.Tasks.Tests/JsonPeekTests.cs
@@ -1,0 +1,111 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using Microsoft.AspNetCore.BuildTools;
+using Xunit;
+
+namespace BuildTools.Tasks.Tests
+{
+    public class JsonPeekTests
+    {
+        [Fact]
+        public void CanReadJsonFile()
+        {
+            var filepath = Path.Combine(AppContext.BaseDirectory, "Resources", "sampledata.json");
+            var task = new JsonPeek
+            {
+                BuildEngine = new MockEngine(),
+                JsonInputPath = filepath,
+                Query = "$.sdk.version"
+            };
+
+            Assert.True(task.Execute(), "Task should passed");
+            var result = Assert.Single(task.Result);
+            Assert.Equal("1.2.3", result.ItemSpec);
+            Assert.Equal("String", result.GetMetadata("Type"));
+        }
+
+        [Fact]
+        public void CanReadContent()
+        {
+            var filepath = Path.Combine(AppContext.BaseDirectory, "Resources", "sampledata.json");
+            var content = File.ReadAllText(filepath);
+            var task = new JsonPeek
+            {
+                BuildEngine = new MockEngine(),
+                JsonContent = content,
+                Query = "$.runtimes[*].version"
+            };
+
+            Assert.True(task.Execute(), "Task should passed");
+            Assert.Collection(task.Result,
+                i => Assert.Equal("1.0.0-beta", i.ItemSpec),
+                i => Assert.Equal("1.0.0-alpha", i.ItemSpec));
+        }
+
+        [Fact]
+        public void HandlesEmptyQuery()
+        {
+            var task = new JsonPeek
+            {
+                BuildEngine = new MockEngine(),
+                JsonContent = "{}",
+                Query = "$.dne.property.notthere"
+            };
+
+            Assert.True(task.Execute(), "Task should passed");
+            Assert.Empty(task.Result);
+        }
+
+        [Fact]
+        public void HandlesBadQuery()
+        {
+            var engine = new MockEngine { ContinueOnError = true };
+            var task = new JsonPeek
+            {
+                BuildEngine = engine,
+                JsonContent = "{}",
+                Query = "this is bad JSONPath syntax"
+            };
+
+            Assert.False(task.Execute(), "Task should not passed");
+            var error = Assert.Single(engine.Errors);
+            Assert.Contains("Unexpected character while parsing path", error.Message);
+            Assert.NotNull(task.Result);
+        }
+
+        [Fact]
+        public void HandlesBadJson()
+        {
+            var engine = new MockEngine { ContinueOnError = true };
+            var task = new JsonPeek
+            {
+                BuildEngine = engine,
+                JsonContent = "{ obj: }",
+                Query = ""
+            };
+
+            Assert.False(task.Execute(), "Task should not passed");
+            var error = Assert.Single(engine.Errors);
+            Assert.Contains("Unexpected character encountered while parsing value", error.Message);
+            Assert.NotNull(task.Result);
+        }
+
+        [Fact]
+        public void InvalidToSpecifyContentAndPath()
+        {
+            var task = new JsonPeek
+            {
+                BuildEngine = new MockEngine { ContinueOnError = true },
+                JsonInputPath = Path.Combine(AppContext.BaseDirectory, "Resources", "sampledata.json"),
+                JsonContent = "{}",
+                Query = ""
+            };
+
+            Assert.False(task.Execute(), "Task should not passed");
+            Assert.NotNull(task.Result);
+        }
+    }
+}

--- a/test/BuildTools.Tasks.Tests/JsonPeekTests.cs
+++ b/test/BuildTools.Tasks.Tests/JsonPeekTests.cs
@@ -21,7 +21,7 @@ namespace BuildTools.Tasks.Tests
                 Query = "$.sdk.version"
             };
 
-            Assert.True(task.Execute(), "Task should passed");
+            Assert.True(task.Execute(), "Task should pass");
             var result = Assert.Single(task.Result);
             Assert.Equal("1.2.3", result.ItemSpec);
             Assert.Equal("String", result.GetMetadata("Type"));
@@ -39,7 +39,7 @@ namespace BuildTools.Tasks.Tests
                 Query = "$.runtimes[*].version"
             };
 
-            Assert.True(task.Execute(), "Task should passed");
+            Assert.True(task.Execute(), "Task should pass");
             Assert.Collection(task.Result,
                 i => Assert.Equal("1.0.0-beta", i.ItemSpec),
                 i => Assert.Equal("1.0.0-alpha", i.ItemSpec));
@@ -55,7 +55,7 @@ namespace BuildTools.Tasks.Tests
                 Query = "$.dne.property.notthere"
             };
 
-            Assert.True(task.Execute(), "Task should passed");
+            Assert.True(task.Execute(), "Task should pass");
             Assert.Empty(task.Result);
         }
 
@@ -70,7 +70,7 @@ namespace BuildTools.Tasks.Tests
                 Query = "this is bad JSONPath syntax"
             };
 
-            Assert.False(task.Execute(), "Task should not passed");
+            Assert.False(task.Execute(), "Task should not pass");
             var error = Assert.Single(engine.Errors);
             Assert.Contains("Unexpected character while parsing path", error.Message);
             Assert.NotNull(task.Result);
@@ -87,7 +87,7 @@ namespace BuildTools.Tasks.Tests
                 Query = ""
             };
 
-            Assert.False(task.Execute(), "Task should not passed");
+            Assert.False(task.Execute(), "Task should not pass");
             var error = Assert.Single(engine.Errors);
             Assert.Contains("Unexpected character encountered while parsing value", error.Message);
             Assert.NotNull(task.Result);
@@ -104,7 +104,7 @@ namespace BuildTools.Tasks.Tests
                 Query = ""
             };
 
-            Assert.False(task.Execute(), "Task should not passed");
+            Assert.False(task.Execute(), "Task should not pass");
             Assert.NotNull(task.Result);
         }
     }

--- a/test/BuildTools.Tasks.Tests/MockEngine.cs
+++ b/test/BuildTools.Tasks.Tests/MockEngine.cs
@@ -1,11 +1,11 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Collections;
 using System.Collections.Generic;
 using Microsoft.Build.Framework;
-using Xunit;
+using Xunit.Sdk;
 
 namespace BuildTools.Tasks.Tests
 {
@@ -13,10 +13,11 @@ namespace BuildTools.Tasks.Tests
     {
         public ICollection<BuildMessageEventArgs> Messages { get; } = new List<BuildMessageEventArgs>();
         public ICollection<BuildWarningEventArgs> Warnings { get; } = new List<BuildWarningEventArgs>();
+        public ICollection<BuildErrorEventArgs> Errors { get; } = new List<BuildErrorEventArgs>();
 
         public bool IsRunningMultipleNodes => false;
 
-        public bool ContinueOnError => false;
+        public bool ContinueOnError { get; set; }
 
         public int LineNumberOfTaskNode => 0;
 
@@ -32,7 +33,11 @@ namespace BuildTools.Tasks.Tests
 
         public void LogErrorEvent(BuildErrorEventArgs e)
         {
-            Assert.False(true, e.Message);
+            Errors.Add(e);
+            if (!ContinueOnError)
+            {
+                throw new XunitException("Task error: " + e.Message);
+            }
         }
 
         #region NotImplemented

--- a/test/BuildTools.Tasks.Tests/Resources/sampledata.json
+++ b/test/BuildTools.Tasks.Tests/Resources/sampledata.json
@@ -1,0 +1,11 @@
+{
+  "sdk": { "version": "1.2.3" },
+  "runtimes": [
+    {
+      "version": "1.0.0-beta"
+    },
+    {
+      "version": "1.0.0-alpha"
+    }
+  ]
+}


### PR DESCRIPTION
Add a task to make it easier to read JSON files from MSBuild.

cc @JunTaoLuo - for our installer tasks :)