### PR TITLE
Allow configuring KoreBuild from the version.props file

### DIFF
--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -12,16 +12,19 @@ Downloads korebuild if required. Then builds the repository.
 The folder to build. Defaults to the folder containing this script.
 
 .PARAMETER Channel
-The channel of KoreBuild to download.
+The channel of KoreBuild to download. Overrides the value from the config file.
 
 .PARAMETER DotNetHome
 The directory where .NET Core tools will be stored.
 
 .PARAMETER ToolsSource
-The base url where build tools can be downloaded.
+The base url where build tools can be downloaded. Overrides the value from the config file.
 
 .PARAMETER Update
 Updates KoreBuild to the latest version even if a lock file is present.
+
+.PARAMETER ConfigFile
+The path to the configuration file that stores values. Defaults to version.props.
 
 .PARAMETER MSBuildArgs
 Arguments to be passed to MSBuild
@@ -30,18 +33,32 @@ Arguments to be passed to MSBuild
 This function will create a file $PSScriptRoot/korebuild-lock.txt. This lock file can be committed to source, but does not have to be.
 When the lockfile is not present, KoreBuild will create one using latest available version from $Channel.
 
+The $ConfigFile is expected to be an XML file. It is optional, and the configuration values in it are optional as well.
+
+.EXAMPLE
+Example config file:
+```xml
+<!-- version.props -->
+<Project>
+  <PropertyGroup>
+    <KoreBuildChannel>dev</KoreBuildChannel>
+    <KoreBuildToolsSource>https://aspnetcore.blob.core.windows.net/buildtools</KoreBuildToolsSource>
+  </PropertyGroup>
+</Project>
+```
 #>
 [CmdletBinding(PositionalBinding = $false)]
 param(
     [string]$Path = $PSScriptRoot,
     [Alias('c')]
-    [string]$Channel = 'rel/2.0.0',
+    [string]$Channel,
     [Alias('d')]
     [string]$DotNetHome,
     [Alias('s')]
-    [string]$ToolsSource = 'https://aspnetcore.blob.core.windows.net/buildtools',
+    [string]$ToolsSource,
     [Alias('u')]
     [switch]$Update,
+    [string]$ConfigFile = (Join-Path $PSScriptRoot 'version.props'),
     [Parameter(ValueFromRemainingArguments = $true)]
     [string[]]$MSBuildArgs
 )
