### PR TITLE
Remove DefaultCompositeRule from SigningVerificationCompositeRule

### DIFF
--- a/src/NuGetPackageVerifier/CompositeRules/SigningVerificationCompositeRule.cs
+++ b/src/NuGetPackageVerifier/CompositeRules/SigningVerificationCompositeRule.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
@@ -13,7 +13,6 @@ namespace NuGetPackageVerifier.Rules
             new AuthenticodeSigningRule(),
             new PowerShellScriptIsSignedRule(),
             new PackageOwnershipRule(),
-            new DefaultCompositeRule(),
             new PrereleaseDependenciesVersionRule(),
         };
 


### PR DESCRIPTION
https://github.com/aspnet/Coherence-Signed/issues/574

We want to run all the non-signing verification rules separately.

@pranavkm @natemcmaster @Eilon 