### PR TITLE
Align versions to 2.0.x-rtm

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -12,6 +12,7 @@
     <EnableApiCheck>false</EnableApiCheck>
     <!-- workaround https://github.com/aspnet/CoreCLR/issues/223 -->
     <NoWarn>$(NoWarn);NU1603</NoWarn>
+    <Serviceable>false</Serviceable>
   </PropertyGroup>
 
   <Import Project="$(_AspNetToolsSdkPath)\build\Internal.AspNetCore.Sdk.props" />
@@ -19,6 +20,7 @@
   <PropertyGroup>
     <RepositoryUrl>https://github.com/aspnet/BuildTools</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
+    <VersionSuffix Condition="'$(VersionSuffix)' != '' AND '$(BuildNumber)' != ''">$(VersionSuffix)-$(BuildNumber)</VersionSuffix>
   </PropertyGroup>
 
 </Project>

--- a/build/repo.targets
+++ b/build/repo.targets
@@ -22,8 +22,17 @@
     </BundledTools>
   </ItemDefinitionGroup>
 
-  <Target Name="PackageKoreBuild" DependsOnTargets="ResolveCommitHash" AfterTargets="Package">
+  <PropertyGroup>
+    <_KoreBuildIntermediateDir>$(IntermediateDir)korebuild\</_KoreBuildIntermediateDir>
+    <_KoreBuildOutDir>$(ArtifactsDir)korebuild\artifacts\$(Version)\</_KoreBuildOutDir>
+    <_ChannelOutDir>$(ArtifactsDir)korebuild\channels\$(KoreBuildChannel)\</_ChannelOutDir>
+  </PropertyGroup>
 
+  <Target Name="CleanKoreBuild">
+    <RemoveDir Directories="$(_KoreBuildIntermediateDir);$(ArtifactsDir)korebuild\" />
+  </Target>
+
+  <Target Name="PackageKoreBuild" DependsOnTargets="ResolveCommitHash;CleanKoreBuild" AfterTargets="Package">
     <Error Text="Missing property: KoreBuildChannel" Condition="'$(KoreBuildChannel)' == ''" />
     <Error Text="Missing property: Version" Condition="'$(Version)' == ''" />
     <Error Text="Missing property: CommitHash" Condition="'$(CommitHash)' == ''" />
@@ -39,13 +48,6 @@
       <Content Include="$(RepositoryRoot)sdk\KoreBuild\**\*" />
     </ItemGroup>
 
-    <PropertyGroup>
-      <_KoreBuildIntermediateDir>$(IntermediateDir)korebuild\</_KoreBuildIntermediateDir>
-      <_KoreBuildOutDir>$(ArtifactsDir)korebuild\artifacts\$(Version)\</_KoreBuildOutDir>
-      <_ChannelOutDir>$(ArtifactsDir)korebuild\channels\$(KoreBuildChannel)\</_ChannelOutDir>
-    </PropertyGroup>
-
-    <RemoveDir Directories="$(_KoreBuildIntermediateDir);$(ArtifactsDir)korebuild\" />
     <MakeDir Directories="$(_ChannelOutDir);$(_KoreBuildOutDir);$(_KoreBuildIntermediateDir)" />
     <Copy SourceFiles="%(Content.Identity)" DestinationFiles="$(_KoreBuildIntermediateDir)%(RecursiveDir)%(FileName)%(Extension)" />
 

--- a/src/Internal.AspNetCore.BuildTools.Tasks/Internal.AspNetCore.BuildTools.Tasks.csproj
+++ b/src/Internal.AspNetCore.BuildTools.Tasks/Internal.AspNetCore.BuildTools.Tasks.csproj
@@ -3,8 +3,6 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <VersionPrefix>2.0.0</VersionPrefix>
-    <VersionSuffix>rc2-$(BuildNumber)</VersionSuffix>
     <DefineConstants>$(DefineConstants);BuildTools</DefineConstants>
     <Description>MSBuild tasks. This package is intended for Microsoft use only</Description>
     <TargetFrameworks>netcoreapp2.0;net46</TargetFrameworks>

