### PR TITLE
Add Overwrite property to UnzipArchive

### DIFF
--- a/src/Internal.AspNetCore.BuildTools.Tasks/UnzipArchive.cs
+++ b/src/Internal.AspNetCore.BuildTools.Tasks/UnzipArchive.cs
@@ -36,6 +36,11 @@ namespace Microsoft.AspNetCore.BuildTools
         public string Destination { get; set; }
 
         /// <summary>
+        /// Overwrite <see cref="File"/> if it exists. Defaults to false.
+        /// </summary>
+        public bool Overwrite { get; set; } = false;
+
+        /// <summary>
         /// The files that were unzipped.
         /// </summary>
         [Output]
@@ -60,7 +65,7 @@ namespace Microsoft.AspNetCore.BuildTools
                     var fileDest = Path.Combine(Destination, entry.FullName);
                     var dirName = Path.GetDirectoryName(fileDest);
                     Directory.CreateDirectory(dirName);
-                    entry.ExtractToFile(fileDest);
+                    entry.ExtractToFile(fileDest, Overwrite);
                     Log.LogMessage(MessageImportance.Low, "Extracted '{0}'", fileDest);
                     output.Add(new TaskItem(fileDest));
                 }

--- a/test/BuildTools.Tasks.Tests/UnzipArchiveTest.cs
+++ b/test/BuildTools.Tasks.Tests/UnzipArchiveTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -40,7 +40,7 @@ namespace BuildTools.Tasks.Tests
                 BuildEngine = new MockEngine(),
             };
 
-            Assert.True(task.Execute(), "Task failed");
+            Assert.True(task.Execute(), "The task failed but should have passed.");
             Assert.True(Directory.Exists(outDir), outDir + " does not exist");
             Assert.Equal(files.Length, task.OutputFiles.Length);
 
@@ -52,6 +52,67 @@ namespace BuildTools.Tasks.Tests
                 var outFile = Path.Combine(outDir, file);
                 Assert.True(File.Exists(outFile), outFile + " does not exist");
             }
+        }
+
+        [Fact]
+        public void Overwrites()
+        {
+            var files = new[]
+            {
+                "a.txt",
+                "dir/b.txt"
+            };
+
+            var dest = CreateZip(files);
+            var outDir = Path.Combine(_tempDir, "out");
+
+            var task = new UnzipArchive
+            {
+                File = dest,
+                Destination = outDir,
+                BuildEngine = new MockEngine(),
+                Overwrite = true
+            };
+
+            Directory.CreateDirectory(outDir);
+
+            // Create a.txt before trying to unzip
+            var path = Path.Combine(outDir, "a.txt");
+            File.WriteAllText(path, "contents!");
+            Assert.True(task.Execute(), "The task failed but should have passed.");
+            Assert.Empty(File.ReadAllText(path));
+        }
+
+        [Fact]
+        public void DoesNotOverwrite()
+        {
+            var files = new[]
+            {
+                "a.txt",
+                "dir/b.txt"
+            };
+
+            var dest = CreateZip(files);
+            var outDir = Path.Combine(_tempDir, "out");
+
+            var task = new UnzipArchive
+            {
+                File = dest,
+                Destination = outDir,
+                BuildEngine = new MockEngine(),
+                Overwrite = false
+            };
+
+            Directory.CreateDirectory(outDir);
+
+            // Create a.txt before trying to unzip
+            var path = Path.Combine(outDir, "a.txt");
+            var contents = "contents!";
+            File.WriteAllText(path, contents);
+
+            Assert.Throws<IOException>(() => task.Execute());
+
+            Assert.Equal(contents, File.ReadAllText(path));
         }
 
         private string CreateZip(string[] files)


### PR DESCRIPTION
Currently if you try to extract a file over an existing file it failes with an IOException.