### PR TITLE
Use fixed build number for non-CI builds

### DIFF
--- a/build/repo.beforecommon.props
+++ b/build/repo.beforecommon.props
@@ -1,0 +1,6 @@
+<Project>
+  <PropertyGroup>
+    <!-- for local builds, always use the time-based build number -->
+    <IncrementalVersion>true</IncrementalVersion>
+  </PropertyGroup>
+</Project>

--- a/build/repo.props
+++ b/build/repo.props
@@ -1,16 +1,6 @@
 <Project>
   <Import Project="..\version.xml" />
 
-  <PropertyGroup Condition=" '$(BuildNumber)' == 'dev-0000' ">
-    <!--
-      Create second-based build number for local builds.
-      635556672000000000 is Jan 1, 2015.
-    -->
-    <_SecondBasedTimeStamp>$([System.DateTime]::UtcNow.Subtract($([System.DateTime]::FromBinary(635556672000000000))).TotalSeconds.ToString("F0"))</_SecondBasedTimeStamp>
-    <_SecondBasedTimeStamp>t$([System.Int64]::Parse($(_SecondBasedTimeStamp)).ToString("x9"))</_SecondBasedTimeStamp>
-    <BuildNumber>$(_SecondBasedTimeStamp)</BuildNumber>
-  </PropertyGroup>
-
   <PropertyGroup>
     <Version>$(VersionPrefix)</Version>
     <Version Condition="'$(VersionSuffix)' != ''">$(Version)-$(VersionSuffix)</Version>

--- a/build/repo.props
+++ b/build/repo.props
@@ -1,6 +1,16 @@
 <Project>
   <Import Project="..\version.xml" />
 
+  <PropertyGroup Condition=" '$(BuildNumber)' == 'dev-0000' ">
+    <!--
+      Create second-based build number for local builds.
+      635556672000000000 is Jan 1, 2015.
+    -->
+    <_SecondBasedTimeStamp>$([System.DateTime]::UtcNow.Subtract($([System.DateTime]::FromBinary(635556672000000000))).TotalSeconds.ToString("F0"))</_SecondBasedTimeStamp>
+    <_SecondBasedTimeStamp>t$([System.Int64]::Parse($(_SecondBasedTimeStamp)).ToString("x9"))</_SecondBasedTimeStamp>
+    <BuildNumber>$(_SecondBasedTimeStamp)</BuildNumber>
+  </PropertyGroup>
+
   <PropertyGroup>
     <Version>$(VersionPrefix)</Version>
     <Version Condition="'$(VersionSuffix)' != ''">$(Version)-$(VersionSuffix)</Version>

--- a/sdk/KoreBuild/KoreBuild.Common.props
+++ b/sdk/KoreBuild/KoreBuild.Common.props
@@ -39,7 +39,6 @@ Default layout and configuration.
     <IntermediateDir>$(RepositoryRoot)obj\</IntermediateDir>
   </PropertyGroup>
 
-
   <!-- Use build number from CI if available -->
   <PropertyGroup Condition=" '$(BuildNumber)' == '' ">
     <!--
@@ -50,8 +49,19 @@ Default layout and configuration.
   </PropertyGroup>
 
   <!-- Create a temporary build number if not assigned by the CI server -->
+  <PropertyGroup Condition=" '$(BuildNumber)' == '' AND '$(IncrementalVersion)' == 'true' ">
+    <!--
+      Create second-based build number for local builds.
+      635556672000000000 is Jan 1, 2015.
+    -->
+    <_SecondBasedTimeStamp>$([System.DateTime]::UtcNow.Subtract($([System.DateTime]::FromBinary(635556672000000000))).TotalSeconds.ToString("F0"))</_SecondBasedTimeStamp>
+    <_SecondBasedTimeStamp>t$([System.Int64]::Parse($(_SecondBasedTimeStamp)).ToString("x9"))</_SecondBasedTimeStamp>
+    <BuildNumber>$(_SecondBasedTimeStamp)</BuildNumber>
+  </PropertyGroup>
+
   <PropertyGroup Condition=" '$(BuildNumber)' == '' ">
-    <BuildNumber>dev-0000</BuildNumber>
+    <BuildNumber>t000</BuildNumber>
+    <UsingLocalBuildNumber>true</UsingLocalBuildNumber>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/sdk/KoreBuild/KoreBuild.Common.props
+++ b/sdk/KoreBuild/KoreBuild.Common.props
@@ -51,13 +51,7 @@ Default layout and configuration.
 
   <!-- Create a temporary build number if not assigned by the CI server -->
   <PropertyGroup Condition=" '$(BuildNumber)' == '' ">
