### PR TITLE
Fix ThirdPartyVersionsRule version check

### DIFF
--- a/src/NuGetPackageVerifier/Rules/ThirdPartyPackageVersionsRule.cs
+++ b/src/NuGetPackageVerifier/Rules/ThirdPartyPackageVersionsRule.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -55,7 +55,15 @@ namespace NuGetPackageVerifier.Rules
             foreach (var expectedVersion in expectedVersions)
             {
                 var expectedSemVersion = VersionRange.Parse(expectedVersion);
-                if (packageVersion.IsSubSetOrEqualTo(expectedSemVersion))
+                if (expectedSemVersion.IsFloating)
+                {
+                    if (expectedSemVersion.Float.Satisfies(packageVersion.MinVersion) &&
+                        expectedSemVersion.MaxVersion == packageVersion.MaxVersion)
+                    {
+                        return null;
+                    }
+                }
+                else if (packageVersion.Equals(expectedSemVersion))
                 {
                     return null;
                 }

--- a/src/NuGetPackageVerifier/third-party.json
+++ b/src/NuGetPackageVerifier/third-party.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "prefixInclusionList": [
     "Libuv",
     "Microsoft.AspNetCore",
@@ -23,20 +23,20 @@
     "Microsoft.Azure.KeyVault": [ "2.3.2" ],
     "Microsoft.Build.Runtime": [ "15.3.406" ],
     "Microsoft.Build.Tasks.Core": [ "15.3.406" ],
-    "Microsoft.CSharp": [ "4.3.0" ],
+    "Microsoft.CSharp": [ "4.4.0-*" ],
     "Microsoft.DotNet.InternalAbstractions": [ "1.0.0" ],
-    "Microsoft.IdentityModel.Clients.ActiveDirectory": [ "3.14.0" ],
-    "Microsoft.IdentityModel.Protocols.OpenIdConnect": [ "2.1.3" ],
+    "Microsoft.IdentityModel.Clients.ActiveDirectory": [ "3.14.1" ],
+    "Microsoft.IdentityModel.Protocols.OpenIdConnect": [ "2.1.4" ],
     "Microsoft.NETCore.Windows.ApiSets": [ "1.0.1" ],
     "Microsoft.Owin.Security": [ "3.0.1" ],
     "Microsoft.Owin.Security.Cookies": [ "3.0.1" ],
     "Microsoft.Web.Administration": [ "7.0.0" ],
     "Microsoft.Web.Xdt": [ "1.4.0" ],
-    "Microsoft.Win32.Registry": [ "4.3.0" ],
+    "Microsoft.Win32.Registry": [ "4.4.0-*" ],
     "MsgPack.Cli": ["0.9.0-beta2"],
     "Newtonsoft.Json": [ "10.0.1" ],
     "Newtonsoft.Json.Bson": [ "1.0.1" ],
-    "NuGet.Frameworks": [ "3.5.0" ],
+    "NuGet.Frameworks": [ "4.0.0" ],
     "Remotion.Linq": [ "2.1.1" ],
     "Serilog.Extensions.Logging": [ "1.4.0" ],
     "Serilog.Sinks.File": [ "3.2.0" ],
@@ -50,9 +50,9 @@
     "StackExchange.Redis.StrongName": [ "1.2.4" ],
     "StreamJsonRpc": [ "1.1.92" ],
     "WindowsAzure.Storage": [ "8.1.4" ],
-    "xunit": [ "2.2.0" ],
+    "xunit": [ "2.3.0-*" ],
     "xunit.abstractions": [ "2.0.1" ],
-    "xunit.assert": [ "2.2.0" ],
-    "xunit.extensibility.core": [ "2.2.0" ]
+    "xunit.assert": [ "2.3.0-*" ],
+    "xunit.extensibility.core": [ "2.3.0-*" ]
   }
 }


### PR DESCRIPTION
#319 

@pakrym @Eilon @pranavkm 

I ran this on the latest packages on both 2.0.0 and dev and it passes.