### PR TITLE
Add runtime store verifier

### DIFF
--- a/BuildTools.sln
+++ b/BuildTools.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26703.0
+VisualStudioVersion = 15.0.26711.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{A4F4353B-C3D2-40B0-909A-5B48A748EA76}"
 EndProject
@@ -49,7 +49,14 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{76ABA507
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RepoTasks", "build\tasks\RepoTasks.csproj", "{F3CAD1F9-68DB-49EA-88A7-573AE7FFE047}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGet.Tasks", "src\NuGet.Tasks\NuGet.Tasks.csproj", "{020ED083-4076-4711-A52B-2F89EA884F9B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NuGet.Tasks", "src\NuGet.Tasks\NuGet.Tasks.csproj", "{020ED083-4076-4711-A52B-2F89EA884F9B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RuntimeStoreVerifier", "src\RuntimeStoreVerifier\RuntimeStoreVerifier.csproj", "{1B5856CC-E597-4E97-9C95-DEAC80CE724A}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "WinTrust.Sources", "WinTrust.Sources", "{B99861A9-F594-4FCF-A09F-9730A3FF9436}"
+	ProjectSection(SolutionItems) = preProject
+		src\WinTrust.Sources\WinTrust.cs = src\WinTrust.Sources\WinTrust.cs
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -123,6 +130,10 @@ Global
 		{020ED083-4076-4711-A52B-2F89EA884F9B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{020ED083-4076-4711-A52B-2F89EA884F9B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{020ED083-4076-4711-A52B-2F89EA884F9B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1B5856CC-E597-4E97-9C95-DEAC80CE724A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1B5856CC-E597-4E97-9C95-DEAC80CE724A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1B5856CC-E597-4E97-9C95-DEAC80CE724A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1B5856CC-E597-4E97-9C95-DEAC80CE724A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -145,6 +156,8 @@ Global
 		{D5D1BD88-1781-4448-89DD-3E62C95D3A77} = {60A938B2-D95A-403C-AA7A-3683AD64DFA0}
 		{F3CAD1F9-68DB-49EA-88A7-573AE7FFE047} = {76ABA507-B453-43BA-BA98-FA3FDDC6DD39}
 		{020ED083-4076-4711-A52B-2F89EA884F9B} = {A4F4353B-C3D2-40B0-909A-5B48A748EA76}
+		{1B5856CC-E597-4E97-9C95-DEAC80CE724A} = {A4F4353B-C3D2-40B0-909A-5B48A748EA76}
+		{B99861A9-F594-4FCF-A09F-9730A3FF9436} = {A4F4353B-C3D2-40B0-909A-5B48A748EA76}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {1B8809C8-A6C3-4761-BC91-B12841F49AE1}

--- a/src/NuGetPackageVerifier/NuGetPackageVerifier.csproj
+++ b/src/NuGetPackageVerifier/NuGetPackageVerifier.csproj
@@ -10,6 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\WinTrust.Sources\**\*.cs" />
     <EmbeddedResource Include="already-owned-packages.txt" />
     <EmbeddedResource Include="third-party.json" />
     <Content Include="build\*.targets">

--- a/src/NuGetPackageVerifier/Rules/AuthenticodeSigningRule.cs
+++ b/src/NuGetPackageVerifier/Rules/AuthenticodeSigningRule.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
 using NuGetPackageVerifier.Logging;
+using WinTrustSources;
 
 namespace NuGetPackageVerifier.Rules
 {

--- a/src/RuntimeStoreVerifier/Program.cs
+++ b/src/RuntimeStoreVerifier/Program.cs
@@ -1,0 +1,26 @@
+using Microsoft.Extensions.CommandLineUtils;
+
+namespace RuntimeStoreVerifier
+{
+    class Program
+    {
+        static int Main(string[] args)
+        {
+            var app = new CommandLineApplication();
+
+            var exclusionFileOption = app.Option("-e|--exclusion-file", "Path to the exclusions file for the runtime store verifier.", CommandOptionType.SingleValue);
+            var verboseOption = app.Option("-v|--verbose", "Enable verbose output and log all files checked. By default only unsigned binaries are logged.", CommandOptionType.NoValue);
+
+            var pathArgument = app.Argument("directory", "Directory containing the unzipped runtime stores.");
+
+            app.HelpOption("-h|--help");
+
+            app.OnExecute(() =>
+            {
+                return RuntimeStoreVerifierCommand.Execute(exclusionFileOption, verboseOption, pathArgument);
+            });
+
+            return app.Execute(args);
+        }
+    }
+}

--- a/src/RuntimeStoreVerifier/RuntimeStoreVerifier.csproj
+++ b/src/RuntimeStoreVerifier/RuntimeStoreVerifier.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="..\..\build\common.props" />
+
+  <PropertyGroup>
+    <Description>Verifies ASP.NET Core runtime store.</Description>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <AssemblyName>RuntimeStoreVerifier</AssemblyName>
+    <OutputType>exe</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\WinTrust.Sources\**\*.cs" />
+    <PackageReference Include="Microsoft.Extensions.CommandLineUtils.Sources" Version="$(AspNetCoreVersion)" />
+  </ItemGroup>
+
+  <!-- packaging settings -->
+  <PropertyGroup>
+    <NoPackageAnalysis>true</NoPackageAnalysis>
+    <NuspecFile>$(MSBuildThisFileDirectory)$(MSBuildProjectName).nuspec</NuspecFile>
+  </PropertyGroup>
+
+  <Target Name="SetPackageDependencies" BeforeTargets="GenerateNuspec" DependsOnTargets="Publish">
+    <PropertyGroup>
+      <NuspecProperties>version=$(PackageVersion);publishdir=$(PublishDir)</NuspecProperties>
+    </PropertyGroup>
+  </Target>
+
+</Project>

--- a/src/RuntimeStoreVerifier/RuntimeStoreVerifier.nuspec
+++ b/src/RuntimeStoreVerifier/RuntimeStoreVerifier.nuspec
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<package>
+  <metadata>
+    <id>RuntimeStoreVerifier</id>
+    <version>$version$</version>
+    <authors>Microsoft</authors>
+    <description>Verifies ASP.NET Core runtime store.</description>
+  </metadata>
+  <files>
+    <file src="$publishdir$" target="/" />
+  </files>
+</package>

--- a/src/RuntimeStoreVerifier/RuntimeStoreVerifierCommand.cs
+++ b/src/RuntimeStoreVerifier/RuntimeStoreVerifierCommand.cs
@@ -50,6 +50,7 @@ namespace RuntimeStoreVerifier
                 return 1;
             }
 
+            Console.WriteLine("All binaries are signed.");
             return 0;
         }
 

--- a/src/RuntimeStoreVerifier/RuntimeStoreVerifierCommand.cs
+++ b/src/RuntimeStoreVerifier/RuntimeStoreVerifierCommand.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.RegularExpressions;
+using Microsoft.Extensions.CommandLineUtils;
+using WinTrustSources;
+
+namespace RuntimeStoreVerifier
+{
+    public class RuntimeStoreVerifierCommand
+    {
+        internal static int Execute(
+            CommandOption exclusionFileOption,
+            CommandOption verboseOption,
+            CommandArgument pathArgument)
+        {
+            var exclusions = exclusionFileOption.HasValue() ? File.ReadAllLines(exclusionFileOption.Value()) : null;
+            var unsignedBinaries = new List<string>();
+
+            foreach (var binary in Directory.GetFiles(pathArgument.Value, "*.dll", SearchOption.AllDirectories))
+            {
+                if (!WinTrust.IsAuthenticodeSigned(binary))
+                {
+                    if (BinaryIsExcluded(binary, exclusions))
+                    {
+                        if (verboseOption.HasValue())
+                        {
+                            Console.WriteLine($"{binary} is not authenticode signed but is explicitly excluded");
+                        }
+                    }
+                    else
+                    {
+                        unsignedBinaries.Add(binary);
+                    }
+                }
+                else if (verboseOption.HasValue())
+                {
+                    Console.WriteLine($"{binary} is authenticode signed");
+                }
+            }
+
+            if (unsignedBinaries.Count > 0)
+            {
+                Console.WriteLine("One or more binaries are unsigned:");
+                foreach (var binary in unsignedBinaries)
+                {
+                    Console.WriteLine(binary);
+                }
+
+                return 1;
+            }
+
+            return 0;
+        }
+
+        internal static bool BinaryIsExcluded(string binary, IEnumerable<string> exclusions)
+        {
+            foreach (var exclusion in exclusions)
+            {
+                if (Regex.Match(new FileInfo(binary).Name, exclusion, RegexOptions.CultureInvariant | RegexOptions.IgnoreCase, TimeSpan.FromSeconds(30)).Success)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/WinTrust.Sources/WinTrust.cs
+++ b/src/WinTrust.Sources/WinTrust.cs
@@ -1,11 +1,11 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.IO;
 using System.Runtime.InteropServices;
 
-namespace NuGetPackageVerifier
+namespace WinTrustSources
 {
     // See http://msdn.microsoft.com/en-us/library/aa388205(v=VS.85).aspx
     public class WinTrust


### PR DESCRIPTION
Addresses https://github.com/aspnet/Coherence-Signed/issues/443 and verifies all managed binaries in the store are signed.

For 2.0.0 I propose we create a standalone tool called RuntimeStoreVerifier to reduce the size of the change. I would like to consolidate the functionality with the NugetPackageVerifier and rename it to PackageVerifier post 2.0 to simplify usage. Since this is planned to be consolidated, I didn't create corresponding MSBuild tasks for this tool.