@@ -128,12 +145,25 @@ function Get-RemoteFile([string]$RemotePath, [string]$LocalPath) {
 # Main
 #
 
+# Load configuration or set defaults
+
+if (Test-Path $ConfigFile) {
+    [xml] $config = Get-Content $ConfigFile
+    if (!($Channel)) { [string] $Channel = Select-Xml -Xml $config -XPath '/Project/PropertyGroup/KoreBuildChannel' }
+    if (!($ToolsSource)) { [string] $ToolsSource = Select-Xml -Xml $config -XPath '/Project/PropertyGroup/KoreBuildToolsSource' }
+}
+
 if (!$DotNetHome) {
     $DotNetHome = if ($env:DOTNET_HOME) { $env:DOTNET_HOME } `
         elseif ($env:USERPROFILE) { Join-Path $env:USERPROFILE '.dotnet'} `
         elseif ($env:HOME) {Join-Path $env:HOME '.dotnet'}`
         else { Join-Path $PSScriptRoot '.dotnet'}
 }
+
+if (!$Channel) { $Channel = 'dev' }
+if (!$ToolsSource) { $ToolsSource = 'https://aspnetcore.blob.core.windows.net/buildtools' }
+
+# Execute
 
 $korebuildPath = Get-KoreBuild
 Import-Module -Force -Scope Local (Join-Path $korebuildPath 'KoreBuild.psd1')

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -2,10 +2,6 @@
 
 set -euo pipefail
 
-# korebuild config values
-channel='rel/2.0.0'
-tools_source='https://aspnetcore.blob.core.windows.net/buildtools'
-
 #
 # variables
 #
@@ -15,9 +11,12 @@ RED="\033[0;31m"
 MAGENTA="\033[0;95m"
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 [ -z "${DOTNET_HOME:-}"] && DOTNET_HOME="$HOME/.dotnet"
+config_file="$DIR/version.props"
 verbose=false
 update=false
 repo_path="$DIR"
+channel=''
+tools_source=''
 
 #
 # Functions
@@ -30,10 +29,11 @@ __usage() {
     echo ""
     echo "Options:"
     echo "    --verbose                Show verbose output."
-    echo "    -c|--channel <CHANNEL>   The channel of KoreBuild to download. Defaults to '$channel'."
+    echo "    -c|--channel <CHANNEL>   The channel of KoreBuild to download. Overrides the value from the config file.."
+    echo "    --config-file <FILE>     TThe path to the configuration file that stores values. Defaults to version.props."
     echo "    -d|--dotnet-home <DIR>   The directory where .NET Core tools will be stored. Defaults to '\$DOTNET_HOME' or '\$HOME/.dotnet."
     echo "    --path <PATH>            The directory to build. Defaults to the directory containing the script."
-    echo "    -s|--tools-source <URL>  The base url where build tools can be downloaded. Defaults to '$tools_source'."
+    echo "    -s|--tools-source <URL>  The base url where build tools can be downloaded. Overrides the value from the config file."
     echo "    -u|--update              Update to the latest KoreBuild even if the lock file is present."
     echo ""
     echo "Description:"
@@ -113,6 +113,8 @@ __get_remote_file() {
     fi
 }
 
+__read_dom () { local IFS=\> ; read -d \< ENTITY CONTENT ;}
+
 #
 # main
 #
@@ -127,6 +129,11 @@ while [[ $# > 0 ]]; do
             shift
             channel=${1:-}
             [ -z "$channel" ] && __usage
+            ;;
+        --config-file|-ConfigFile)
+            shift
+            config_file="${1:-}"
+            [ -z "$config_file" ] && __usage
             ;;
         -d|--dotnet-home|-DotNetHome)
             shift
@@ -169,6 +176,19 @@ if ! __machine_has curl && ! __machine_has wget; then
     __error 'Missing required command. Either wget or curl is required.'
     exit 1
 fi
+
+if [ -f $config_file ]; then
+    comment=false
+    while __read_dom; do
+        if [ "$comment" = true ]; then [[ $CONTENT == *'-->'* ]] && comment=false ; continue; fi
+        if [[ $ENTITY == '!--'* ]]; then comment=true; continue; fi
+        if [ -z "$channel" ] && [[ $ENTITY == "KoreBuildChannel" ]]; then channel=$CONTENT; fi
+        if [ -z "$tools_source" ] && [[ $ENTITY == "KoreBuildToolsSource" ]]; then tools_source=$CONTENT; fi
+    done < $config_file
+fi
+
+[ -z "$channel" ] && channel='dev'
+[ -z "$tools_source" ] && tools_source='https://aspnetcore.blob.core.windows.net/buildtools'
 
 get_korebuild
 install_tools "$tools_source" "$DOTNET_HOME"

--- a/testassets/SimpleRepo/version.props
+++ b/testassets/SimpleRepo/version.props
@@ -1,0 +1,7 @@
+<Project>
+  <PropertyGroup>
+    <KoreBuildChannel>rel/2.0.0</KoreBuildChannel>
+    <VersionPrefix>2.0.0</VersionPrefix>
+    <VersionSuffix>rtm</VersionSuffix>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
Currently, when we branch we have to touch our build.sh and build.ps1 scripts to change which version of KoreBuild is acquired. This keeps the command-line flag overrides but moves the default channel into version.props

Expected usage:
```xml
<Project>
  <PropertyGroup>
     <!-- defaults to 'dev' in the script if not specified in version.props -->
     <KoreBuildChannel>rel/2.0.0</KoreBuildChannel>
     <!-- defaults to 'https://aspnetcore.blob.core.windows.net/buildtools' in the script if not specified in version.props -->
     <KoreBuildToolsSource>C:/buildtools/</KoreBuildToolsSource>
     <VersionPrefix>2.0.0</VersionPrefix>
     <VersionSuffix>rtm</VersionSuffix>
   </PropertyGroup>
</Project>
```