### PR TITLE
Add support for /t:Noop

### DIFF
--- a/sdk/KoreBuild/modules/noop/module.targets
+++ b/sdk/KoreBuild/modules/noop/module.targets
@@ -1,0 +1,10 @@
+<!-- Don't do anything. Useful for scripts that need to initialize KoreBuild without building anything. -->
+<Project>
+
+  <Target Name="Noop" />
+
+  <Target Name="Cow" DependsOnTargets="Noop">
+    <Message Text="Moo!" Importance="High" />
+  </Target>
+
+</Project>

--- a/sdk/KoreBuild/modules/noop/module.targets
+++ b/sdk/KoreBuild/modules/noop/module.targets
@@ -4,7 +4,20 @@
   <Target Name="Noop" />
 
   <Target Name="Cow" DependsOnTargets="Noop">
-    <Message Text="Moo!" Importance="High" />
+    <PropertyGroup>
+      <CowSay>
+ ______
+( Moo! )
+ ------
+        \   ^__^
+         \  (oo)\_______
+            (__)\       )\/\
+                ||----w |
+                ||     ||
+      </CowSay>
+    </PropertyGroup>
+
+    <Message Text="$(CowSay)" Importance="High" />
   </Target>
 
 </Project>

--- a/sdk/KoreBuild/scripts/KoreBuild.psm1
+++ b/sdk/KoreBuild/scripts/KoreBuild.psm1
@@ -89,7 +89,15 @@ function Invoke-RepositoryBuild(
 
         $msBuildArguments | Out-File -Encoding ASCII -FilePath $msBuildResponseFile
 
-        __build_task_project $Path
+        $noop = ($MSBuildArgs -contains '/t:Noop' -or $MSBuildArgs -contains '/t:Cow')
+        Write-Verbose "Noop = $noop"
+        $firstTime = $env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE
+        if ($noop) {
+            $env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE = 'true'
+        }
+        else {
+            __build_task_project $Path
+        }
 
         Write-Verbose "Invoking msbuild with '$(Get-Content $msBuildResponseFile)'"
 
@@ -97,6 +105,7 @@ function Invoke-RepositoryBuild(
     }
     finally {
         Pop-Location
+        $env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE = $firstTime
     }
 }
 

--- a/sdk/KoreBuild/scripts/invoke-repository-build.sh
+++ b/sdk/KoreBuild/scripts/invoke-repository-build.sh
@@ -26,11 +26,16 @@ if [[ $# -gt 0 ]]; then
     shift
 fi
 
-msbuild_args=""
+noop=false
+msbuild_args=''
 while [[ $# -gt 0 ]]; do
     case $1 in
         --verbose)
             __is_verbose=true
+            ;;
+        /t:[Cc]ow|/t:[Nn]oop)
+            noop=true
+            msbuild_args+="\"$1\"\n"
             ;;
         *)
             msbuild_args+="\"$1\"\n"
@@ -84,7 +89,10 @@ __verbose "dotnet = $(which dotnet)"
 
 task_proj="$repo_path/build/tasks/RepoTasks.csproj"
 
-if [ -f "$task_proj" ]; then
+__verbose "Noop = $noop"
+if [ "${noop}" = true ]; then
+    export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true
+elif [ -f "$task_proj" ]; then
     sdk_path="/p:RepoTasksSdkPath=$__script_dir/../msbuild/KoreBuild.RepoTasks.Sdk/Sdk/"
     __exec dotnet restore "$task_proj" "$sdk_path"
     task_publish_dir="$repo_path/build/tasks/bin/publish/"


### PR DESCRIPTION
Per discussion we had last week.

This adds a /t:Noop target that will attempt to do as little as possible. This is useful when you want to update tools without invoking the full build, or even part of the build.