### PR TITLE
Implement version pinning from PackageLineup's

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ _ReSharper.*
 *.pidb
 *.vspx
 *.psess
+*.log
+*.binlog
 packages
 target
 artifacts

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -6,6 +6,7 @@
     <DotNetProjectModelVersion>1.0.0-rc3-1-003177</DotNetProjectModelVersion>
     <!-- This one is OK for console tools that bundle their own version of JSON.NET -->
     <JsonNetVersion>10.0.1</JsonNetVersion>
+    <MoqVersion>4.7.99</MoqVersion>
     <NetStandardPackageVersion>1.6.1</NetStandardPackageVersion>
     <NuGetPackagesVersion>4.0.0</NuGetPackagesVersion>
     <SystemCollectionsImmutableVersion>1.4.0-*</SystemCollectionsImmutableVersion>

--- a/files/KoreBuild/msbuild/KoreBuild.RepoTasks.Sdk/Sdk/Sdk.targets
+++ b/files/KoreBuild/msbuild/KoreBuild.RepoTasks.Sdk/Sdk/Sdk.targets
@@ -2,11 +2,11 @@
 
   <ItemGroup Condition="'$(DisableImplicitFrameworkReferences)' != 'true'">
     <!-- set as private assets all since we don't need this in the publish output folder -->
-    <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildVersion)" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildVersion)" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" IsImplicitlyDefined="true" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildVersion)" IsImplicitlyDefined="true" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildVersion)" IsImplicitlyDefined="true" PrivateAssets="All" />
     <!-- because almost everyone ends up using JSON in repo tasks -->
-    <PackageReference Include="Newtonsoft.Json" Version="$(JsonInMSBuildVersion)" PrivateAssets="All" />
+    <PackageReference Include="Newtonsoft.Json" Version="$(JsonInMSBuildVersion)" IsImplicitlyDefined="true" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/modules/NuGet.Tasks/ApplyNuGetPolicies.cs
+++ b/modules/NuGet.Tasks/ApplyNuGetPolicies.cs
@@ -1,0 +1,249 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Build.Framework;
+using Newtonsoft.Json;
+using NuGet.Tasks.Policies;
+using NuGet.Tasks.ProjectModel;
+using NuGet.Tasks.Utilties;
+
+namespace NuGet.Tasks
+{
+    /// <summary>
+    /// Applies policies to a repository on how NuGet can be used, such as restricting which PackageReference's are allowed,
+    /// which versions of packages can be used, which feeds are available, etc.
+    /// </summary>
+    public class ApplyNuGetPolicies : Microsoft.Build.Utilities.Task, ICancelableTask
+    {
+        private readonly CancellationTokenSource _cts;
+        private readonly MSBuildPolicyFactory _policyFactory;
+
+        public ApplyNuGetPolicies()
+        {
+            _policyFactory = new MSBuildPolicyFactory();
+            _cts = new CancellationTokenSource();
+        }
+
+        [Required]
+        public string SolutionDirectory { get; set; }
+
+        /// <summary>
+        /// The policies to be applied to the repository.
+        /// </summary>
+        [Required]
+        public ITaskItem[] Policies { get; set; }
+
+        /// <summary>
+        /// The MSBuild projects or solutions to which the policy should be applied.
+        /// </summary>
+        [Required]
+        public ITaskItem[] Projects { get; set; }
+
+        /// <summary>
+        /// Key-value base list of properties to be applied to <see cref="Projects" /> during project evaluation.
+        /// e.g. "Configuration=Debug;BuildNumber=1234"
+        /// </summary>
+        public string ProjectProperties { get; set; }
+
+        /// <summary>
+        /// NuGet sources, ; delimited. When set, they override sources from NuGet.config.
+        /// </summary>
+        public string RestoreSources { get; set; }
+
+        /// <summary>
+        /// NuGet sources, ; delimited.
+        /// When set they are in addition to source from NuGet.config and/or <see cref="RestoreSources"/>.
+        /// </summary>
+        public string RestoreAdditionalSources { get; set; }
+
+        /// <summary>
+        /// User packages folder
+        /// </summary>
+        public string RestorePackagesPath { get; set; }
+
+        /// <summary>
+        /// Disable parallel project restores and downloads
+        /// </summary>
+        public bool RestoreDisableParallel { get; set; }
+
+        /// <summary>
+        /// NuGet.Config path
+        /// </summary>
+        public string RestoreConfigFile { get; set; }
+
+        /// <summary>
+        /// Disable the web cache
+        /// </summary>
+        public bool RestoreNoCache { get; set; }
+
+        /// <summary>
+        /// Ignore errors from package sources
+        /// </summary>
+        public bool RestoreIgnoreFailedSources { get; set; }
+
+        public void Cancel()
+        {
+            _cts.Cancel();
+        }
+
+        public override bool Execute()
+        {
+            return ExecuteAsync().GetAwaiter().GetResult();
+        }
+
+        private async Task<bool> ExecuteAsync()
+        {
+            if (_cts.IsCancellationRequested)
+            {
+                return false;
+            }
+
+            var policies = CreatePolicies();
+            if (policies.Count == 0)
+            {
+                return !Log.HasLoggedErrors;
+            }
+
+            var projects = CreateProjectContext();
+
+            if (_cts.IsCancellationRequested)
+            {
+                return false;
+            }
+
+            var context = new PolicyContext
+            {
+                SolutionDirectory = SolutionDirectory,
+                Projects = projects,
+                Log = Log,
+                RestoreSources = MSBuildListSplitter.SplitItemList(RestoreSources).ToList(),
+                RestoreAdditionalSources = MSBuildListSplitter.SplitItemList(RestoreAdditionalSources).ToList(),
+                RestorePackagesPath = RestorePackagesPath,
+                RestoreDisableParallel = RestoreDisableParallel,
+                RestoreConfigFile = RestoreConfigFile,
+                RestoreNoCache = RestoreNoCache,
+                RestoreIgnoreFailedSources = RestoreIgnoreFailedSources,
+            };
+
+            foreach (var policy in policies)
+            {
+                if (_cts.IsCancellationRequested)
+                {
+                    return false;
+                }
+
+                try
+                {
+                    await policy.ApplyAsync(context, _cts.Token);
+                }
+                catch (Exception ex)
+                {
+                    Log.LogKoreBuildError(KoreBuildErrors.PolicyFailedToApply, $"Unexpected error when applying package policy: {policy.GetType().Name}." + Environment.NewLine, ex.ToString());
+                    return false;
+                }
+            }
+
+            var verifierProps = Path.Combine(
+                Path.GetDirectoryName(typeof(ApplyNuGetPolicies).Assembly.Location),
+                "Policy.VerifyImport.props");
+
+            if (_cts.IsCancellationRequested)
+            {
+                return false;
+            }
+
+            foreach (var project in context.Projects)
+            {
+                project.TargetsExtension.AddImport(verifierProps, required: false);
+                project.TargetsExtension.Save();
+            }
+
+            return !Log.HasLoggedErrors;
+        }
+
+        internal IList<INuGetPolicy> CreatePolicies()
+        {
+            var policies = new List<INuGetPolicy>();
+            foreach (var policyItems in Policies.GroupBy(g => g.GetMetadata("PolicyType") ?? string.Empty, StringComparer.OrdinalIgnoreCase))
+            {
+                var type = policyItems.Key;
+                var policy = _policyFactory.Create(type, policyItems);
+                if (policy == null)
+                {
+                    Log.LogKoreBuildError(KoreBuildErrors.UnknownPolicyType, $"Unrecognized package policy type: '{policyItems.Key}'");
+                    Cancel();
+                    continue;
+                }
+
+                policies.Add(policy);
+            }
+
+            return policies;
+        }
+
+        internal IReadOnlyList<ProjectInfo> CreateProjectContext()
+        {
+            var solutionProps = MSBuildListSplitter.GetNamedProperties(ProjectProperties);
+            var projectFiles = Projects.SelectMany(p => GetFilePaths(p, solutionProps)).Distinct();
+            var projects = new ConcurrentBag<ProjectInfo>();
+            var stop = Stopwatch.StartNew();
+
+            Parallel.ForEach(projectFiles, projectFile =>
+            {
+                if (_cts.IsCancellationRequested)
+                {
+                    return;
+                }
+
+                try
+                {
+                    projects.Add(ProjectInfoFactory.Create(projectFile));
+                }
+                catch (Exception ex)
+                {
+                    Log.LogErrorFromException(ex);
+                    Cancel();
+                }
+            });
+
+            stop.Stop();
+            Log.LogMessage(MessageImportance.Low, $"Finished design-time build in {stop.ElapsedMilliseconds}ms");
+            return projects.ToArray();
+        }
+
+        private IEnumerable<string> GetFilePaths(ITaskItem projectOrSolution, IDictionary<string, string> solutionProperties)
+        {
+            var projectFilePath = projectOrSolution.ItemSpec.Replace('\\', '/');
+
+            if (Path.GetExtension(projectFilePath).Equals(".sln", StringComparison.OrdinalIgnoreCase))
+            {
+                // prefer the AdditionalProperties metadata as this is what the MSBuild task will use when building solutions
+                var props = MSBuildListSplitter.GetNamedProperties(projectOrSolution.GetMetadata("AdditionalProperties"));
+                props.TryGetValue("Configuration", out var config);
+
+                if (config == null)
+                {
+                    solutionProperties.TryGetValue("Configuration", out config);
+                }
+
+                var sln = SolutionInfoFactory.Create(projectFilePath, config);
+                foreach (var project in sln.Projects)
+                {
+                    yield return project;
+                }
+            }
+            else
+            {
+                yield return Path.GetFullPath(projectFilePath);
+            }
+        }
+    }
+}

--- a/modules/NuGet.Tasks/Internal/KoreBuildErrors.cs
+++ b/modules/NuGet.Tasks/Internal/KoreBuildErrors.cs
@@ -6,5 +6,14 @@ namespace NuGet.Tasks
     public static class KoreBuildErrors
     {
         public const int InvalidNuspecFile = 4001;
+
+        // see Policy.NoVersions.targets
+        public const int PackageReferenceHasVersion = 4002;
+        public const int DotNetCliReferenceReferenceHasVersion = 4003;
+
+        public const int PackageVersionNotFoundInLineup = 4004;
+
+        public const int PolicyFailedToApply = 5000;
+        public const int UnknownPolicyType = 5001;
     }
 }

