### PR TITLE
Add /t:Pin so users can pin without restoring

### DIFF
--- a/modules/NuGet.Tasks/module.targets
+++ b/modules/NuGet.Tasks/module.targets
@@ -5,7 +5,6 @@
     <ApplyNuGetPoliciesDependsOn>
       $(ApplyNuGetPoliciesDependsOn);
       ResolveSolutions;
-      $(PrepareDependsOn);
     </ApplyNuGetPoliciesDependsOn>
   </PropertyGroup>
 
@@ -18,6 +17,10 @@
 
   <Target Name="GetLineups"
           Returns="@(PackageLineup)" />
+
+  <Target Name="Pin" DependsOnTargets="ApplyNuGetPolicies">
+    <Message Text="Pinning done. Run /t:Restore to install the updated versions." Importance="High" />
+  </Target>
 
   <Target Name="ApplyNuGetPolicies"
           DependsOnTargets="$(ApplyNuGetPoliciesDependsOn)"

--- a/testassets/RepoWithLineupPolicy/Directory.Build.targets
+++ b/testassets/RepoWithLineupPolicy/Directory.Build.targets
@@ -1,5 +1,11 @@
 <Project InitialTargets="EnsureKoreBuildRestored">
   <Target Name="EnsureKoreBuildRestored" Condition=" '$(KoreBuildRestoreTargetsImported)' != 'true'">
-    <Error Text="Package references have not been pinned. Run 'build.cmd /t:Restore'." />
+
+    <PropertyGroup>
+      <_BootstrapperFile Condition=" $([MSBuild]::IsOSUnixLike()) ">build.sh</_BootstrapperFile>
+      <_BootstrapperFile Condition="! $([MSBuild]::IsOSUnixLike()) ">build.cmd</_BootstrapperFile>
+    </PropertyGroup>
+
+    <Error Text="Package references have not been pinned. Run './$(_BootstrapperFile) /t:Pin'. Or, './$(_BootstrapperFile) /t:Restore' to pin and restore packages. '$(_BootstrapperFile)' can be found in '$(MSBuildThisFileDirectory)'." />
   </Target>
 </Project>

--- a/testassets/RepoWithVersionRestrictionsPolicy/Directory.Build.targets
+++ b/testassets/RepoWithVersionRestrictionsPolicy/Directory.Build.targets
@@ -1,5 +1,11 @@
 <Project InitialTargets="EnsureKoreBuildRestored">
   <Target Name="EnsureKoreBuildRestored" Condition=" '$(KoreBuildRestoreTargetsImported)' != 'true'">
-    <Error Text="Package references have not been pinned. Run 'build.cmd /t:Restore'." />
+
+    <PropertyGroup>
+      <_BootstrapperFile Condition=" $([MSBuild]::IsOSUnixLike()) ">build.sh</_BootstrapperFile>
+      <_BootstrapperFile Condition="! $([MSBuild]::IsOSUnixLike()) ">build.cmd</_BootstrapperFile>
+    </PropertyGroup>
+
+    <Error Text="Package references have not been pinned. Run './$(_BootstrapperFile) /t:Pin'. Or, './$(_BootstrapperFile) /t:Restore' to pin and restore packages. '$(_BootstrapperFile)' can be found in '$(MSBuildThisFileDirectory)'." />
   </Target>
 </Project>


### PR DESCRIPTION
For those who have VS auto-restore on, this will help avoid race conditions on writing to project.assets.json.