--- a/src/Internal.AspNetCore.Sdk/Internal.AspNetCore.Sdk.csproj
+++ b/src/Internal.AspNetCore.Sdk/Internal.AspNetCore.Sdk.csproj
@@ -3,8 +3,7 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <VersionPrefix>2.1.0</VersionPrefix>
-    <VersionSuffix>rc2-$(BuildNumber)</VersionSuffix>
+    <VersionPrefix>2.0.1</VersionPrefix>
     <TargetFrameworks>netcoreapp2.0;net46</TargetFrameworks>
     <DefineConstants>$(DefineConstants);SDK</DefineConstants>
     <Serviceable>false</Serviceable>

--- a/src/Microsoft.AspNetCore.BuildTools.ApiCheck/Microsoft.AspNetCore.BuildTools.ApiCheck.csproj
+++ b/src/Microsoft.AspNetCore.BuildTools.ApiCheck/Microsoft.AspNetCore.BuildTools.ApiCheck.csproj
@@ -2,9 +2,6 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <VersionPrefix>2.0.0</VersionPrefix>
-    <VersionSuffix>rc2-$(BuildNumber)</VersionSuffix>
-
     <!--
       The netstandard1.0 TFM doesn't actually compile. It's just there so Internal.AspNetCore.Sdk can take a dependency
       on this project.

--- a/src/NuGetPackageVerifier/NuGetPackageVerifier.csproj
+++ b/src/NuGetPackageVerifier/NuGetPackageVerifier.csproj
@@ -4,8 +4,6 @@
 
   <PropertyGroup>
     <Description>Verifies Asp.Net Core NuGet packages.</Description>
-    <VersionPrefix>2.0.0</VersionPrefix>
-    <VersionSuffix>rc2-$(BuildNumber)</VersionSuffix>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <AssemblyName>NuGetPackageVerifier</AssemblyName>
     <OutputType>exe</OutputType>

--- a/src/PackageClassifier/PackageClassifier.csproj
+++ b/src/PackageClassifier/PackageClassifier.csproj
@@ -5,8 +5,6 @@
   <PropertyGroup>
     <Description>Classifies a set of packages from several directories based on information from a csv file</Description>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
-    <VersionPrefix>2.0.0</VersionPrefix>
-    <VersionSuffix>rc2-$(BuildNumber)</VersionSuffix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/PackagePublisher/PackagePublisher.csproj
+++ b/src/PackagePublisher/PackagePublisher.csproj
@@ -6,8 +6,6 @@
     <DebugType>portable</DebugType>
     <OutputType>exe</OutputType>
     <TargetFramework>netcoreapp2.0</TargetFramework>
-    <VersionPrefix>2.0.0</VersionPrefix>
-    <VersionSuffix>rc2-$(BuildNumber)</VersionSuffix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/SplitPackages/SplitPackages.csproj
+++ b/src/SplitPackages/SplitPackages.csproj
@@ -3,8 +3,6 @@
 
   <PropertyGroup>
     <Description>Copies NuGet packages form a given source folder into a specific set of folders based on a CSV file.</Description>
-    <VersionPrefix>2.0.0</VersionPrefix>
-    <VersionSuffix>rc2-$(BuildNumber)</VersionSuffix>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <DebugType>portable</DebugType>
     <OutputType>exe</OutputType>

--- a/src/VersionTool/VersionTool.csproj
+++ b/src/VersionTool/VersionTool.csproj
@@ -4,7 +4,6 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
-    <VersionSuffix>rc2-$(BuildNumber)</VersionSuffix>
     <AssemblyName>VersionTool</AssemblyName>
     <OutputType>exe</OutputType>
   </PropertyGroup>

--- a/version.props
+++ b/version.props
@@ -2,6 +2,6 @@
   <PropertyGroup>
     <KoreBuildChannel>dev</KoreBuildChannel>
     <VersionPrefix>2.0.0</VersionPrefix>
-    <VersionSuffix>build</VersionSuffix>
+    <VersionSuffix>rtm</VersionSuffix>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Resolves https://github.com/aspnet/BuildTools/issues/284

 - Internal.AspNetCore.Sdk is technically rolling back in time from 2.1.0 to 2.0.1, but I'll update our source repos. This will help us reason better about which version of this package should be used to build `rel/2.0.0`.