--- a/modules/NuGet.Tasks/Internal/MSBuildLogger.cs
+++ b/modules/NuGet.Tasks/Internal/MSBuildLogger.cs
@@ -1,0 +1,200 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using NuGet.Common;
+
+namespace NuGet.Build
+{
+    /// <summary>
+    /// TaskLoggingHelper -> ILogger
+    /// </summary>
+    internal class MSBuildLogger : LoggerBase, Common.ILogger
+    {
+        private readonly TaskLoggingHelper _taskLogging;
+
+        private delegate void LogMessageWithDetails(string subcategory,
+            string code,
+            string helpKeyword,
+            string file,
+            int lineNumber,
+            int columnNumber,
+            int endLineNumber,
+            int endColumnNumber,
+            MessageImportance importance,
+            string message,
+            params object[] messageArgs);
+
+        private delegate void LogErrorWithDetails(string subcategory,
+            string code,
+            string helpKeyword,
+            string file,
+            int lineNumber,
+            int columnNumber,
+            int endLineNumber,
+            int endColumnNumber,
+            string message,
+            params object[] messageArgs);
+
+        private delegate void LogMessageAsString(MessageImportance importance,
+            string message,
+            params object[] messageArgs);
+
+        private delegate void LogErrorAsString(string message,
+            params object[] messageArgs);
+
+        public MSBuildLogger(TaskLoggingHelper taskLogging)
+        {
+            _taskLogging = taskLogging ?? throw new ArgumentNullException(nameof(taskLogging));
+        }
+
+        public override void Log(ILogMessage message)
+        {
+            if (DisplayMessage(message.Level))
+            {
+                if (RuntimeEnvironmentHelper.IsMono)
+                {
+                    LogForMono(message);
+                    return;
+                }
+                else
+                {
+                    var logMessage = message as IRestoreLogMessage;
+
+                    if (logMessage == null)
+                    {
+                        logMessage = new RestoreLogMessage(message.Level, message.Message)
+                        {
+                            Code = message.Code,
+                            FilePath = message.ProjectPath
+                        };
+                    }
+                    LogForNonMono(logMessage);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Log using with metadata for non mono platforms.
+        /// </summary>
+        private void LogForNonMono(IRestoreLogMessage message)
+        {
+            switch (message.Level)
+            {
+                case LogLevel.Error:
+                    LogError(message, _taskLogging.LogError, _taskLogging.LogError);
+                    break;
+
+                case LogLevel.Warning:
+                    LogError(message, _taskLogging.LogWarning, _taskLogging.LogWarning);
+                    break;
+
+                case LogLevel.Minimal:
+                    LogMessage(message, MessageImportance.High, _taskLogging.LogMessage, _taskLogging.LogMessage);
+                    break;
+
+                case LogLevel.Information:
+                    LogMessage(message, MessageImportance.Normal, _taskLogging.LogMessage, _taskLogging.LogMessage);
+                    break;
+
+                case LogLevel.Debug:
+                case LogLevel.Verbose:
+                default:
+                    // Default to LogLevel.Debug and low importance
+                    LogMessage(message, MessageImportance.Low, _taskLogging.LogMessage, _taskLogging.LogMessage);
+                    break;
+            }
+        }
+
+        /// <summary>
+        /// Log using basic methods to avoid missing methods on mono.
+        /// </summary>
+        private void LogForMono(ILogMessage message)
+        {
+            switch (message.Level)
+            {
+                case LogLevel.Error:
+                    _taskLogging.LogError(message.Message);
+                    break;
+
+                case LogLevel.Warning:
+                    _taskLogging.LogWarning(message.Message);
+                    break;
+
+                case LogLevel.Minimal:
+                    _taskLogging.LogMessage(MessageImportance.High, message.Message);
+                    break;
+
+                case LogLevel.Information:
+                    _taskLogging.LogMessage(MessageImportance.Normal, message.Message);
+                    break;
+
+                case LogLevel.Debug:
+                case LogLevel.Verbose:
+                default:
+                    // Default to LogLevel.Debug and low importance
+                    _taskLogging.LogMessage(MessageImportance.Low, message.Message);
+                    break;
+            }
+
+            return;
+        }
+
+        private void LogMessage(IRestoreLogMessage logMessage,
+            MessageImportance importance,
+            LogMessageWithDetails logWithDetails,
+            LogMessageAsString logAsString)
+        {
+            if (logMessage.Code > NuGetLogCode.Undefined)
+            {
+                // NuGet does not currently have a subcategory while throwing logs, hence string.Empty
+                logWithDetails(string.Empty,
+                    Enum.GetName(typeof(NuGetLogCode), logMessage.Code),
+                    Enum.GetName(typeof(NuGetLogCode), logMessage.Code),
+                    logMessage.FilePath,
+                    logMessage.StartLineNumber,
+                    logMessage.StartColumnNumber,
+                    logMessage.EndLineNumber,
+                    logMessage.EndColumnNumber,
+                    importance,
+                    logMessage.Message);
+            }
+            else
+            {
+                logAsString(importance, logMessage.Message);
+            }
+        }
+
+        private void LogError(IRestoreLogMessage logMessage,
+            LogErrorWithDetails logWithDetails,
+            LogErrorAsString logAsString)
+        {
+            if (logMessage.Code > NuGetLogCode.Undefined)
+            {
+                // NuGet does not currently have a subcategory while throwing logs, hence string.Empty
+                logWithDetails(string.Empty,
+                    Enum.GetName(typeof(NuGetLogCode), logMessage.Code),
+                    Enum.GetName(typeof(NuGetLogCode), logMessage.Code),
+                    logMessage.FilePath,
+                    logMessage.StartLineNumber,
+                    logMessage.StartColumnNumber,
+                    logMessage.EndLineNumber,
+                    logMessage.EndColumnNumber,
+                    logMessage.Message);
+            }
+            else
+            {
+                logAsString(logMessage.Message);
+            }
+        }
+
+        public override System.Threading.Tasks.Task LogAsync(ILogMessage message)
+        {
+            Log(message);
+
+            return System.Threading.Tasks.Task.FromResult(0);
+        }
+    }
+}

--- a/modules/NuGet.Tasks/Internal/MSBuildProjectBuilder.cs
+++ b/modules/NuGet.Tasks/Internal/MSBuildProjectBuilder.cs
@@ -1,0 +1,83 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Xml.Linq;
+
+namespace NuGet.Tasks
+{
+    internal class MSBuildProjectBuilder
+    {
+        private readonly XDocument _document;
+
+        public MSBuildProjectBuilder(string path)
+        {
+            if (!System.IO.Path.IsPathRooted(path))
+            {
+                throw new ArgumentException(nameof(path));
+            }
+
+            Path = path;
+            _document = new XDocument();
+            Project = new XElement("Project");
+            _document.Add(Project);
+        }
+
+        public string Path { get; }
+
+        public XElement Project { get; }
+
+        public void Save()
+        {
+            Directory.CreateDirectory(System.IO.Path.GetDirectoryName(Path));
+            _document.Save(Path);
+        }
+
+        public XElement AddPropertyGroup()
+        {
+            var propertyGroup = new XElement("PropertyGroup");
+            Project.Add(propertyGroup);
+            return propertyGroup;
+        }
+
+        public XElement AddPropertyGroup(string name, string value)
+        {
+            var propertyGroup = AddPropertyGroup();
+            propertyGroup.Add(new XElement(name, value));
+            return propertyGroup;
+        }
+
+        public XElement AddImport(string path, bool required)
+        {
+            var import = new XElement("Import", new XAttribute("Project", path));
+            if (!required)
+            {
+                import.Add(new XAttribute("Condition", $"Exists('{path}')"));
+            }
+
+            Project.Add(import);
+            return import;
+        }
+
+        public XElement AddItemGroup()
+        {
+            var itemGroup = new XElement("ItemGroup");
+            Project.Add(itemGroup);
+            return itemGroup;
+        }
+
+        public XElement AddItemGroup(string condition)
+        {
+            var itemGroup = AddItemGroup();
+            itemGroup.Add(new XAttribute("Condition", condition));
+            return itemGroup;
+        }
+
+        public void AddToAllProjectsList()
+        {
+            AddPropertyGroup("MSBuildAllProjects",
+                "$(MSBuildAllProjects);$(MSBuildThisFileFullPath)");
+        }
+    }
+}

--- a/modules/NuGet.Tasks/Internal/ProjectModel/DotNetCliReferenceInfo.cs
+++ b/modules/NuGet.Tasks/Internal/ProjectModel/DotNetCliReferenceInfo.cs
@@ -1,0 +1,24 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace NuGet.Tasks.ProjectModel
+{
+    internal class DotNetCliReferenceInfo
+    {
+        public DotNetCliReferenceInfo(string id, string version)
+        {
+            if (string.IsNullOrEmpty(id))
+            {
+                throw new ArgumentException(nameof(id));
+            }
+
+            Id = id;
+            Version = version;
+        }
+
+        public string Id { get; }
+        public string Version { get; }
+    }
+}

--- a/modules/NuGet.Tasks/Internal/ProjectModel/PackageReferenceInfo.cs
+++ b/modules/NuGet.Tasks/Internal/ProjectModel/PackageReferenceInfo.cs
@@ -1,0 +1,28 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace NuGet.Tasks.ProjectModel
+{
+    internal class PackageReferenceInfo
+    {
+        public PackageReferenceInfo(string id, string version, bool isImplicitlyDefined, bool noWarn)
+        {
+            if (string.IsNullOrEmpty(id))
+            {
+                throw new ArgumentException(nameof(id));
+            }
+
+            Id = id;
+            Version = version;
+            IsImplicitlyDefined = isImplicitlyDefined;
+            NoWarn = noWarn;
+        }
+
+        public string Id { get; }
+        public string Version { get; }
+        public bool IsImplicitlyDefined { get; }
+        public bool NoWarn { get; }
+    }
+}

--- a/modules/NuGet.Tasks/Internal/ProjectModel/ProjectFrameworkInfo.cs
+++ b/modules/NuGet.Tasks/Internal/ProjectModel/ProjectFrameworkInfo.cs
@@ -1,0 +1,21 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using NuGet.Frameworks;
+
+namespace NuGet.Tasks.ProjectModel
+{
+    internal class ProjectFrameworkInfo
+    {
+        public ProjectFrameworkInfo(NuGetFramework targetFramework, IReadOnlyList<PackageReferenceInfo> dependencies)
+        {
+            TargetFramework = targetFramework ?? throw new ArgumentNullException(nameof(targetFramework));
+            Dependencies = dependencies ?? throw new ArgumentNullException(nameof(dependencies));
+        }
+
+        public NuGetFramework TargetFramework { get; }
+        public IReadOnlyList<PackageReferenceInfo> Dependencies { get; }
+    }
+}

--- a/modules/NuGet.Tasks/Internal/ProjectModel/ProjectInfo.cs
+++ b/modules/NuGet.Tasks/Internal/ProjectModel/ProjectInfo.cs
@@ -1,0 +1,44 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace NuGet.Tasks.ProjectModel
+{
+    internal class ProjectInfo
+    {
+        public ProjectInfo(string fullPath,
+            string projectExtensionsPath,
+            IReadOnlyList<ProjectFrameworkInfo> frameworks,
+            IReadOnlyList<DotNetCliReferenceInfo> tools)
+        {
+            if (!Path.IsPathRooted(fullPath))
+            {
+                throw new ArgumentException("Path must be absolute", nameof(fullPath));
+            }
+
+            Frameworks = frameworks ?? throw new ArgumentNullException(nameof(frameworks));
+            Tools = tools ?? throw new ArgumentNullException(nameof(tools));
+
+            FullPath = fullPath;
+            FileName = Path.GetFileName(fullPath);
+            Directory = Path.GetDirectoryName(FullPath);
+            ProjectExtensionsPath = projectExtensionsPath ?? Path.Combine(Directory, "obj");
+
+            const string extension = ".nugetpolicy.g.targets";
+            TargetsExtension = new MSBuildProjectBuilder(Path.Combine(ProjectExtensionsPath, FileName + extension));
+        }
+
+        public string FullPath { get; }
+        public string FileName { get; }
+        public string ProjectExtensionsPath { get; }
+        public string Directory { get; }
+
+        public IReadOnlyList<ProjectFrameworkInfo> Frameworks { get; }
+        public IReadOnlyList<DotNetCliReferenceInfo> Tools { get; }
+
+        public MSBuildProjectBuilder TargetsExtension { get; }
+    }
+}

--- a/modules/NuGet.Tasks/Internal/ProjectModel/ProjectInfoFactory.cs
+++ b/modules/NuGet.Tasks/Internal/ProjectModel/ProjectInfoFactory.cs
@@ -1,0 +1,83 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.Build.Construction;
+using Microsoft.Build.Evaluation;
+using Microsoft.Build.Execution;
+using NuGet.Frameworks;
+
+namespace NuGet.Tasks.ProjectModel
+{
+    internal class ProjectInfoFactory
+    {
+        public static ProjectInfo Create(string path)
+        {
+            var xml = ProjectRootElement.Open(path, ProjectCollection.GlobalProjectCollection);
+            var globalProps = new Dictionary<string, string>()
+            {
+                ["DesignTimeBuild"] = "true",
+                ["PolicyDesignTimeBuild"] = "true",
+            };
+
+            var project = new Project(xml, globalProps, toolsVersion: null, projectCollection: ProjectCollection.GlobalProjectCollection)
+            {
+                IsBuildEnabled = false
+            };
+            var instance = project.CreateProjectInstance(ProjectInstanceSettings.ImmutableWithFastItemLookup);
+            var projExtPath = instance.GetPropertyValue("MSBuildProjectExtensionsPath");
+
+            var targetFrameworks = instance.GetPropertyValue("TargetFrameworks");
+            var targetFramework = instance.GetPropertyValue("TargetFramework");
+
+            var frameworks = new List<ProjectFrameworkInfo>();
+            if (!string.IsNullOrEmpty(targetFrameworks) && string.IsNullOrEmpty(targetFramework))
+            {
+                // multi targeting
+                foreach (var tfm in targetFrameworks.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries))
+                {
+                    project.SetGlobalProperty("TargetFramework", tfm);
+                    var innerBuild = project.CreateProjectInstance(ProjectInstanceSettings.ImmutableWithFastItemLookup);
+
+                    var tfmInfo = new ProjectFrameworkInfo(NuGetFramework.Parse(tfm), GetDependencies(innerBuild).ToArray());
+
+                    frameworks.Add(tfmInfo);
+                }
+
+                project.RemoveGlobalProperty("TargetFramework");
+            }
+            else if (!string.IsNullOrEmpty(targetFramework))
+            {
+                var tfmInfo = new ProjectFrameworkInfo(NuGetFramework.Parse(targetFramework), GetDependencies(instance).ToArray());
+
+                frameworks.Add(tfmInfo);
+            }
+
+            var projectDir = Path.GetDirectoryName(path);
+
+            var tools = GetTools(instance).ToArray();
+
+            return new ProjectInfo(path, projExtPath, frameworks, tools);
+        }
+
+        private static IEnumerable<PackageReferenceInfo> GetDependencies(ProjectInstance project)
+        {
+            return project.GetItems("PackageReference").Select(item =>
+            {
+                bool.TryParse(item.GetMetadataValue("IsImplicitlyDefined"), out var isImplicit);
+                bool.TryParse(item.GetMetadataValue("NoWarn"), out var noWarn);
+
+                return new PackageReferenceInfo(item.EvaluatedInclude, item.GetMetadataValue("Version"), isImplicit, noWarn);
+            });
+        }
+
+        private static IEnumerable<DotNetCliReferenceInfo> GetTools(ProjectInstance project)
+        {
+            return project.GetItems("DotNetCliToolReference").Select(item =>
+                new DotNetCliReferenceInfo(item.EvaluatedInclude, item.GetMetadataValue("Version")));
+        }
+    }
+}

--- a/modules/NuGet.Tasks/Internal/ProjectModel/SolutionInfo.cs
+++ b/modules/NuGet.Tasks/Internal/ProjectModel/SolutionInfo.cs
@@ -1,0 +1,26 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace NuGet.Tasks.ProjectModel
+{
+    internal class SolutionInfo
+    {
+        public SolutionInfo(string fullPath, IReadOnlyList<string> projects)
+        {
+            if (string.IsNullOrEmpty(fullPath))
+            {
+                throw new ArgumentException(nameof(fullPath));
+            }
+
+            FullPath = fullPath;
+            Projects = projects ?? throw new ArgumentNullException(nameof(projects));
+        }
+
+        public string FullPath { get; }
+
+        public IReadOnlyList<string> Projects { get; }
+    }
+}

--- a/modules/NuGet.Tasks/Internal/ProjectModel/SolutionInfoFactory.cs
+++ b/modules/NuGet.Tasks/Internal/ProjectModel/SolutionInfoFactory.cs
@@ -1,0 +1,41 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Build.Construction;
+
+namespace NuGet.Tasks.ProjectModel
+{
+    internal class SolutionInfoFactory
+    {
+        public static SolutionInfo Create(string filePath, string configName)
+        {
+            var sln = SolutionFile.Parse(filePath);
+
+            if (string.IsNullOrEmpty(configName))
+            {
+                configName = sln.GetDefaultConfigurationName();
+            }
+
+            var projects = new List<string>();
+
+            var config = sln.SolutionConfigurations.FirstOrDefault(c => c.ConfigurationName == configName);
+            if (config == null)
+            {
+                throw new InvalidOperationException($"A solution configuration by the name of '{configName}' was not found in '{filePath}'");
+            }
+
+            foreach (var project in sln.ProjectsInOrder
+                .Where(p =>
+                    p.ProjectType == SolutionProjectType.KnownToBeMSBuildFormat // skips solution folders
+                    && p.ProjectConfigurations.TryGetValue(config.FullName, out var projectConfig)))
+            {
+                projects.Add(project.AbsolutePath.Replace('\\', '/'));
+            }
+
+            return new SolutionInfo(filePath, projects.ToArray());
+        }
+    }
+}

--- a/modules/NuGet.Tasks/NuGet.Tasks.csproj
+++ b/modules/NuGet.Tasks/NuGet.Tasks.csproj
@@ -6,14 +6,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Content Include="module.props" CopyToPublishDirectory="PreserveNewest" />
+    <Content Include="*.props" CopyToPublishDirectory="PreserveNewest" />
+    <Content Include="*.targets" CopyToPublishDirectory="PreserveNewest" />
   </ItemGroup>
 
   <ItemGroup>
     <!-- set as private assets all so these assemblies get resolved from the version bundled in the .NET Core SDK -->
+    <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildVersion)" PrivateAssets="All" />
-    <PackageReference Include="NuGet.Packaging" Version="$(NuGetInMSBuildVersion)" PrivateAssets="All" />
-    <PackageReference Include="NuGet.Protocol" Version="$(NuGetInMSBuildVersion)" PrivateAssets="All" />
+    <PackageReference Include="NuGet.Build.Tasks" Version="$(NuGetInMSBuildVersion)" PrivateAssets="All" />
     <PackageReference Include="Newtonsoft.Json" Version="$(JsonNetInMSBuildVersion)" PrivateAssets="All" />
   </ItemGroup>
 

--- a/modules/NuGet.Tasks/PackNuSpec.cs
+++ b/modules/NuGet.Tasks/PackNuSpec.cs
@@ -9,6 +9,7 @@ using Microsoft.Build.Utilities;
 using NuGet.Frameworks;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
+using NuGet.Tasks.Utilties;
 using NuGet.Versioning;
 
 namespace NuGet.Tasks
@@ -50,21 +51,7 @@ namespace NuGet.Tasks
                 return false;
             }
 
