### PR TITLE
Fix bugs in shared sources packaging targets

### DIFF
--- a/sdk/KoreBuild/modules/sharedsources/module.targets
+++ b/sdk/KoreBuild/modules/sharedsources/module.targets
@@ -23,8 +23,7 @@ that matches "$(RepositoryRoot)/shared/*.Sources".
 
     <MSBuild Targets="Restore;Pack"
       Projects="$(MSBuildThisFileDirectory)sharedsources.csproj"
-      Properties="PackageOutputPath=$(BuildDir);RepositoryRoot=$(RepositoryRoot);NuspecBasePath=%(_SharedSourceItems.Identity);PackageId=%(FileName)%(Extension);BuildNumber=$(BuildNumber)"
-      Condition="'@(_SharedSourceItems)' != ''"
-      BuildInParallel="$(BuildInParallel)" />
+      Properties="PackageOutputPath=$(BuildDir);RepositoryRoot=$(RepositoryRoot);NuspecBasePath=$([MSBuild]::EnsureTrailingSlash('%(_SharedSourceItems.Identity)'));PackageId=%(FileName)%(Extension);BuildNumber=$(BuildNumber)"
+      Condition="'@(_SharedSourceItems)' != ''" />
   </Target>
 </Project>

--- a/sdk/KoreBuild/modules/sharedsources/sharedsources.csproj
+++ b/sdk/KoreBuild/modules/sharedsources/sharedsources.csproj
@@ -4,9 +4,11 @@
   <PropertyGroup>
     <BaseOutputPath>$(NuspecBasePath)bin\</BaseOutputPath>
     <BaseIntermediateOutputPath>$(NuspecBasePath)obj\</BaseIntermediateOutputPath>
+    <DirBuildPropsInRepo>$([MSBuild]::GetDirectoryNameOfFileAbove($(NuspecBasePath), Directory.Build.props))\Directory.Build.props</DirBuildPropsInRepo>
+    <DirBuildTargetsInRepo>$([MSBuild]::GetDirectoryNameOfFileAbove($(NuspecBasePath), Directory.Build.targets))\Directory.Build.targets</DirBuildTargetsInRepo>
   </PropertyGroup>
 
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(NuspecBasePath), Directory.Build.props))\Directory.Build.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(NuspecBasePath), Directory.Build.props))\Directory.Build.props')" />
+  <Import Project="$(DirBuildPropsInRepo)" Condition="Exists('$(DirBuildPropsInRepo)')" />
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
   <Target Name="VerifyProperties" BeforeTargets="Pack">
@@ -19,8 +21,8 @@
   <Import Project="$(NuspecBasePath)\sharedsources.props" Condition="Exists('$(NuspecBasePath)\sharedsources.props')" />
 
   <Target Name="WarnIfNoCommonProps" BeforeTargets="Pack">
-    <Warning Text="Expected a props file in '$(RepositoryRoot)build\common.props' or '$([MSBuild]::GetDirectoryNameOfFileAbove($(NuspecBasePath), Directory.Build.props))\Directory.Build.props')'. Shared sources packages may be missing the right version number when this is left out."
-             Condition="!Exists('$(RepositoryRoot)build\common.props') And !Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(NuspecBasePath), Directory.Build.props))\Directory.Build.props')"/>
+    <Warning Text="Expected a props file in '$(RepositoryRoot)build\common.props' or '$(DirBuildPropsInRepo)')'. Shared sources packages may be missing the right version number when this is left out."
+             Condition="!Exists('$(RepositoryRoot)build\common.props') And !Exists('$(DirBuildPropsInRepo)')"/>
   </Target>
 
   <PropertyGroup>
@@ -33,14 +35,15 @@
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <ContentTargetFolders>contentFiles</ContentTargetFolders>
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
+    <DefaultExcludeItems>$(DefaultExcludeItems);$(BaseOutputPath);$(BaseIntermediateOutputPath);</DefaultExcludeItems>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(NuspecBasePath)'!=''">
-    <Compile Include="$(NuspecBasePath)\**\*.cs" Exclude="$(BaseOutputPath);$(BaseIntermediateOutputPath);">
+    <Compile Include="$(NuspecBasePath)\**\*.cs" Exclude="$(DefaultExcludeItems)">
       <Pack>true</Pack>
       <PackagePath>$(ContentTargetFolders)\cs\netstandard1.0\</PackagePath>
     </Compile>