-    <!--
-      Create second-based build number for local builds.
-      635556672000000000 is Jan 1, 2015.
-    -->
-    <_SecondBasedTimeStamp>$([System.DateTime]::UtcNow.Subtract($([System.DateTime]::FromBinary(635556672000000000))).TotalSeconds.ToString("F0"))</_SecondBasedTimeStamp>
-    <_SecondBasedTimeStamp>t$([System.Int64]::Parse($(_SecondBasedTimeStamp)).ToString("x9"))</_SecondBasedTimeStamp>
-    <BuildNumber>$(_SecondBasedTimeStamp)</BuildNumber>
+    <BuildNumber>dev-0000</BuildNumber>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/sdk/KoreBuild/KoreBuild.proj
+++ b/sdk/KoreBuild/KoreBuild.proj
@@ -2,6 +2,8 @@
 <Project DefaultTargets="Build">
 
   <!-- props -->
+  <Import Project="$(RepositoryRoot)build\repo.beforecommon.props" Condition="Exists('$(RepositoryRoot)build\repo.beforecommon.props')" />
+
   <Import Project="KoreBuild.Common.props" />
 
   <Import Project="modules\*\module.props" />

--- a/test/KoreBuild.FunctionalTests/SimpleRepoTests.cs
+++ b/test/KoreBuild.FunctionalTests/SimpleRepoTests.cs
@@ -26,7 +26,7 @@ namespace KoreBuild.FunctionalTests
         {
             var app = _fixture.CreateTestApp("SimpleRepo");
 
-            var build = app.ExecuteBuild(_output, "/p:BuildNumber=0001");
+            var build = app.ExecuteBuild(_output);
             var task = await Task.WhenAny(build, Task.Delay(TimeSpan.FromMinutes(5)));
 
             Assert.Same(task, build);
@@ -36,12 +36,12 @@ namespace KoreBuild.FunctionalTests
             Assert.True(File.Exists(Path.Combine(app.WorkingDirectory, "korebuild-lock.txt")), "Should have created the korebuild lock file");
 
             // /t:Package
-            Assert.True(File.Exists(Path.Combine(app.WorkingDirectory, "artifacts", "build", "Simple.Lib.1.0.0-beta-0001.nupkg")), "Build should have produced a lib nupkg");
-            Assert.True(File.Exists(Path.Combine(app.WorkingDirectory, "artifacts", "build", "Simple.Sources.1.0.0-beta-0001.nupkg")), "Build should have produced a sources nupkg");
+            Assert.True(File.Exists(Path.Combine(app.WorkingDirectory, "artifacts", "build", "Simple.Lib.1.0.0-beta-t000.nupkg")), "Build should have produced a lib nupkg");
+            Assert.True(File.Exists(Path.Combine(app.WorkingDirectory, "artifacts", "build", "Simple.Sources.1.0.0-beta-t000.nupkg")), "Build should have produced a sources nupkg");
 
             // /t:TestNuGetPush
-            Assert.True(File.Exists(Path.Combine(app.WorkingDirectory, "obj", "tmp-nuget", "Simple.Lib.1.0.0-beta-0001.nupkg")), "Build done a test push of all the packages");
-            Assert.True(File.Exists(Path.Combine(app.WorkingDirectory, "obj", "tmp-nuget", "Simple.Sources.1.0.0-beta-0001.nupkg")), "Build done a test push of all the packages");
+            Assert.True(File.Exists(Path.Combine(app.WorkingDirectory, "obj", "tmp-nuget", "Simple.Lib.1.0.0-beta-t000.nupkg")), "Build done a test push of all the packages");
+            Assert.True(File.Exists(Path.Combine(app.WorkingDirectory, "obj", "tmp-nuget", "Simple.Sources.1.0.0-beta-t000.nupkg")), "Build done a test push of all the packages");
         }
     }
 }


### PR DESCRIPTION
Don't use a time-based build number for local builds to allow for restore noop.

In the 2.0 SDK, NuGet restore will no-op if there have been no changes to the dependency spec. For local builds, this time-based build number invalidates the restore cache each time build.ps1 one. This increases restore time that is often unnecessary.

Comparison on aspnet/Mvc, with no new dependencies to install:
Restore w/ time-based buildnumber: ~44 seconds 
Restore w/ fixed build number: ~20 seconds.