-            var properties = new Dictionary<string, string>();
-            if (!string.IsNullOrEmpty(Properties))
-            {
-                foreach (var item in Properties.Split(';'))
-                {
-                    var splitIdx = item.IndexOf('=');
-                    if (splitIdx <= 0)
-                    {
-                        continue;
-                    }
-                    var key = item.Substring(0, splitIdx);
-                    var value = item.Substring(splitIdx + 1);
-                    properties[key] = value;
-                }
-            }
+            var properties = MSBuildListSplitter.GetNamedProperties(Properties);
 
             string PropertyProvider(string name)
             {

--- a/modules/NuGet.Tasks/Policies/AdditionalProjectRestoreSourcePolicy.cs
+++ b/modules/NuGet.Tasks/Policies/AdditionalProjectRestoreSourcePolicy.cs
@@ -1,0 +1,35 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+using Microsoft.Build.Framework;
+
+namespace NuGet.Tasks.Policies
+{
+    internal class AdditionalProjectRestoreSourcePolicy : INuGetPolicy
+    {
+        private readonly ITaskItem[] _sources;
+
+        public AdditionalProjectRestoreSourcePolicy(ITaskItem[] items)
+        {
+            _sources = items;
+        }
+
+        public Task ApplyAsync(PolicyContext context, CancellationToken cancellationToken)
+        {
+            foreach (var project in context.Projects)
+            {
+                var propGroup = project.TargetsExtension.AddPropertyGroup();
+
+                foreach (var source in _sources)
+                {
+                    propGroup.Add(new XElement("RestoreAdditionalProjectSources", "$(RestoreAdditionalProjectSources);" + source.ItemSpec));
+                }
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/modules/NuGet.Tasks/Policies/INuGetPolicy.cs
+++ b/modules/NuGet.Tasks/Policies/INuGetPolicy.cs
@@ -1,0 +1,13 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NuGet.Tasks.Policies
+{
+    internal interface INuGetPolicy
+    {
+        Task ApplyAsync(PolicyContext context, CancellationToken cancellationToken);
+    }
+}

--- a/modules/NuGet.Tasks/Policies/Lineup/IRestoreLineupCommand.cs
+++ b/modules/NuGet.Tasks/Policies/Lineup/IRestoreLineupCommand.cs
@@ -1,0 +1,13 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NuGet.Tasks.Lineup
+{
+    internal interface IRestoreLineupCommand
+    {
+        Task<bool> ExecuteAsync(RestoreContext context, CancellationToken cancellationToken);
+    }
+}

--- a/modules/NuGet.Tasks/Policies/Lineup/MSBuildLineupFileBuilder.cs
+++ b/modules/NuGet.Tasks/Policies/Lineup/MSBuildLineupFileBuilder.cs
@@ -1,0 +1,68 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Xml.Linq;
+using NuGet.Frameworks;
+using NuGet.Tasks.ProjectModel;
+
+namespace NuGet.Tasks.Policies
+{
+    internal class MSBuildLineupFileBuilder
+    {
+        private readonly MSBuildProjectBuilder _builder;
+        private readonly XElement _defaultItemGroup;
+        private readonly Dictionary<NuGetFramework, XElement> _tfmGroups = new Dictionary<NuGetFramework, XElement>();
+
+        public MSBuildLineupFileBuilder(MSBuildProjectBuilder builder)
+        {
+            _builder = builder;
+            // add this condition so when re-applying lineups we get the original references, not the pinned versions
+            _defaultItemGroup = CreateRuntimeItemGroup();
+        }
+
+        public void AddLineup(string id, string version)
+        {
+            _defaultItemGroup.Add(new XElement("PackageLineup", new XAttribute("Include", id), new XAttribute("Version", version)));
+        }
+
+        public void PinPackageReference(PackageReferenceInfo package, string version, NuGetFramework framework)
+        {
+            XElement itemGroup;
+            if (framework.Equals(NuGetFramework.AnyFramework))
+            {
+                itemGroup = _defaultItemGroup;
+            }
+            else
+            {
+                if (!_tfmGroups.TryGetValue(framework, out itemGroup))
+                {
+                    itemGroup = CreateRuntimeItemGroup($" AND '$(TargetFramework)' == '{framework.GetShortFolderName()}'");
+                    _tfmGroups.Add(framework, itemGroup);
+                }
+            }
+
+            itemGroup.Add(CreatePinItem("PackageReference", package.Id, version));
+        }
+
+        public void PinCliToolReference(DotNetCliReferenceInfo tool, string version)
+        {
+            _defaultItemGroup.Add(CreatePinItem("DotNetCliToolReference", tool.Id, version));
+        }
+
+        private XElement CreatePinItem(string type, string itemSpec, string version)
+        {
+            return new XElement(type,
+                  new XAttribute("Update", itemSpec),
+                  new XAttribute("Version", version),
+                  new XAttribute("AutoVersion", "true"),
+                  // Prevents upgrades from the NuGet GUI in VS, and the NoVersions policy can filter this reference.
+                  new XAttribute("IsImplicitlyDefined", "true"));
+        }
+
+        private XElement CreateRuntimeItemGroup(string condition = null)
+        {
+            return _builder.AddItemGroup("'$(PolicyDesignTimeBuild)' != 'true' " + condition);
+        }
+    }
+}

--- a/modules/NuGet.Tasks/Policies/Lineup/PackageLineupRequest.cs
+++ b/modules/NuGet.Tasks/Policies/Lineup/PackageLineupRequest.cs
@@ -1,0 +1,21 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using NuGet.Versioning;
+
+namespace NuGet.Tasks.Lineup
+{
+    internal class PackageLineupRequest
+    {
+        public PackageLineupRequest(string id, VersionRange version)
+        {
+            Id = id;
+            Version = version;
+        }
+
+        public string Id { get; }
+        public VersionRange Version { get;  }
+
+        public string RestoreSpec => $"{Id}/{Version.OriginalString}";
+    }
+}

--- a/modules/NuGet.Tasks/Policies/Lineup/PackageVersionSource.cs
+++ b/modules/NuGet.Tasks/Policies/Lineup/PackageVersionSource.cs
@@ -1,0 +1,84 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using NuGet.Common;
+using NuGet.Packaging;
+using NuGet.Packaging.Core;
+using NuGet.Versioning;
+
+namespace NuGet.Tasks.Lineup
+{
+    internal class PackageVersionSource
+    {
+        private readonly ILogger _logger;
+        private Dictionary<string, string> _packageLineupMap;
+        private Dictionary<string, PackageDependency> _packages;
+        private List<PackageIdentity> _lineups;
+
+        public PackageVersionSource(ILogger logger)
+        {
+            _logger = logger;
+            _packageLineupMap = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            _packages = new Dictionary<string, PackageDependency>(StringComparer.OrdinalIgnoreCase);
+            _lineups = new List<PackageIdentity>();
+        }
+
+        public IEnumerable<PackageIdentity> Lineups => _lineups;
+
+        public void AddPackagesFromLineup(string lineupId, NuGetVersion lineupVersion, List<PackageDependencyGroup> dependencies)
+        {
+            _lineups.Add(new PackageIdentity(lineupId, lineupVersion));
+
+            foreach (var dep in dependencies)
+            {
+                foreach (var package in dep.Packages)
+                {
+                    if (package.VersionRange.Equals(VersionRange.All))
+                    {
+                        _logger.LogWarning($"Lineup '{lineupId}' has an unbound version for '{package.Id}'. Lineups should include a specific version, so this package will be skipped.");
+                        continue;
+                    }
+
+                    if (_packageLineupMap.TryGetValue(package.Id, out var existingLineup))
+                    {
+                        _logger.LogError($"Packages versions for '{package.Id}' found from multiple lineups: {lineupId} and {existingLineup}. Cannot determine which one to use.");
+                        continue;
+                    }
+
+                    if (!TryAddPackage(package))
+                    {
+                        _logger.LogError($"A package versions for '{package.Id}' has already been specified from another source.");
+                        continue;
+                    }
+
+                    _packageLineupMap.Add(package.Id, lineupId);
+                }
+            }
+        }
+
+        public bool TryAddPackage(PackageDependency package)
+        {
+            if (_packages.TryGetValue(package.Id, out _))
+            {
+                return false;
+            }
+
+            _packages.Add(package.Id, package);
+            return true;
+        }
+
+        public bool TryGetPackageVersion(string id, out string version)
+        {
+            version = null;
+            if (_packages.TryGetValue(id, out var info))
+            {
+                version = info.VersionRange.ToShortString();
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/modules/NuGet.Tasks/Policies/Lineup/RestoreContext.cs
+++ b/modules/NuGet.Tasks/Policies/Lineup/RestoreContext.cs
@@ -1,0 +1,23 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using NuGet.Common;
+using NuGet.Tasks.Policies;
+
+namespace NuGet.Tasks.Lineup
+{
+    internal class RestoreContext
+    {
+        public ILogger Log { get; set; }
+
+        public List<PackageLineupRequest> PackageLineups { get; set; }
+
+        public PolicyContext Policy { get; set; }
+        
+        public string ProjectDirectory { get; set; }
+
+        // collects a list of package versions that should be pinned
+        public PackageVersionSource VersionSource { get; set; }
+    }
+}

--- a/modules/NuGet.Tasks/Policies/Lineup/RestoreLineupsCommand.cs
+++ b/modules/NuGet.Tasks/Policies/Lineup/RestoreLineupsCommand.cs
@@ -1,0 +1,148 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using NuGet.Commands;
+using NuGet.Configuration;
+using NuGet.DependencyResolver;
+using NuGet.Frameworks;
+using NuGet.LibraryModel;
+using NuGet.Packaging;
+using NuGet.Protocol;
+using NuGet.Protocol.Core.Types;
+using NuGet.Repositories;
+using NuGet.RuntimeModel;
+
+namespace NuGet.Tasks.Lineup
+{
+    // Executes a NuGet restore, but only downloads the top-level packages and not their dependencies.
+    internal class RestoreLineupsCommand : IRestoreLineupCommand
+    {
+        public async Task<bool> ExecuteAsync(RestoreContext context, CancellationToken cancellationToken)
+        {
+            var success = true;
+
+            var providersCache = new RestoreCommandProvidersCache();
+            using (var cacheContext = new SourceCacheContext())
+            {
+                cacheContext.NoCache = context.Policy.RestoreNoCache;
+                cacheContext.IgnoreFailedSources = context.Policy.RestoreIgnoreFailedSources;
+
+                var defaultSettings = Settings.LoadDefaultSettings(root: null, configFileName: null, machineWideSettings: null);
+                var sourceProvider = new CachingSourceProvider(new PackageSourceProvider(defaultSettings));
+
+                var restoreContext = new RestoreArgs
+                {
+                    CacheContext = cacheContext,
+                    DisableParallel = context.Policy.RestoreDisableParallel,
+                    Log = context.Log,
+                    MachineWideSettings = new XPlatMachineWideSetting(),
+                    ConfigFile = context.Policy.RestoreConfigFile,
+                    PackageSaveMode = PackageSaveMode.Defaultv3,
+                    GlobalPackagesFolder = context.Policy.RestorePackagesPath,
+                    CachingSourceProvider = sourceProvider,
+                    Sources = context.Policy.RestoreSources
+                };
+
+                var settings = restoreContext.GetSettings(context.ProjectDirectory);
+                var globalFolder = restoreContext.GetEffectiveGlobalPackagesFolder(context.ProjectDirectory, settings);
+                var effectiveSources = GetEffectiveSources(settings, restoreContext, context.Policy.RestoreAdditionalSources);
+                var sharedCache = providersCache.GetOrCreate(
+                    globalFolder,
+                    restoreContext.GetEffectiveFallbackPackageFolders(settings),
+                    effectiveSources,
+                    cacheContext,
+                    context.Log);
+
+                var installer = new SimplePackageInstaller(globalFolder, cacheContext, context.Policy.RestoreDisableParallel, context.Log);
+                var localRepositories = new List<NuGetv3LocalRepository>
+                {
+                    sharedCache.GlobalPackages
+                };
+
+                localRepositories.AddRange(sharedCache.FallbackPackageFolders);
+
+                var remoteWalkContext = new RemoteWalkContext(cacheContext, context.Log)
+                {
+                    // don't write msbuild props/targets
+                    IsMsBuildBased = false,
+                };
+
+                remoteWalkContext.LocalLibraryProviders.AddRange(sharedCache.LocalProviders);
+                remoteWalkContext.RemoteLibraryProviders.AddRange(sharedCache.RemoteProviders);
+
+                var remoteWalker = new RemoteDependencyWalker(remoteWalkContext);
+                var graphs = new List<GraphNode<RemoteResolveResult>>();
+
+                foreach (var group in context.PackageLineups)
+                {
+                    var libraryRange = new LibraryRange(group.Id, group.Version, LibraryDependencyTarget.Package);
+                    var graph = await remoteWalker.WalkAsync(libraryRange, NuGetFramework.AnyFramework, null, RuntimeGraph.Empty, recursive: false);
+                    graphs.Add(graph);
+                }
+
+                var restoreTargetGraph = RestoreTargetGraph.Create(graphs, remoteWalkContext, context.Log, NuGetFramework.AnyFramework);
+                var allInstalledPackages = new HashSet<LibraryIdentity>();
+                await installer.InstallPackagesAsync(new[] { restoreTargetGraph }, allInstalledPackages, cancellationToken);
+
+                foreach (var lineup in context.PackageLineups)
+                {
+                    var library = restoreTargetGraph.Flattened.FirstOrDefault(g => g.Key.Name.Equals(lineup.Id, StringComparison.OrdinalIgnoreCase))?.Key;
+                    if (library == null)
+                    {
+                        context.Log.LogError($"Could not resolve a package for the lineup '{lineup.RestoreSpec}'.");
+                        success = false;
+                        break;
+                    }
+
+                    var packageInfo = NuGetv3LocalRepositoryUtility.GetPackage(localRepositories, library.Name, library.Version);
+                    var dependencies = packageInfo.Package.Nuspec.GetDependencyGroups().ToList();
+
+                    if (dependencies == null)
+                    {
+                        context.Log.LogMinimal($"Could not find dependency info for lineup '{lineup.RestoreSpec}'.");
+                        success = false;
+                        break;
+                    }
+
+                    context.VersionSource.AddPackagesFromLineup(library.Name, library.Version, dependencies);
+                }
+            }
+
+            return success;
+        }
+
+        private List<SourceRepository> GetEffectiveSources(ISettings settings, RestoreArgs context, List<string> additionalSources)
+        {
+            var sources = new List<PackageSource>();
+
+            if (context.Sources.Any())
+            {
+                // if explicit sources are specified, use these instead of any that may come from NuGet.config files
+                sources.AddRange(context.Sources.Select(s => new PackageSource(s)));
+            }
+            else
+            {
+                // load sources from NuGet.config files
+                var packageSourceProvider = new PackageSourceProvider(settings);
+                var sourcesFromConfig = packageSourceProvider.LoadPackageSources();
+
+                sources.AddRange(sourcesFromConfig.Where(s => s.IsEnabled));
+            }
+
+            if (additionalSources.Any())
+            {
+                // always use any additional sources
+                sources.AddRange(additionalSources.Select(s => new PackageSource(s)));
+            }
+
+            return sources.Select(entry =>
+                context.CachingSourceProvider.CreateRepository(entry))
+                .ToList();
+        }
+    }
+}

--- a/modules/NuGet.Tasks/Policies/Lineup/SimplePackageInstaller.cs
+++ b/modules/NuGet.Tasks/Policies/Lineup/SimplePackageInstaller.cs
@@ -1,0 +1,85 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using NuGet.Commands;
+using NuGet.Common;
+using NuGet.DependencyResolver;
+using NuGet.LibraryModel;
+using NuGet.Packaging;
+using NuGet.Packaging.Core;
+using NuGet.Protocol.Core.Types;
+
+namespace NuGet.Tasks.Lineup
+{
+    internal class SimplePackageInstaller
+    {
+        private readonly string _packagesDirectory;
+        private readonly ILogger _logger;
+        private readonly SourceCacheContext _cacheContext;
+        private readonly int _maxDegreeOfConcurrency;
+
+        public SimplePackageInstaller(string packageDir, SourceCacheContext cacheContext, bool disableParallel, ILogger logger)
+        {
+            _packagesDirectory = packageDir;
+            _cacheContext = cacheContext;
+            _logger = logger;
+            _maxDegreeOfConcurrency = disableParallel ? 1 : 16;
+        }
+
+        public async Task InstallPackagesAsync(IEnumerable<RestoreTargetGraph> graphs,
+            HashSet<LibraryIdentity> allInstalledPackages,
+            CancellationToken token)
+        {
+            var packagesToInstall = graphs.SelectMany(g => g.Install.Where(match => allInstalledPackages.Add(match.Library)));
+            if (_maxDegreeOfConcurrency <= 1)
+            {
+                foreach (var match in packagesToInstall)
+                {
+                    await InstallPackageAsync(match, token);
+                }
+            }
+            else
+            {
+                var bag = new ConcurrentBag<RemoteMatch>(packagesToInstall);
+                var tasks = Enumerable.Range(0, _maxDegreeOfConcurrency)
+                    .Select(async _ =>
+                    {
+                        while (bag.TryTake(out RemoteMatch match))
+                        {
+                            await InstallPackageAsync(match, token);
+                        }
+                    });
+                await Task.WhenAll(tasks);
+            }
+        }
+
+        private async Task InstallPackageAsync(RemoteMatch installItem, CancellationToken token)
+        {
+            var packageIdentity = new PackageIdentity(installItem.Library.Name, installItem.Library.Version);
+
+            var versionFolderPathContext = new VersionFolderPathContext(
+                packageIdentity,
+                _packagesDirectory,
+                _logger,
+                PackageSaveMode.Defaultv3,
+                XmlDocFileSaveMode.Skip);
+
+            using (var packageDependency = await installItem.Provider.GetPackageDownloaderAsync(
+                packageIdentity,
+                _cacheContext,
+                _logger,
+                token))
+            {
+                await PackageExtractor.InstallFromSourceAsync(
+                    packageDependency,
+                    versionFolderPathContext,
+                    token);
+            }
+        }
+    }
+}

--- a/modules/NuGet.Tasks/Policies/MSBuildPolicyFactory.cs
+++ b/modules/NuGet.Tasks/Policies/MSBuildPolicyFactory.cs
@@ -1,0 +1,28 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Build.Framework;
+using NuGet.Tasks.Policies;
+
+namespace NuGet.Tasks
+{
+    internal class MSBuildPolicyFactory
+    {
+        public virtual INuGetPolicy Create(string type, IEnumerable<ITaskItem> items)
+        {
+            switch (type.ToLowerInvariant())
+            {
+                case "additionalrestoresource":
+                    return new AdditionalProjectRestoreSourcePolicy(items.ToArray());
+                case "lineup":
+                    return new PackageLineupPolicy(items.ToArray());
+                case "disallowpackagereferenceversion":
+                    return new PackageVersionRestrictionPolicy(items.ToArray());
+                default:
+                    return null;
+            }
+        }
+    }
+}

--- a/modules/NuGet.Tasks/Policies/PackageLineupPolicy.cs
+++ b/modules/NuGet.Tasks/Policies/PackageLineupPolicy.cs
@@ -1,0 +1,186 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Build.Framework;
+using NuGet.Build;
+using NuGet.Tasks.Lineup;
+using NuGet.Tasks.ProjectModel;
+using NuGet.Versioning;
+
+namespace NuGet.Tasks.Policies
+{
+    internal class PackageLineupPolicy : INuGetPolicy
+    {
+        private readonly IEnumerable<ITaskItem> _items;
+        private readonly IRestoreLineupCommand _command;
+        private int _pinned;
+
+        public PackageLineupPolicy(ITaskItem[] items)
+            : this(items, new RestoreLineupsCommand())
+        {
+        }
+
+        // for testing
+        internal PackageLineupPolicy(ITaskItem[] items, IRestoreLineupCommand command)
+        {
+            _items = items;
+            _command = command;
+        }
+
+        public async Task ApplyAsync(PolicyContext context, CancellationToken cancellationToken)
+        {
+            var logger = new MSBuildLogger(context.Log);
+            var versionSource = new PackageVersionSource(logger);
+            var lineupRequests = CreateRequests(context);
+            if (lineupRequests.Count == 0)
+            {
+                return;
+            }
+
+            logger.LogInformation("Beginning lineup package restore.");
+
+            var stopwatch = Stopwatch.StartNew();
+
+            try
+            {
+                var restoreContext = new RestoreContext
+                {
+                    Log = logger,
+                    PackageLineups = lineupRequests,
+                    VersionSource = versionSource,
+                    Policy = context,
+                    ProjectDirectory = context.SolutionDirectory
+                };
+
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    return;
+                }
+
+                var success = await _command.ExecuteAsync(restoreContext, cancellationToken);
+
+                if (!success)
+                {
+                    stopwatch.Stop();
+                    logger.LogError($"Failed to pin packages. Time elapsed = {stopwatch.ElapsedMilliseconds}ms");
+                    return;
+                }
+
+                var lineupCount = 0;
+                foreach (var lineup in versionSource.Lineups)
+                {
+                    logger.LogMinimal($"Using lineup {lineup.Id} {lineup.Version.ToNormalizedString()}");
+                    lineupCount++;
+                }
+
+                _pinned = 0;
+                Parallel.ForEach(context.Projects, project =>
+                {
+                    GeneratePinFile(context, project, versionSource);
+                });
+
+                stopwatch.Stop();
+                logger.LogMinimal($"Pinned {_pinned} package(s) from {lineupCount} lineup(s) in {stopwatch.ElapsedMilliseconds}ms");
+            }
+            catch (Exception ex)
+            {
+#if DEBUG
+                var showStackTrace = true;
+#else
+                var showStackTrace = false;
+#endif
+                context.Log.LogErrorFromException(ex, showStackTrace);
+            }
+        }
+
+        private void GeneratePinFile(PolicyContext context, ProjectInfo project, PackageVersionSource versionSource)
+        {
+            var builder = new MSBuildLineupFileBuilder(project.TargetsExtension);
+
+            foreach (var lineup in versionSource.Lineups)
+            {
+                builder.AddLineup(lineup.Id, lineup.Version.ToNormalizedString());
+            }
+
+            foreach (var framework in project.Frameworks)
+            {
+                foreach (var package in framework.Dependencies)
+                {
+                    var shouldOverride =
+                        // true for references that come from the SDK, like Microsoft.NETCore.App
+                        package.IsImplicitlyDefined
+                        // if the original PackageReference is version-less
+                        || string.IsNullOrEmpty(package.Version);
+
+                    if (!shouldOverride)
+                    {
+                        continue;
+                    }
+
+                    if (versionSource.TryGetPackageVersion(package.Id, out string version))
+                    {
+                        builder.PinPackageReference(package, version, framework.TargetFramework);
+                        Interlocked.Increment(ref _pinned);
+                    }
+                    else if (!package.IsImplicitlyDefined && !package.NoWarn)
+                    {
+                        context.Log.LogKoreBuildError(project.FullPath, KoreBuildErrors.PackageVersionNotFoundInLineup,
+                            $"PackageReference to {package.Id} did not specify a version and was not found in any lineup.");
+                    }
+                }
+            }
+
+            foreach (var toolPackage in project.Tools)
+            {
+                if (!string.IsNullOrEmpty(toolPackage.Version))
+                {
+                    continue;
+                }
+
+                if (versionSource.TryGetPackageVersion(toolPackage.Id, out string version))
+                {
+                    builder.PinCliToolReference(toolPackage, version);
+                    Interlocked.Increment(ref _pinned);
+                }
+                else
+                {
+                    context.Log.LogKoreBuildError(project.FullPath, KoreBuildErrors.PackageVersionNotFoundInLineup,
+                        $"DotNetCliToolReference to {toolPackage.Id} did not specify a version and was not found in any lineup.");
+                }
+            }
+        }
+
+        private List<PackageLineupRequest> CreateRequests(PolicyContext context)
+        {
+            var lineupRequest = new List<PackageLineupRequest>();
+
+            foreach (var item in _items)
+            {
+                var packageId = item.ItemSpec;
+                var version = item.GetMetadata("Version");
+
+                if (string.IsNullOrEmpty(version))
+                {
+                    context.Log.LogError($"Missing required metadata 'Version' on lineup policy for {packageId}.");
+                    continue;
+                }
+
+                if (!VersionRange.TryParse(version, out var versionRange))
+                {
+                    context.Log.LogError($"Invalid version range '{version}' on package lineup '{packageId}'");
+                    continue;
+                }
+
+                lineupRequest.Add(new PackageLineupRequest(packageId, versionRange));
+            }
+
+            return lineupRequest;
+        }
+    }
+}

--- a/modules/NuGet.Tasks/Policies/PackageVersionRestrictionPolicy.cs
+++ b/modules/NuGet.Tasks/Policies/PackageVersionRestrictionPolicy.cs
@@ -1,0 +1,56 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+using Microsoft.Build.Framework;
+
+namespace NuGet.Tasks.Policies
+{
+    internal class PackageVersionRestrictionPolicy : INuGetPolicy
+    {
+        private readonly ITaskItem[] _items;
+
+        public PackageVersionRestrictionPolicy(ITaskItem[] items)
+        {
+            _items = items;
+        }
+
+        public Task ApplyAsync(PolicyContext context, CancellationToken cancellationToken)
+        {
+            foreach (var item in _items)
+            {
+                var config = item.ItemSpec;
+
+                var propName = "error".Equals(item.GetMetadata("ErrorLevel"), StringComparison.OrdinalIgnoreCase)
+                    ? "TreatPackageVersionAsError"
+                    : "TreatPackageVersionAsWarning";
+
+
+                foreach (var project in context.Projects)
+                {
+                    var propGroup = project.TargetsExtension.AddPropertyGroup(propName, "true");
+
+                    if (!config.Equals("Any", StringComparison.OrdinalIgnoreCase))
+                    {
+                        propGroup.Add(new XAttribute("Condition", $" '$(Configuration)' == '{config}' "));
+                    }
+                }
+            }
+
+            var targets = Path.Combine(
+                Path.GetDirectoryName(typeof(PackageVersionRestrictionPolicy).Assembly.Location),
+                "Policy.VersionRestrictions.targets");
+
+            foreach (var project in context.Projects)
+            {
+                project.TargetsExtension.AddImport(targets, required: false);
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/modules/NuGet.Tasks/Policies/PolicyContext.cs
+++ b/modules/NuGet.Tasks/Policies/PolicyContext.cs
@@ -1,0 +1,26 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Build.Utilities;
+using NuGet.Tasks.ProjectModel;
+
+namespace NuGet.Tasks.Policies
+{
+    internal class PolicyContext
+    {
+        public string SolutionDirectory { get; set; }
+        public TaskLoggingHelper Log { get; set; }
+
+        public List<string> RestoreSources { get; set; }
+        public List<string> RestoreAdditionalSources { get; set; }
+        public bool RestoreDisableParallel { get; set; }
+        public string RestorePackagesPath { get; set; }
+        public string RestoreConfigFile { get; set; }
+        public bool RestoreIgnoreFailedSources { get; set; }
+        public bool RestoreNoCache { get; set; }
+
+        public IReadOnlyList<ProjectInfo> Projects { get; set; } = Array.Empty<ProjectInfo>();
+    }
+}

--- a/modules/NuGet.Tasks/Policy.VerifyImport.props
+++ b/modules/NuGet.Tasks/Policy.VerifyImport.props
@@ -1,0 +1,7 @@
+<!-- This target should be imported into the project to verify the result of the package policies. -->
+<Project>
+  <PropertyGroup>
+    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+    <KoreBuildRestoreTargetsImported>true</KoreBuildRestoreTargetsImported>
+  </PropertyGroup>
+</Project>

--- a/modules/NuGet.Tasks/Policy.VersionRestrictions.targets
+++ b/modules/NuGet.Tasks/Policy.VersionRestrictions.targets
@@ -1,0 +1,32 @@
+<!-- This target should be imported into the project to verify the result of the package policies. -->
+<Project>
+  <PropertyGroup>
+    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+  </PropertyGroup>
+
+  <Target Name="VerifyPackageVersionRestrictions"
+          BeforeTargets="PrepareForBuild">
+
+    <ItemGroup>
+      <PackageReferenceWithVersion Include="@(PackageReference)" />
+      <PackageReferenceWithVersion Remove="@(PackageReferenceWithVersion->WithMetadataValue('IsImplicitlyDefined', 'true'))" />
+      <PackageReferenceWithVersion Remove="@(PackageReferenceWithVersion->WithMetadataValue('NoWarn', 'true'))" />
+    </ItemGroup>
+
+    <PropertyGroup>
+      <_PackageWithVersionMessage>This project has the 'NoVersions' policy applied but an explicit versions found on some PackageReference items.</_PackageWithVersionMessage>
+      <_PackageWithVersionMessage>$(_PackageWithVersionMessage)%0AAdd 'NoWarn="true"' to the PackageReference to ignore this warning.</_PackageWithVersionMessage>
+      <_PackageWithVersionMessage>$(_PackageWithVersionMessage)%0A - @(PackageReferenceWithVersion->'%(Identity)/%(Version)', '%0A - ')</_PackageWithVersionMessage>
+    </PropertyGroup>
+
+    <Warning Text="$(_PackageWithVersionMessage)"
+             Code="KRB4002"
+             File="$(MSBuildProjectFullPath)"
+             Condition=" @(PackageReferenceWithVersion->Count()) != 0 AND '$(TreatPackageVersionAsWarning)' == 'true' " />
+
+    <Error Text="$(_PackageWithVersionMessage)"
+           Code="KRB4002"
+           File="$(MSBuildProjectFullPath)"
+           Condition=" @(PackageReferenceWithVersion->Count()) != 0 AND '$(TreatPackageVersionAsError)' == 'true' " />
+  </Target>
+</Project>

--- a/modules/NuGet.Tasks/Properties/InternalsVisibleTo.cs
+++ b/modules/NuGet.Tasks/Properties/InternalsVisibleTo.cs
@@ -1,0 +1,7 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("NuGet.Tasks.Tests")]
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]

--- a/modules/NuGet.Tasks/Utilties/MSBuildListSplitter.cs
+++ b/modules/NuGet.Tasks/Utilties/MSBuildListSplitter.cs
@@ -1,0 +1,45 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace NuGet.Tasks.Utilties
+{
+    public static class MSBuildListSplitter
+    {
+        private static readonly char[] SemiColon = { ';' };
+
+        public static IEnumerable<string> SplitItemList(string value)
+        {
+            return string.IsNullOrEmpty(value)
+                ? Enumerable.Empty<string>()
+                : value.Split(SemiColon, StringSplitOptions.RemoveEmptyEntries);
+        }
+
+        public static IDictionary<string, string> GetNamedProperties(string input)
+        {
+            var values = new Dictionary<string, string>();
+            if (string.IsNullOrEmpty(input))
+            {
+                return values;
+            }
+
+            foreach (var item in input.Split(SemiColon, StringSplitOptions.RemoveEmptyEntries))
+            {
+                var splitIdx = item.IndexOf('=');
+                if (splitIdx <= 0)
+                {
+                    continue;
+                }
+
+                var key = item.Substring(0, splitIdx);
+                var value = item.Substring(splitIdx + 1);
+                values[key] = value;
+            }
+
+            return values;
+        }
+    }
+}

--- a/modules/NuGet.Tasks/module.props
+++ b/modules/NuGet.Tasks/module.props
@@ -1,4 +1,22 @@
 <Project>
+  <UsingTask TaskName="NuGet.Tasks.ApplyNuGetPolicies" AssemblyFile="$(MSBuildThisFileDirectory)Internal.AspNetCore.NuGet.Tasks.dll" />
   <UsingTask TaskName="NuGet.Tasks.PackNuSpec" AssemblyFile="$(MSBuildThisFileDirectory)Internal.AspNetCore.NuGet.Tasks.dll" />
   <UsingTask TaskName="NuGet.Tasks.PushNuGetPackages" AssemblyFile="$(MSBuildThisFileDirectory)Internal.AspNetCore.NuGet.Tasks.dll" />
+
+  <ItemDefinitionGroup>
+
+    <DisallowPackageReferenceVersion>
+      <PolicyType>DisallowPackageReferenceVersion</PolicyType>
+    </DisallowPackageReferenceVersion>
+    
+    <PackageLineup>
+      <PolicyType>Lineup</PolicyType>
+    </PackageLineup>
+    
+    <AdditionalRestoreSources>
+      <PolicyType>AdditionalRestoreSource</PolicyType>
+    </AdditionalRestoreSources>
+    
+  </ItemDefinitionGroup>
+
 </Project>

--- a/modules/NuGet.Tasks/module.targets
+++ b/modules/NuGet.Tasks/module.targets
@@ -1,0 +1,41 @@
+<Project>
+
+  <PropertyGroup>
+    <RestoreDependsOn>ApplyNuGetPolicies;$(RestoreDependsOn)</RestoreDependsOn>
+    <ApplyNuGetPoliciesDependsOn>
+      $(ApplyNuGetPoliciesDependsOn);
+      ResolveSolutions;
+      $(PrepareDependsOn);
+    </ApplyNuGetPoliciesDependsOn>
+  </PropertyGroup>
+
+  <ItemGroup Condition="@(PackageLineup->Count()) != 0 AND '$(RestrictVersionOnPackageReference)' != 'false' ">
+    <!-- Automatically warn about package reference's that have a non-empty version, but only when lineups are used. -->
+    <DisallowPackageReferenceVersion Include="Debug" ErrorLevel="warn"/>
+    <DisallowPackageReferenceVersion Include="Release" ErrorLevel="error"/>
+    <DisallowPackageReferenceVersion Include="Any" ErrorLevel="error" />
+  </ItemGroup>
+
+  <Target Name="GetLineups"
+          Returns="@(PackageLineup)" />
+
+  <Target Name="ApplyNuGetPolicies"
+          DependsOnTargets="$(ApplyNuGetPoliciesDependsOn)"
+          Condition="@(Solutions->Count()) != 0">
+
+    <ApplyNuGetPolicies
+      Policies="@(PackageLineup);@(AdditionalRestoreSources);@(DisallowPackageReferenceVersion)"
+      Projects="@(Solutions)"
+      ProjectProperties="$(SolutionProperties)"
+      SolutionDirectory="$(RepositoryRoot)"
+      RestoreSources="$(PolicyRestoreSources)"
+      RestoreAdditionalSources="$(PolicyRestoreAdditionalSources)"
+      RestorePackagesPath="$(PolicyRestorePackagesPath)"
+      RestoreDisableParallel="$(PolicyRestoreDisableParallel)"
+      RestoreConfigFile="$(PolicyRestoreConfigFile)"
+      RestoreNoCache="$(PolicyRestoreNoCache)"
+      RestoreIgnoreFailedSources="$(PolicyRestoreIgnoreFailedSources)" />
+
+  </Target>
+
+</Project>

--- a/test/KoreBuild.FunctionalTests/RepoPolicyTests.cs
+++ b/test/KoreBuild.FunctionalTests/RepoPolicyTests.cs
@@ -1,0 +1,58 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace KoreBuild.FunctionalTests
+{
+    [Collection(nameof(RepoTestCollection))]
+    public class RepoPolicyTests
+    {
+        private readonly ITestOutputHelper _output;
+        private readonly RepoTestFixture _fixture;
+
+        public RepoPolicyTests(ITestOutputHelper output, RepoTestFixture fixture)
+        {
+            _output = output;
+            _fixture = fixture;
+        }
+
+        [Fact]
+        public async Task BuildsRepoWithLineupPolicy()
+        {
+            var app = _fixture.CreateTestApp("RepoWithLineupPolicy");
+
+            var build = app.ExecuteBuild(_output);
+            var task = await Task.WhenAny(build, Task.Delay(TimeSpan.FromMinutes(5)));
+
+            Assert.Same(task, build);
+            Assert.Equal(0, build.Result);
+
+            Assert.True(File.Exists(Path.Combine(app.WorkingDirectory, "artifacts", "build", "TestLineup.1.0.0.nupkg")), "Should have produced a lineup package");
+        }
+
+        [Theory]
+        [InlineData("Debug", 0)]
+        [InlineData("Release", 1)]
+        public async Task RepoWithVersionRestrictions(string config, int exitCode)
+        {
+            var app = _fixture.CreateTestApp("RepoWithVersionRestrictionsPolicy");
+            var logFile = Path.Combine(app.WorkingDirectory, "artifacts", "msbuild", "test.log");
+
+            var build = app.ExecuteBuild(_output, "/p:Configuration=" + config, "/flp:LogFile=" + logFile, "/flp:Verbosity=Minimal");
+            var task = await Task.WhenAny(build, Task.Delay(TimeSpan.FromMinutes(5)));
+
+            Assert.Same(task, build);
+            Assert.Equal(exitCode, build.Result);
+
+            var logText = File.ReadAllText(logFile);
+            Assert.Contains("KRB4002", logText);
+            Assert.Contains("Newtonsoft.Json/", logText);
+            Assert.DoesNotContain("Moq/", logText);
+        }
+    }
+}

--- a/test/KoreBuild.FunctionalTests/Utilities/TestApp.cs
+++ b/test/KoreBuild.FunctionalTests/Utilities/TestApp.cs
@@ -55,6 +55,7 @@ namespace KoreBuild.FunctionalTests
                 "-Update"
             });
 
+            arguments.Add("/v:n");
             arguments.AddRange(args);
 
             var process = new Process

--- a/test/NuGet.Tasks.Tests/ApplyNuGetPoliciesTests.cs
+++ b/test/NuGet.Tasks.Tests/ApplyNuGetPoliciesTests.cs
@@ -1,0 +1,198 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections;
+using System.IO;
+using BuildTools.Tasks.Tests;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using NuGet.Frameworks;
+using NuGet.Tasks.Policies;
+using NuGet.Tasks.ProjectModel;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace NuGet.Tasks.Tests
+{
+    public class ApplyNuGetPoliciesTests : IDisposable
+    {
+        private readonly string _tmpDir;
+        private readonly ITestOutputHelper _output;
+
+        public ApplyNuGetPoliciesTests(ITestOutputHelper output)
+        {
+            _output = output;
+            _tmpDir = Path.Combine(Path.GetTempPath(), "korebuild", Path.GetRandomFileName());
+            Directory.CreateDirectory(_tmpDir);
+        }
+
+        [Fact]
+        public void CreatesPolicies()
+        {
+            var task = new ApplyNuGetPolicies
+            {
+                Policies = new ITaskItem[]
+                {
+                    new TaskItem("Example.Lineup", new Hashtable { ["PolicyType"] = "Lineup" }),
+                    new TaskItem("Another.Lineup", new Hashtable { ["PolicyType"] = "Lineup" }),
+                    new TaskItem("Release", new Hashtable { ["PolicyType"] = "DisallowPackageReferenceVersion" }),
+                    new TaskItem("Debug", new Hashtable { ["PolicyType"] = "DisallowPackageReferenceVersion" }),
+                    new TaskItem("https://api.nuget.org/v3/index.json", new Hashtable { ["PolicyType"] = "AdditionalRestoreSource" }),
+                    new TaskItem("https://anotherfeed/v3/index.json", new Hashtable { ["PolicyType"] = "AdditionalRestoreSource" }),
+                },
+                BuildEngine = new MockEngine()
+            };
+
+            var policies = task.CreatePolicies();
+
+            var lineup = Assert.Single(policies, p => p is PackageLineupPolicy);
+            var sources = Assert.Single(policies, p => p is AdditionalProjectRestoreSourcePolicy);
+            var restriction = Assert.Single(policies, p => p is PackageVersionRestrictionPolicy);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("  ")]
+        [InlineData("random")]
+        public void FailsForPoliciesWithUnknownType(string policyType)
+        {
+            var items = new ITaskItem[]
+            {
+                new TaskItem("Hello", new Hashtable { ["PolicyType"] = policyType })
+            };
+
+            var engine = new MockEngine
+            {
+                ContinueOnError = true
+            };
+
+            var task = new ApplyNuGetPolicies
+            {
+                BuildEngine = engine,
+                Policies = items,
+            };
+
+            Assert.False(task.Execute(), "Expected the task to fail");
+
+            var error = Assert.Single(engine.Errors);
+            Assert.Equal("KRB" + KoreBuildErrors.UnknownPolicyType, error.Code);
+        }
+
+        [Fact]
+        public void ExecutesDesignTimeBuild()
+        {
+            var sln = Path.Combine(_tmpDir, "Test.sln");
+            File.WriteAllText(sln, @"
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26124.0
+MinimumVisualStudioVersion = 15.0.26124.0
+Project(`{2150E333-8FDC-42A3-9474-1A3956D46DE8}`) = `src`, `src`, `{6BC8A037-601B-412E-B394-92F55C01C7A6}`
+EndProject
+Project(`{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}`) = `ClassLib1`, `src\ClassLib1\ClassLib1.csproj`, `{89EF0B05-98D4-4C4D-8870-718571091F79}`
+EndProject
+Project(`{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}`) = `VsixProject`, `src\VsixProject\VsixProject.csproj`, `{86986537-8DF5-423F-A3A8-0CA568A9FFC4}`
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		ReleaseNoVSIX|Any CPU = ReleaseNoVSIX|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{89EF0B05-98D4-4C4D-8870-718571091F79}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{89EF0B05-98D4-4C4D-8870-718571091F79}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{86986537-8DF5-423F-A3A8-0CA568A9FFC4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{86986537-8DF5-423F-A3A8-0CA568A9FFC4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{89EF0B05-98D4-4C4D-8870-718571091F79}.ReleaseNoVSIX|Any CPU.ActiveCfg = Debug|Any CPU
+		{89EF0B05-98D4-4C4D-8870-718571091F79}.ReleaseNoVSIX|Any CPU.Build.0 = Debug|Any CPU
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{89EF0B05-98D4-4C4D-8870-718571091F79} = {6BC8A037-601B-412E-B394-92F55C01C7A6}
+	EndGlobalSection
+EndGlobal
+".Replace('`', '"'));
+
+            var projectPath = Path.Combine(_tmpDir, "src", "ClassLib1", "ClassLib1.csproj").Replace('\\', '/');
+            Directory.CreateDirectory(Path.GetDirectoryName(projectPath));
+            File.WriteAllText(projectPath, @"<Project Sdk=`Microsoft.NET.Sdk`>
+    <PropertyGroup>
+        <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include=`Abc` Version=`1.1.0` NoWarn=`true` />
+        <PackageReference Include=`Xyz` />
+    </ItemGroup>
+</Project>".Replace('`', '"'));
+
+            var items = new[]
+            {
+                new TaskItem(sln, new Hashtable { ["AdditionalProperties"] = "Configuration=ReleaseNoVSIX" }),
+            };
+
+            MSBuildEnvironmentHelper.InitializeEnvironment(_output);
+            var task = new ApplyNuGetPolicies
+            {
+                ProjectProperties = "BuildNumber=123;Configuration=Release",
+                Projects = items,
+                BuildEngine = new MockEngine(),
+            };
+
+            var projects = task.CreateProjectContext();
+            Assert.NotNull(projects);
+            var project = Assert.Single(projects);
+            Assert.Equal(projectPath, project.FullPath);
+
+            void AssertAbc(ProjectFrameworkInfo tfm)
+            {
+                var abc = Assert.Single(tfm.Dependencies, d => d.Id == "Abc");
+                Assert.True(abc.NoWarn, "Abc should not have NoWarn set");
+                Assert.Equal("1.1.0", abc.Version);
+            }
+
+            void AssertXyz(ProjectFrameworkInfo tfm)
+            {
+                var xyz = Assert.Single(tfm.Dependencies, d => d.Id == "Xyz");
+                Assert.False(xyz.NoWarn, "Xyz should have NoWarn set");
+                Assert.Empty(xyz.Version);
+            }
+
+            Assert.Collection(project.Frameworks,
+                tfm =>
+                {
+                    Assert.Equal(FrameworkConstants.CommonFrameworks.NetStandard20, tfm.TargetFramework);
+
+                    Assert.Equal(3, tfm.Dependencies.Count);
+
+                    AssertAbc(tfm);
+                    AssertXyz(tfm);
+
+                    var nslibrary = Assert.Single(tfm.Dependencies, d => d.Id == "NETStandard.Library");
+                    Assert.True(nslibrary.IsImplicitlyDefined, "NETStandard.Library should be implicitly defined");
+                },
+                tfm =>
+                {
+                    Assert.Equal(FrameworkConstants.CommonFrameworks.Net461, tfm.TargetFramework);
+
+                    Assert.Equal(2, tfm.Dependencies.Count);
+
+                    AssertAbc(tfm);
+                    AssertXyz(tfm);
+                });
+        }
+
+        public void Dispose()
+        {
+            try
+            {
+                Directory.Delete(_tmpDir, recursive: true);
+            }
+            catch { }
+        }
+    }
+}

--- a/test/NuGet.Tasks.Tests/MSBuildEnvironmentHelper.cs
+++ b/test/NuGet.Tasks.Tests/MSBuildEnvironmentHelper.cs
@@ -1,0 +1,53 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using Newtonsoft.Json;
+using Xunit.Abstractions;
+
+namespace NuGet.Tasks.Tests
+{
+    internal class MSBuildEnvironmentHelper
+    {
+        public static void InitializeEnvironment(ITestOutputHelper output)
+        {
+            var dotnet = Process.GetCurrentProcess().MainModule.FileName;
+            var dotnetDir = Path.GetDirectoryName(dotnet);
+            output.WriteLine($"dotnet = {dotnetDir}");
+            string version = null;
+            var dir = new DirectoryInfo(AppContext.BaseDirectory);
+
+            while (dir != null)
+            {
+                var globalJson = dir.GetFiles("global.json").FirstOrDefault();
+                if (globalJson != null)
+                {
+                    var settings = JsonConvert.DeserializeAnonymousType(File.ReadAllText(globalJson.FullName), new { sdk = new { version = "" } });
+                    version = settings.sdk.version;
+                    output.WriteLine($"global.json found in '{globalJson.FullName}' with SDK version '{version}'");
+                    break;
+                }
+                dir = dir.Parent;
+            }
+
+            string sdkDir;
+            if (string.IsNullOrEmpty(version))
+            {
+                var sdkDirs = new DirectoryInfo(Path.Combine(dotnetDir, "sdk"));
+                var sdks = sdkDirs.GetDirectories().First();
+                sdkDir = sdks.FullName;
+            }
+            else
+            {
+                sdkDir = Path.Combine(dotnetDir, "sdk", version);
+            }
+
+            output.WriteLine($"Setting MSBuild directory to {sdkDir}");
+            Environment.SetEnvironmentVariable("MSBUILD_EXE_PATH", Path.Combine(sdkDir, "MSBuild.dll"));
+            Environment.SetEnvironmentVariable("MSBUILDEXTENSIONSPATH", sdkDir);
+        }
+    }
+}

--- a/test/NuGet.Tasks.Tests/NuGet.Tasks.Tests.csproj
+++ b/test/NuGet.Tasks.Tests/NuGet.Tasks.Tests.csproj
@@ -11,9 +11,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildVersion)" />
+    <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildVersion)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
+    <PackageReference Include="Moq" Version="$(MoqVersion)" />
     <PackageReference Include="NuGet.Packaging" Version="$(NuGetInMSBuildVersion)" />
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />

--- a/test/NuGet.Tasks.Tests/PackageLineupPolicyTests.cs
+++ b/test/NuGet.Tasks.Tests/PackageLineupPolicyTests.cs
@@ -1,0 +1,126 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading;
+using BuildTools.Tasks.Tests;
+using Microsoft.Build.Utilities;
+using Moq;
+using NuGet.Frameworks;
+using NuGet.Packaging;
+using NuGet.Packaging.Core;
+using NuGet.Tasks.Lineup;
+using NuGet.Tasks.Policies;
+using NuGet.Tasks.ProjectModel;
+using NuGet.Versioning;
+using Xunit;
+using Task = System.Threading.Tasks.Task;
+
+namespace NuGet.Tasks.Tests
+{
+    public class PackageLineupPolicyTests
+    {
+        [Fact]
+        public async Task CreatesRestoreRequests()
+        {
+            var requests = new[]
+            {
+                new TaskItem("Example.Lineup", new Hashtable{ ["Version"] = "1.0.0-*" })
+            };
+
+            RestoreContext restoreArgs = null;
+            var mockCommand = new Mock<IRestoreLineupCommand>();
+            mockCommand.Setup(i => i.ExecuteAsync(It.IsAny<RestoreContext>(), It.IsAny<CancellationToken>()))
+                .Callback<RestoreContext, CancellationToken>((ctx, _) =>
+                {
+                    restoreArgs = ctx;
+                })
+                .Returns(Task.FromResult(true));
+
+            var policy = new PackageLineupPolicy(requests, mockCommand.Object);
+            await policy.ApplyAsync(new PolicyContext { Log = new TaskLoggingHelper(new MockEngine(), "TestTask"), }, default(CancellationToken));
+            mockCommand.VerifyAll();
+
+            Assert.NotNull(restoreArgs);
+
+            var request = Assert.Single(restoreArgs.PackageLineups);
+            Assert.Equal("Example.Lineup", request.Id);
+            Assert.Equal(VersionRange.Parse("1.0.0-*"), request.Version);
+        }
+
+        [Fact]
+        public async Task GeneratesMSBuildFile()
+        {
+            // arrange
+            var mockCommand = new Mock<IRestoreLineupCommand>();
+            mockCommand.Setup(i => i.ExecuteAsync(It.IsAny<RestoreContext>(), It.IsAny<CancellationToken>()))
+                .Callback<RestoreContext, CancellationToken>((ctx, _) =>
+                {
+                    ctx.VersionSource.AddPackagesFromLineup("SampleLineup",
+                        NuGetVersion.Parse("1.0.0"),
+                        new List<PackageDependencyGroup>
+                    {
+                        new PackageDependencyGroup(
+                            NuGetFramework.AnyFramework,
+                            new [] {
+                                new PackageDependency("Microsoft.AspNetCore", VersionRange.Parse("2.0.0")),
+                                new PackageDependency("xunit", VersionRange.Parse("2.3.0")),
+                                new PackageDependency("Microsoft.NETCore.App", VersionRange.Parse("99.99.99")),
+                            }),
+                    });
+                })
+                .Returns(Task.FromResult(true));
+
+            var policy = new PackageLineupPolicy(new[]
+            {
+                new TaskItem("Example.Lineup", new Hashtable{ ["Version"] = "1.0.0-*" })
+            },
+            mockCommand.Object);
+
+            var packageRef = new[]
+            {
+                new PackageReferenceInfo("Microsoft.NETCore.App", "2.0.0", isImplicitlyDefined: true, noWarn: false),
+                new PackageReferenceInfo("Microsoft.AspNetCore", string.Empty, false, false),
+                new PackageReferenceInfo("xunit", "2.2.0", false, false),
+            };
+
+            var framework = new[] { new ProjectFrameworkInfo(FrameworkConstants.CommonFrameworks.NetCoreApp20, packageRef) };
+            var projectDir = AppContext.BaseDirectory;
+            var project = new ProjectInfo(Path.Combine(projectDir, "Test.csproj"), null, framework, Array.Empty<DotNetCliReferenceInfo>());
+
+            var context = new PolicyContext
+            {
+                Log = new TaskLoggingHelper(new MockEngine(), "TestTask"),
+                Projects = new[] { project },
+            };
+
+            // act
+            await policy.ApplyAsync(context, default(CancellationToken));
+
+            var sb = new StringBuilder();
+            using (var writer = new StringWriter(sb))
+            {
+                project.TargetsExtension.Project.Save(writer);
+            }
+
+            var xml = sb.ToString();
+
+            // assert
+
+            Assert.Contains("<PackageLineup Include=\"SampleLineup\" Version=\"1.0.0\" />", xml);
+
+            // Should pin for PackageRef that has no version on it
+            Assert.Contains("<PackageReference Update=\"Microsoft.AspNetCore\" Version=\"2.0.0\" AutoVersion=\"true\" IsImplicitlyDefined=\"true\" />", xml);
+
+            // Should not overwrite for PackageRef that have Version
+            Assert.DoesNotContain("xunit", xml);
+
+            // May overwrite for PackageRef that have Version but are defined by the SDK
+            Assert.Contains("<PackageReference Update=\"Microsoft.NETCore.App\" Version=\"99.99.99\" AutoVersion=\"true\" IsImplicitlyDefined=\"true\" />", xml);
+        }
+    }
+}

--- a/test/NuGet.Tasks.Tests/SolutionInfoFactoryTests.cs
+++ b/test/NuGet.Tasks.Tests/SolutionInfoFactoryTests.cs
@@ -1,0 +1,95 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using NuGet.Tasks.ProjectModel;
+using Xunit;
+
+namespace NuGet.Tasks.Tests
+{
+    public class SolutionInfoFactoryTests : IDisposable
+    {
+        private readonly string _slnFile;
+
+        public SolutionInfoFactoryTests()
+        {
+            _slnFile = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        }
+
+        [Theory]
+        [InlineData("", new[] { "ClassLib1", "VsixProject" })]
+        [InlineData("Debug", new[] { "ClassLib1", "VsixProject" })]
+        [InlineData("DebugNoVSIX", new[] { "ClassLib1" })]
+        public void FindsProjectsByDefaultConfiguration(string config, string[] projects)
+        {
+            File.WriteAllText(_slnFile, @"
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26124.0
+MinimumVisualStudioVersion = 15.0.26124.0
+Project(`{2150E333-8FDC-42A3-9474-1A3956D46DE8}`) = `src`, `src`, `{6BC8A037-601B-412E-B394-92F55C01C7A6}`
+EndProject
+Project(`{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}`) = `ClassLib1`, `src\ClassLib1\ClassLib1.csproj`, `{89EF0B05-98D4-4C4D-8870-718571091F79}`
+EndProject
+Project(`{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}`) = `VsixProject`, `src\VsixProject\VsixProject.csproj`, `{86986537-8DF5-423F-A3A8-0CA568A9FFC4}`
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		DebugNoVSIX|Any CPU = DebugNoVSIX|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{89EF0B05-98D4-4C4D-8870-718571091F79}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{89EF0B05-98D4-4C4D-8870-718571091F79}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{86986537-8DF5-423F-A3A8-0CA568A9FFC4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{86986537-8DF5-423F-A3A8-0CA568A9FFC4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{89EF0B05-98D4-4C4D-8870-718571091F79}.DebugNoVSIX|Any CPU.ActiveCfg = Debug|Any CPU
+		{89EF0B05-98D4-4C4D-8870-718571091F79}.DebugNoVSIX|Any CPU.Build.0 = Debug|Any CPU
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{89EF0B05-98D4-4C4D-8870-718571091F79} = {6BC8A037-601B-412E-B394-92F55C01C7A6}
+		{86986537-8DF5-423F-A3A8-0CA568A9FFC4} = {6BC8A037-601B-412E-B394-92F55C01C7A6}
+	EndGlobalSection
+EndGlobal
+".Replace('`', '"'));
+
+            var solution = SolutionInfoFactory.Create(_slnFile, config);
+            Assert.Equal(projects.Length, solution.Projects.Count);
+            Assert.All(projects, expected => Assert.Contains(solution.Projects, proj => Path.GetFileNameWithoutExtension(proj) == expected));
+        }
+
+        [Fact]
+        public void ThrowsForBadConfigName()
+        {
+            File.WriteAllText(_slnFile, @"
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26124.0
+MinimumVisualStudioVersion = 15.0.26124.0
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal
+".Replace('`', '"'));
+
+            Assert.Throws<InvalidOperationException>(() => SolutionInfoFactory.Create(_slnFile, "Release"));
+        }
+
+        public void Dispose()
+        {
+            try
+            {
+                File.Delete(_slnFile);
+            }
+            catch { }
+        }
+    }
+}

--- a/testassets/RepoWithLineupPolicy/Directory.Build.targets
+++ b/testassets/RepoWithLineupPolicy/Directory.Build.targets
@@ -1,0 +1,5 @@
+<Project InitialTargets="EnsureKoreBuildRestored">
+  <Target Name="EnsureKoreBuildRestored" Condition=" '$(KoreBuildRestoreTargetsImported)' != 'true'">
+    <Error Text="Package references have not been pinned. Run 'build.cmd /t:Restore'." />
+  </Target>
+</Project>

--- a/testassets/RepoWithLineupPolicy/RepoWithLineupPolicy.sln
+++ b/testassets/RepoWithLineupPolicy/RepoWithLineupPolicy.sln
@@ -1,0 +1,39 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26124.0
+MinimumVisualStudioVersion = 15.0.26124.0
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{60E7422E-28AA-4858-889E-A4B9A4F2352A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestProject1", "test\TestProject1\TestProject1.csproj", "{DD34158D-FC39-43DC-AD8A-81CF5CAADA97}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{DD34158D-FC39-43DC-AD8A-81CF5CAADA97}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DD34158D-FC39-43DC-AD8A-81CF5CAADA97}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DD34158D-FC39-43DC-AD8A-81CF5CAADA97}.Debug|x64.ActiveCfg = Debug|x64
+		{DD34158D-FC39-43DC-AD8A-81CF5CAADA97}.Debug|x64.Build.0 = Debug|x64
+		{DD34158D-FC39-43DC-AD8A-81CF5CAADA97}.Debug|x86.ActiveCfg = Debug|x86
+		{DD34158D-FC39-43DC-AD8A-81CF5CAADA97}.Debug|x86.Build.0 = Debug|x86
+		{DD34158D-FC39-43DC-AD8A-81CF5CAADA97}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DD34158D-FC39-43DC-AD8A-81CF5CAADA97}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DD34158D-FC39-43DC-AD8A-81CF5CAADA97}.Release|x64.ActiveCfg = Release|x64
+		{DD34158D-FC39-43DC-AD8A-81CF5CAADA97}.Release|x64.Build.0 = Release|x64
+		{DD34158D-FC39-43DC-AD8A-81CF5CAADA97}.Release|x86.ActiveCfg = Release|x86
+		{DD34158D-FC39-43DC-AD8A-81CF5CAADA97}.Release|x86.Build.0 = Release|x86
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{DD34158D-FC39-43DC-AD8A-81CF5CAADA97} = {60E7422E-28AA-4858-889E-A4B9A4F2352A}
+	EndGlobalSection
+EndGlobal

--- a/testassets/RepoWithLineupPolicy/build/TestLineup.nuspec
+++ b/testassets/RepoWithLineupPolicy/build/TestLineup.nuspec
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
+  <metadata>
+    <id>TestLineup</id>
+    <version>1.0.0</version>
+    <authors>Test</authors>
+    <description>Test</description>
+    <packageTypes>
+      <packageType name="lineup" />
+    </packageTypes>
+  </metadata>
+</package>

--- a/testassets/RepoWithLineupPolicy/build/repo.props
+++ b/testassets/RepoWithLineupPolicy/build/repo.props
@@ -1,0 +1,11 @@
+<Project>
+  <ItemGroup>
+    <PackageLineup Include="TestLineup" Version="1.0.0" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <PolicyRestoreSources>$(BuildDir)</PolicyRestoreSources>
+    <PolicyRestorePackagesPath>$(RepositoryRoot)packages\</PolicyRestorePackagesPath>
+  </PropertyGroup>
+
+</Project>

--- a/testassets/RepoWithLineupPolicy/build/repo.targets
+++ b/testassets/RepoWithLineupPolicy/build/repo.targets
@@ -1,0 +1,18 @@
+<Project>
+  <ItemGroup>
+    <TestLineupDeps Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <TestLineupDeps Include="Moq" Version="4.7.99" />
+    <TestLineupDeps Include="xunit" Version="2.2.0" />
+    <TestLineupDeps Include="xunit.runner.visualstudio" Version="2.2.0" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <ApplyNuGetPoliciesDependsOn>$(ApplyNuGetPoliciesDependsOn);CreateLineupPackage</ApplyNuGetPoliciesDependsOn>
+  </PropertyGroup>
+
+  <Target Name="CreateLineupPackage">
+    <PackNuSpec NuSpecPath="$(MSBuildThisFileDirectory)TestLineup.nuspec"
+                DestinationFolder="$(PolicyRestoreSources)"
+                Dependencies="@(TestLineupDeps)" />
+  </Target>
+</Project>

--- a/testassets/RepoWithLineupPolicy/test/TestProject1/TestClass1.cs
+++ b/testassets/RepoWithLineupPolicy/test/TestProject1/TestClass1.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Reflection;
+using Xunit;
+
+namespace TestProject1
+{
+    public class TestClass1
+    {
+        [Fact]
+        public void HasVersion220()
+        {
+            var xunitVersion = typeof(FactAttribute).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion;
+            Assert.Equal("2.2.0", xunitVersion);
+        }
+
+        // Even though the TestLineup includes Moq, the project does not have a PackageReference to moq.
+        // This ensures that Moq is not installed into the project
+        [Fact]
+        public void DoesNotHaveMoq()
+        {
+            Assert.Null(Type.GetType("Moq.Mock, Moq, Culture=neutral, PublicKeyToken=69f491c39445e920"));
+        }
+    }
+}

--- a/testassets/RepoWithLineupPolicy/test/TestProject1/TestProject1.csproj
+++ b/testassets/RepoWithLineupPolicy/test/TestProject1/TestProject1.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+
+</Project>

--- a/testassets/RepoWithVersionRestrictionsPolicy/Directory.Build.targets
+++ b/testassets/RepoWithVersionRestrictionsPolicy/Directory.Build.targets
@@ -1,0 +1,5 @@
+<Project InitialTargets="EnsureKoreBuildRestored">
+  <Target Name="EnsureKoreBuildRestored" Condition=" '$(KoreBuildRestoreTargetsImported)' != 'true'">
+    <Error Text="Package references have not been pinned. Run 'build.cmd /t:Restore'." />
+  </Target>
+</Project>

--- a/testassets/RepoWithVersionRestrictionsPolicy/RepoWithVersionRestrictionsPolicy.sln
+++ b/testassets/RepoWithVersionRestrictionsPolicy/RepoWithVersionRestrictionsPolicy.sln
@@ -1,0 +1,39 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26124.0
+MinimumVisualStudioVersion = 15.0.26124.0
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{6BC8A037-601B-412E-B394-92F55C01C7A6}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ClassLib1", "src\ClassLib1\ClassLib1.csproj", "{EEFA9157-05D0-41CA-8E27-845B6088F9AB}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{EEFA9157-05D0-41CA-8E27-845B6088F9AB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EEFA9157-05D0-41CA-8E27-845B6088F9AB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EEFA9157-05D0-41CA-8E27-845B6088F9AB}.Debug|x64.ActiveCfg = Debug|x64
+		{EEFA9157-05D0-41CA-8E27-845B6088F9AB}.Debug|x64.Build.0 = Debug|x64
+		{EEFA9157-05D0-41CA-8E27-845B6088F9AB}.Debug|x86.ActiveCfg = Debug|x86
+		{EEFA9157-05D0-41CA-8E27-845B6088F9AB}.Debug|x86.Build.0 = Debug|x86
+		{EEFA9157-05D0-41CA-8E27-845B6088F9AB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EEFA9157-05D0-41CA-8E27-845B6088F9AB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EEFA9157-05D0-41CA-8E27-845B6088F9AB}.Release|x64.ActiveCfg = Release|x64
+		{EEFA9157-05D0-41CA-8E27-845B6088F9AB}.Release|x64.Build.0 = Release|x64
+		{EEFA9157-05D0-41CA-8E27-845B6088F9AB}.Release|x86.ActiveCfg = Release|x86
+		{EEFA9157-05D0-41CA-8E27-845B6088F9AB}.Release|x86.Build.0 = Release|x86
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{EEFA9157-05D0-41CA-8E27-845B6088F9AB} = {6BC8A037-601B-412E-B394-92F55C01C7A6}
+	EndGlobalSection
+EndGlobal

--- a/testassets/RepoWithVersionRestrictionsPolicy/build/repo.props
+++ b/testassets/RepoWithVersionRestrictionsPolicy/build/repo.props
@@ -1,0 +1,6 @@
+<Project>
+  <ItemGroup>
+    <DisallowPackageReferenceVersion Include="Debug" ErrorLevel="warn"/>
+    <DisallowPackageReferenceVersion Include="Release" ErrorLevel="error"/>
+  </ItemGroup>
+</Project>

--- a/testassets/RepoWithVersionRestrictionsPolicy/src/ClassLib1/Class1.cs
+++ b/testassets/RepoWithVersionRestrictionsPolicy/src/ClassLib1/Class1.cs
@@ -1,0 +1,8 @@
+﻿using System;
+
+namespace ClassLib1
+{
+    public class Class1
+    {
+    }
+}

--- a/testassets/RepoWithVersionRestrictionsPolicy/src/ClassLib1/ClassLib1.csproj
+++ b/testassets/RepoWithVersionRestrictionsPolicy/src/ClassLib1/ClassLib1.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="Moq" Version="4.7.49" NoWarn="true" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
PackageLineup can be specified in repo.props/targets as a way to pin a set of package references. This adds support to KoreBuild for using a nuget package as a lineup, and to pin the versions.

Details: https://github.com/aspnet/BuildTools/wiki/%5Bspec%5D-Package-version-lineups

Part of https://github.com/aspnet/KoreBuild/issues/239.

**Example usage:**
To use this feature, our repos can make the following changes:
1. Remove the `Version` attribute from PackageReference
```xml
<ItemGroup>
  <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstraction" />
</ItemGroup>
```
2. Add a package lineup to the repo.
```xml
<!-- build/repo.props -->
<ItemGroup>
  <PackageLineup Include="Internal.AspNetCore.Coherence.Lineup" Version="2.1.0-*" />
</ItemGroup>
```
3. To make the VS experience better, add the following target to the project.
```xml
<Project InitialTargets="EnsureKoreBuildRestored">
  <Target Name="EnsureKoreBuildRestored" Condition=" '$(KoreBuildRestoreTargetsImported)' != 'true'">
    <Error Text="Package references have not been pinned. Run 'build.cmd /t:Restore'." />
  </Target>
</Project>
```

cc @mikeharder @davidfowl 