-    <EmbeddedResource Include="$(NuspecBasePath)\**\*.resx" Exclude="$(BaseOutputPath);$(BaseIntermediateOutputPath);">
+    <EmbeddedResource Include="$(NuspecBasePath)\**\*.resx" Exclude="$(DefaultExcludeItems)">
       <Pack>true</Pack>
       <PackagePath>$(ContentTargetFolders)\any\any\</PackagePath>
     </EmbeddedResource>
@@ -50,6 +53,6 @@
     <PackageReference Remove="@(PackageReference)" />
   </ItemGroup>
 
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(NuspecBasePath), Directory.Build.targets))\Directory.Build.targets" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(NuspecBasePath), Directory.Build.targets))\Directory.Build.targets')" />
+  <Import Project="$(DirBuildTargetsInRepo)" Condition="Exists('$(DirBuildTargetsInRepo)')" />
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 </Project>

--- a/sdk/KoreBuild/modules/sharedsources/sharedsources.csproj
+++ b/sdk/KoreBuild/modules/sharedsources/sharedsources.csproj
@@ -1,5 +1,13 @@
 <!-- this is a dummy project designed to produce contentFiles packages -->
-<Project Sdk="Microsoft.NET.Sdk">
+<Project>
+
+  <PropertyGroup>
+    <BaseOutputPath>$(NuspecBasePath)bin\</BaseOutputPath>
+    <BaseIntermediateOutputPath>$(NuspecBasePath)obj\</BaseIntermediateOutputPath>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(NuspecBasePath), Directory.Build.props))\Directory.Build.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(NuspecBasePath), Directory.Build.props))\Directory.Build.props')" />
+  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
   <Target Name="VerifyProperties" BeforeTargets="Pack">
     <Error Text="Missing property: RepositoryRoot" Condition="'$(RepositoryRoot)'==''"/>
@@ -11,11 +19,12 @@
   <Import Project="$(NuspecBasePath)\sharedsources.props" Condition="Exists('$(NuspecBasePath)\sharedsources.props')" />
 
   <Target Name="WarnIfNoCommonProps" BeforeTargets="Pack">
-    <Warning Text="Expected a props file in '$(RepositoryRoot)build\common.props'. Shared sources packages may be missing the right version number when this is left out."
-             Condition="!Exists('$(RepositoryRoot)build\common.props')"/>
+    <Warning Text="Expected a props file in '$(RepositoryRoot)build\common.props' or '$([MSBuild]::GetDirectoryNameOfFileAbove($(NuspecBasePath), Directory.Build.props))\Directory.Build.props')'. Shared sources packages may be missing the right version number when this is left out."
+             Condition="!Exists('$(RepositoryRoot)build\common.props') And !Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(NuspecBasePath), Directory.Build.props))\Directory.Build.props')"/>
   </Target>
 
   <PropertyGroup>
+    <IsPackable>true</IsPackable>
     <NoBuild>true</NoBuild>
     <PackageOutputPath Condition="'$(PackageOutputPath)'==''">$(RepositoryRoot)artifacts\build</PackageOutputPath>
     <TargetFramework>netstandard1.0</TargetFramework>
@@ -27,11 +36,11 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(NuspecBasePath)'!=''">
-    <Compile Include="$(NuspecBasePath)\**\*.cs">
+    <Compile Include="$(NuspecBasePath)\**\*.cs" Exclude="$(BaseOutputPath);$(BaseIntermediateOutputPath);">
       <Pack>true</Pack>
       <PackagePath>$(ContentTargetFolders)\cs\netstandard1.0\</PackagePath>
     </Compile>
-    <EmbeddedResource Include="$(NuspecBasePath)\**\*.resx">
+    <EmbeddedResource Include="$(NuspecBasePath)\**\*.resx" Exclude="$(BaseOutputPath);$(BaseIntermediateOutputPath);">
       <Pack>true</Pack>
       <PackagePath>$(ContentTargetFolders)\any\any\</PackagePath>
     </EmbeddedResource>
@@ -41,4 +50,6 @@
     <PackageReference Remove="@(PackageReference)" />
   </ItemGroup>
 
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(NuspecBasePath), Directory.Build.targets))\Directory.Build.targets" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(NuspecBasePath), Directory.Build.targets))\Directory.Build.targets')" />
+  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 </Project>


### PR DESCRIPTION
The shared sources packaging targets was writing files into the korebuild installation folder instead of the project folder. This fixes this by changing the obj and bin folders for the shared sources project to be in the project folder instead.

It also ensures that the same behavior of Directory.Build.props and Directory.Build.targets will be preserved when switching from old KoreBuild to compiled KoreBuild.