### PR TITLE
Updated properties to generate nuget package's nuspec properties

### DIFF
--- a/src/Internal.AspNetCore.Sdk/build/Common.props
+++ b/src/Internal.AspNetCore.Sdk/build/Common.props
@@ -12,12 +12,14 @@ Usage: this should be imported once via NuGet at the top of the file.
   <PropertyGroup>
     <Authors>Microsoft</Authors>
     <Company>Microsoft Corporation.</Company>
-    <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
+    <Copyright>Copyright © Microsoft Corporation</Copyright>
     <IncludeSymbols>true</IncludeSymbols>
     <NeutralLanguage>en-US</NeutralLanguage>
     <NoPackageAnalysis>true</NoPackageAnalysis>
-    <ProjectUrl>https://asp.net</ProjectUrl>
-    <RequireLicenseAcceptance>true</RequireLicenseAcceptance>
+    <PackageLicenseUrl>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</PackageLicenseUrl>
+    <PackageIconUrl>https://go.microsoft.com/fwlink/?LinkID=288859</PackageIconUrl>
+    <PackageProjectUrl>https://asp.net</PackageProjectUrl>
+    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <Serviceable Condition="'$(Configuration)' == 'Release'">true</Serviceable>
   </PropertyGroup>
 


### PR DESCRIPTION
Fixes: https://github.com/aspnet/Coherence-Signed/issues/564

- A follow up PR would be to remove this https://github.com/aspnet/Coherence-Signed/blob/dev/build/Legacy-MsBuild.targets#L83

