### PR TITLE
Make default dotnet dir consistent on Windows and Linux: ~/.dotnet

### DIFF
--- a/sdk/KoreBuild/KoreBuild.sh
+++ b/sdk/KoreBuild/KoreBuild.sh
@@ -22,20 +22,21 @@ install_tools() {
     local tools_home="$install_dir/buildtools"
     local netfx_version='4.6.1'
 
-    # Set environment variables
-    export ReferenceAssemblyRoot="$tools_home/netfx/$netfx_version"
-    export PATH="$install_dir:$PATH"
-
     verbose_flag=''
     [ "$verbose" = true ] && verbose_flag='--verbose'
 
+    # Instructs MSBuild where to find .NET Framework reference assemblies
+    export ReferenceAssemblyRoot="$tools_home/netfx/$netfx_version"
     chmod +x "$__korebuild_dir/scripts/get-netfx.sh"
     "$__korebuild_dir/scripts/get-netfx.sh" $verbose_flag $netfx_version "$tools_source" "$ReferenceAssemblyRoot" \
         || return 1
 
     chmod +x "$__korebuild_dir/scripts/get-dotnet.sh"
-    "$__korebuild_dir/scripts/get-dotnet.sh" $verbose_flag "$install_dir"
-    return $?
+    "$__korebuild_dir/scripts/get-dotnet.sh" $verbose_flag "$install_dir" \
+        || return 1
+
+    # Set environment variables
+    export PATH="$install_dir:$PATH"
 }
 
 __show_version_info() {

--- a/sdk/KoreBuild/scripts/KoreBuild.psm1
+++ b/sdk/KoreBuild/scripts/KoreBuild.psm1
@@ -126,11 +126,27 @@ function Install-Tools(
     }
 
     $DotNetHome = Resolve-Path $DotNetHome
-    $installDir = if ($IS_WINDOWS) { Join-Path $DotNetHome 'x64' } else { $DotNetHome }
+    $installDir = $DotNetHome
+    Write-Verbose "Installing tools to '$installDir'"
+    if ($env:DOTNET_INSTALL_DIR -and $env:DOTNET_INSTALL_DIR -ne $installDir) {
+        # DOTNET_INSTALL_DIR is used by dotnet-install.ps1 only, and some repos used it in their automation to isolate dotnet.
+        # DOTNET_HOME is used by the rest of our KoreBuild tools and is set by the bootstrappers.
+        Write-Verbose "installDir = $installDir"
+        Write-Verbose "DOTNET_INSTALL_DIR = ${env:DOTNET_INSTALL_DIR}"
+        Write-Warning 'It looks like a deprecated environment variable is set: $env:DOTNET_INSTALL_DIR. The recommended alternative is $env:DOTNET_HOME.'
+    }
+
     $global:dotnet = Join-Path $installDir "dotnet$EXE_EXT"
+
+    $dotnetOnPath = Get-Command dtnet -ErrorAction Ignore
+    if ($dotnetOnPath -and ($dotnetOnPath.Path -ne $global:dotnet)) {
+        Write-Warning "dotnet on PATH is '$($dotnetOnPath.Path)' but KoreBuild will use dotnet: '${global:dotnet}'"
+    }
+
     $pathPrefix = Split-Path -Parent $global:dotnet
     if ($env:PATH -notlike "${pathPrefix};*") {
         # only prepend if PATH doesn't already start with the location of dotnet
+        Write-Host "Adding $pathPrefix to PATH"
         $env:PATH = "$pathPrefix;$env:PATH"
     }
 
@@ -174,6 +190,7 @@ function Install-Tools(
 
     # Install the main CLI
     if (!(Test-Path (Join-Paths $installDir ('sdk', $version, 'dotnet.dll')))) {
+
         Write-Verbose "Installing dotnet $version to $installDir"
         & $scriptPath -Channel $channel `
             -Version $version `

--- a/sdk/KoreBuild/scripts/common.sh
+++ b/sdk/KoreBuild/scripts/common.sh
@@ -10,6 +10,7 @@ fi
 # colors
 GREEN="\033[1;32m"
 MAGENTA="\033[0;95m"
+YELLOW="\033[0;33m"
 CYAN="\033[0;36m"
 RESET="\033[0m"
 RED="\033[0;31m"
@@ -19,17 +20,21 @@ __is_verbose=false
 
 __verbose() {
     if [ "$__is_verbose" = true ]; then
-        echo -e "${GRAY}debug: $*${RESET}"
+        echo -e "${GRAY}debug  : $*${RESET}"
     fi
+}
+
+__warn() {
+    echo -e "${YELLOW}warning: $*${RESET}"
+}
+
+__error() {
+    echo -e "${RED}error  : $*${RESET}" 1>&2
 }
 
 __machine_has() {
     hash "$1" > /dev/null 2>&1
     return $?
-}
-
-__error() {
-    echo -e "${RED}$*${RESET}" 1>&2
 }
 
 __exec() {

--- a/sdk/KoreBuild/scripts/dotnet-install.ps1
+++ b/sdk/KoreBuild/scripts/dotnet-install.ps1
@@ -456,7 +456,6 @@ if ($IsSdkInstalled) {
 New-Item -ItemType Directory -Force -Path $InstallRoot | Out-Null
 
 $installDrive = $((Get-Item $InstallRoot).PSDrive.Name);
-Write-Output "${installDrive}:";
 $free = Get-CimInstance -Class win32_logicaldisk | where Deviceid -eq "${installDrive}:"
 if ($free.Freespace / 1MB -le 100 ) {
     Say "There is not enough disk space on drive ${installDrive}:"

--- a/sdk/KoreBuild/scripts/get-dotnet.sh
+++ b/sdk/KoreBuild/scripts/get-dotnet.sh
@@ -44,6 +44,18 @@ fi
 
 install_dir=$1
 
+if [ ! -z "${DOTNET_INSTALL_DIR:-}" ] && [ "${DOTNET_INSTALL_DIR:-}" != "$install_dir" ]; then
+    __verbose "install_dir = $install_dir"
+    __verbose "DOTNET_INSTALL_DIR = $DOTNET_INSTALL_DIR"
+    __warn 'It looks like a deprecated environment variable is set: $DOTNET_INSTALL_DIR. The recommended alternative is $DOTNET_HOME.'
+fi
+
+dotnet_in_path="$(which dotnet 2>/dev/null || true )"
+# The '-ef' condition tests if files are the same inode. This avoids showing the warning if users symlink dotnet into path
+if [ ! -z "$dotnet_in_path" ] && [ ! "$dotnet_in_path" -ef "$install_dir/dotnet" ]; then
+    __warn "dotnet on PATH is '$dotnet_in_path' but KoreBuild will use dotnet from '$install_dir/dotnet'."
+fi
+
 if [ ! -z "${KOREBUILD_SKIP_RUNTIME_INSTALL:-}" ]; then
      echo "Skipping runtime installation because KOREBUILD_SKIP_RUNTIME_INSTALL is set"
      exit 0
@@ -73,6 +85,7 @@ fi
 __verbose "Installing .NET Core SDK $version"
 
 if [ ! -f "$install_dir/sdk/$version/dotnet.dll" ]; then
+
     "$__script_dir/dotnet-install.sh" \
         --install-dir "$install_dir" \
         --architecture x64 \


### PR DESCRIPTION
On Windows, we used to install to ~/.dotnet/x64. We did this because we were anticipating a dotnet feature that got cut. 

To simplify build tools and scripts, let's remove <arch> from the default dotnet path on Windows.

Also, I added some warning messages when the shell environment may lead to issues in which dotnet is used.