### PR TITLE
Remove dependency on aspnetcore-ci-dev NuGet feed

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -2,7 +2,6 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="AspNetCore" value="https://dotnet.myget.org/F/aspnetcore-ci-dev/api/v3/index.json" />
     <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
 </configuration>

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -1,16 +1,16 @@
 <Project>
   <PropertyGroup>
-    <AspNetCoreVersion>2.0.0-*</AspNetCoreVersion>
-    <CoreFxVersion>4.3.0</CoreFxVersion>
     <DotNetCliUtilsVersion>1.0.1</DotNetCliUtilsVersion>
     <DotNetProjectModelVersion>1.0.0-rc3-1-003177</DotNetProjectModelVersion>
+    <HtmlAgilityPackVersion>1.5.0-beta8</HtmlAgilityPackVersion>
     <!-- This one is OK for console tools that bundle their own version of JSON.NET -->
     <JsonNetVersion>10.0.1</JsonNetVersion>
+    <MicrosoftDotNetPlatformAbstractionsVersion>1.1.0</MicrosoftDotNetPlatformAbstractionsVersion>
+    <MonoCecilVersion>0.10.0-beta1-v2</MonoCecilVersion>
     <MoqVersion>4.7.99</MoqVersion>
-    <NetStandardPackageVersion>1.6.1</NetStandardPackageVersion>
     <NuGetPackagesVersion>4.0.0</NuGetPackagesVersion>
-    <SystemCollectionsImmutableVersion>1.4.0-*</SystemCollectionsImmutableVersion>
-    <SystemReflectionMetadataVersion>1.5.0-*</SystemReflectionMetadataVersion>
+    <SystemCollectionsImmutableVersion>1.4.0</SystemCollectionsImmutableVersion>
+    <SystemReflectionMetadataVersion>1.5.0</SystemReflectionMetadataVersion>
     <TestSdkVersion>15.3.0</TestSdkVersion>
     <XunitVersion>2.3.0-beta3-build3705</XunitVersion>
   </PropertyGroup>

--- a/build/repo.props
+++ b/build/repo.props
@@ -5,6 +5,8 @@
     <Version>$(VersionPrefix)</Version>
     <Version Condition="'$(VersionSuffix)' != ''">$(Version)-$(VersionSuffix)</Version>
     <Version Condition="'$(BuildNumber)' != ''">$(Version)-$(BuildNumber)</Version>
+
+    <DisableSharedSources>true</DisableSharedSources>
   </PropertyGroup>
 
   <ItemGroup>

--- a/files/KoreBuild/modules/sharedsources/module.props
+++ b/files/KoreBuild/modules/sharedsources/module.props
@@ -3,7 +3,7 @@
     <SharedSourcesFolder>$(RepositoryRoot)shared/</SharedSourcesFolder>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition=" '$(DisableSharedSources)' != 'true' ">
     <SharedSourceDirectories Include="$([System.IO.Directory]::GetDirectories(&quot;$(SharedSourcesFolder)&quot;, '*.Sources'))"
       Condition="Exists('$(SharedSourcesFolder)')"
       Exclude="@(ExcludeSharedSourceDirectories)" />

--- a/files/KoreBuild/modules/solutionbuild/module.props
+++ b/files/KoreBuild/modules/solutionbuild/module.props
@@ -1,0 +1,6 @@
+<Project>
+  <PropertyGroup>
+    <!-- Makes CSC error links clickable in the VS Code integrated terminal. -->
+    <SolutionProperties Condition=" '$(VSCODE_PID)' != 'true' ">$(SolutionProperties);GenerateFullPaths=true</SolutionProperties>
+  </PropertyGroup>
+</Project>

--- a/modules/BuildTools.Tasks/BuildTools.Tasks.csproj
+++ b/modules/BuildTools.Tasks/BuildTools.Tasks.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\..\shared\Microsoft.Extensions.CommandLineUtils.Sources\**\*.cs" />
     <None Include="module.props" CopyToPublishDirectory="PreserveNewest" />
     <None Include="BuildTools.Tasks.props" CopyToPublishDirectory="PreserveNewest" />
     <None Include="*.targets" CopyToPublishDirectory="PreserveNewest" />
@@ -16,9 +17,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildVersion)" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildVersion)" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildVersion)" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Extensions.CommandLineUtils.Sources" Version="$(AspNetCoreVersion)" PrivateAssets="All" />
     <PackageReference Include="Newtonsoft.Json" Version="$(JsonNetInMSBuildVersion)" />
     <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />
     <PackageReference Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataVersion)" />

--- a/modules/NuGetPackageVerifier/console/NuGetPackageVerifier.Console.csproj
+++ b/modules/NuGetPackageVerifier/console/NuGetPackageVerifier.Console.csproj
@@ -14,8 +14,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="HtmlAgilityPack" Version="1.5.0-beta8" />
-    <PackageReference Include="Mono.Cecil" Version="0.10.0-beta1-v2" />
+    <PackageReference Include="HtmlAgilityPack" Version="$(HtmlAgilityPackVersion)" />
+    <PackageReference Include="Mono.Cecil" Version="$(MonoCecilVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(JsonNetVersion)" />
     <PackageReference Include="NuGet.Packaging" Version="$(NuGetPackagesVersion)" />
   </ItemGroup>

--- a/modules/NuGetPackageVerifier/msbuild/NuGetPackageVerifier.Task.csproj
+++ b/modules/NuGetPackageVerifier/msbuild/NuGetPackageVerifier.Task.csproj
@@ -7,13 +7,12 @@
 
   <ItemGroup>
     <Content Include="build\**\*.targets" CopyToOutputDirectory="PreserveNewest" />
+    <Compile Include="..\..\..\shared\Microsoft.Extensions.CommandLineUtils.Sources\**\*.cs" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildVersion)" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildVersion)" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildVersion)" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Extensions.CommandLineUtils.Sources" Version="$(AspNetCoreVersion)" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/shared/Microsoft.Extensions.CommandLineUtils.Sources/CommandLine/AnsiConsole.cs
+++ b/shared/Microsoft.Extensions.CommandLineUtils.Sources/CommandLine/AnsiConsole.cs
@@ -1,0 +1,143 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+
+namespace Microsoft.Extensions.CommandLineUtils
+{
+    internal class AnsiConsole
+    {
+        private AnsiConsole(TextWriter writer, bool useConsoleColor)
+        {
+            Writer = writer;
+
+            _useConsoleColor = useConsoleColor;
+            if (_useConsoleColor)
+            {
+                OriginalForegroundColor = Console.ForegroundColor;
+            }
+        }
+
+        private int _boldRecursion;
+        private bool _useConsoleColor;
+
+        public static AnsiConsole GetOutput(bool useConsoleColor)
+        {
+            return new AnsiConsole(Console.Out, useConsoleColor);
+        }
+
+        public static AnsiConsole GetError(bool useConsoleColor)
+        {
+            return new AnsiConsole(Console.Error, useConsoleColor);
+        }
+
+        public TextWriter Writer { get; }
+
+        public ConsoleColor OriginalForegroundColor { get; }
+
+        private void SetColor(ConsoleColor color)
+        {
+            Console.ForegroundColor = (ConsoleColor)(((int)Console.ForegroundColor & 0x08) | ((int)color & 0x07));
+        }
+
+        private void SetBold(bool bold)
+        {
+            _boldRecursion += bold ? 1 : -1;
+            if (_boldRecursion > 1 || (_boldRecursion == 1 && !bold))
+            {
+                return;
+            }
+
+            Console.ForegroundColor = (ConsoleColor)((int)Console.ForegroundColor ^ 0x08);
+        }
+
+        public void WriteLine(string message)
+        {
+            if (!_useConsoleColor)
+            {
+                Writer.WriteLine(message);
+                return;
+            }
+
+            var escapeScan = 0;
+            for (; ;)
+            {
+                var escapeIndex = message.IndexOf("\x1b[", escapeScan);
+                if (escapeIndex == -1)
+                {
+                    var text = message.Substring(escapeScan);
+                    Writer.Write(text);
+                    break;
+                }
+                else
+                {
+                    var startIndex = escapeIndex + 2;
+                    var endIndex = startIndex;
+                    while (endIndex != message.Length &&
+                        message[endIndex] >= 0x20 &&
+                        message[endIndex] <= 0x3f)
+                    {
+                        endIndex += 1;
+                    }
+
+                    var text = message.Substring(escapeScan, escapeIndex - escapeScan);
+                    Writer.Write(text);
+                    if (endIndex == message.Length)
+                    {
+                        break;
+                    }
+
+                    switch (message[endIndex])
+                    {
+                        case 'm':
+                            int value;
+                            if (int.TryParse(message.Substring(startIndex, endIndex - startIndex), out value))
+                            {
+                                switch (value)
+                                {
+                                    case 1:
+                                        SetBold(true);
+                                        break;
+                                    case 22:
+                                        SetBold(false);
+                                        break;
+                                    case 30:
+                                        SetColor(ConsoleColor.Black);
+                                        break;
+                                    case 31:
+                                        SetColor(ConsoleColor.Red);
+                                        break;
+                                    case 32:
+                                        SetColor(ConsoleColor.Green);
+                                        break;
+                                    case 33:
+                                        SetColor(ConsoleColor.Yellow);
+                                        break;
+                                    case 34:
+                                        SetColor(ConsoleColor.Blue);
+                                        break;
+                                    case 35:
+                                        SetColor(ConsoleColor.Magenta);
+                                        break;
+                                    case 36:
+                                        SetColor(ConsoleColor.Cyan);
+                                        break;
+                                    case 37:
+                                        SetColor(ConsoleColor.Gray);
+                                        break;
+                                    case 39:
+                                        SetColor(OriginalForegroundColor);
+                                        break;
+                                }
+                            }
+                            break;
+                    }
+
+                    escapeScan = endIndex + 1;
+                }
+            }
+            Writer.WriteLine();
+        }
+    }
+}

--- a/shared/Microsoft.Extensions.CommandLineUtils.Sources/CommandLine/CommandArgument.cs
+++ b/shared/Microsoft.Extensions.CommandLineUtils.Sources/CommandLine/CommandArgument.cs
@@ -1,0 +1,29 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.Extensions.CommandLineUtils
+{
+    internal class CommandArgument
+    {
+        public CommandArgument()
+        {
+            Values = new List<string>();
+        }
+
+        public string Name { get; set; }
+        public bool ShowInHelpText { get; set; } = true;
+        public string Description { get; set; }
+        public List<string> Values { get; private set; }
+        public bool MultipleValues { get; set; }
+        public string Value
+        {
+            get
+            {
+                return Values.FirstOrDefault();
+            }
+        }
+    }
+}

--- a/shared/Microsoft.Extensions.CommandLineUtils.Sources/CommandLine/CommandLineApplication.cs
+++ b/shared/Microsoft.Extensions.CommandLineUtils.Sources/CommandLine/CommandLineApplication.cs
@@ -1,0 +1,555 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Extensions.CommandLineUtils
+{
+    internal class CommandLineApplication
+    {
+        // Indicates whether the parser should throw an exception when it runs into an unexpected argument.
+        // If this field is set to false, the parser will stop parsing when it sees an unexpected argument, and all
+        // remaining arguments, including the first unexpected argument, will be stored in RemainingArguments property.
+        private readonly bool _throwOnUnexpectedArg;
+
+        public CommandLineApplication(bool throwOnUnexpectedArg = true)
+        {
+            _throwOnUnexpectedArg = throwOnUnexpectedArg;
+            Options = new List<CommandOption>();
+            Arguments = new List<CommandArgument>();
+            Commands = new List<CommandLineApplication>();
+            RemainingArguments = new List<string>();
+            Invoke = () => 0;
+        }
+
+        public CommandLineApplication Parent { get; set; }
+        public string Name { get; set; }
+        public string FullName { get; set; }
+        public string Syntax { get; set; }
+        public string Description { get; set; }
+        public bool ShowInHelpText { get; set; } = true;
+        public string ExtendedHelpText { get; set; }
+        public readonly List<CommandOption> Options;
+        public CommandOption OptionHelp { get; private set; }
+        public CommandOption OptionVersion { get; private set; }
+        public readonly List<CommandArgument> Arguments;
+        public readonly List<string> RemainingArguments;
+        public bool IsShowingInformation { get; protected set; }  // Is showing help or version?
+        public Func<int> Invoke { get; set; }
+        public Func<string> LongVersionGetter { get; set; }
+        public Func<string> ShortVersionGetter { get; set; }
+        public readonly List<CommandLineApplication> Commands;
+        public bool AllowArgumentSeparator { get; set; }
+        public TextWriter Out { get; set; } = Console.Out;
+        public TextWriter Error { get; set; } = Console.Error;
+
+        public IEnumerable<CommandOption> GetOptions()
+        {
+            var expr = Options.AsEnumerable();
+            var rootNode = this;
+            while (rootNode.Parent != null)
+            {
+                rootNode = rootNode.Parent;
+                expr = expr.Concat(rootNode.Options.Where(o => o.Inherited));
+            }
+
+            return expr;
+        }
+
+        public CommandLineApplication Command(string name, Action<CommandLineApplication> configuration,
+            bool throwOnUnexpectedArg = true)
+        {
+            var command = new CommandLineApplication(throwOnUnexpectedArg) { Name = name, Parent = this };
+            Commands.Add(command);
+            configuration(command);
+            return command;
+        }
+
+        public CommandOption Option(string template, string description, CommandOptionType optionType)
+            => Option(template, description, optionType, _ => { }, inherited: false);
+
+        public CommandOption Option(string template, string description, CommandOptionType optionType, bool inherited)
+            => Option(template, description, optionType, _ => { }, inherited);
+
+        public CommandOption Option(string template, string description, CommandOptionType optionType, Action<CommandOption> configuration)
+            => Option(template, description, optionType, configuration, inherited: false);
+
+        public CommandOption Option(string template, string description, CommandOptionType optionType, Action<CommandOption> configuration, bool inherited)
+        {
+            var option = new CommandOption(template, optionType)
+            {
+                Description = description,
+                Inherited = inherited
+            };
+            Options.Add(option);
+            configuration(option);
+            return option;
+        }
+
+        public CommandArgument Argument(string name, string description, bool multipleValues = false)
+        {
+            return Argument(name, description, _ => { }, multipleValues);
+        }
+
+        public CommandArgument Argument(string name, string description, Action<CommandArgument> configuration, bool multipleValues = false)
+        {
+            var lastArg = Arguments.LastOrDefault();
+            if (lastArg != null && lastArg.MultipleValues)
+            {
+                var message = string.Format("The last argument '{0}' accepts multiple values. No more argument can be added.",
+                    lastArg.Name);
+                throw new InvalidOperationException(message);
+            }
+
+            var argument = new CommandArgument { Name = name, Description = description, MultipleValues = multipleValues };
+            Arguments.Add(argument);
+            configuration(argument);
+            return argument;
+        }
+
+        public void OnExecute(Func<int> invoke)
+        {
+            Invoke = invoke;
+        }
+
+        public void OnExecute(Func<Task<int>> invoke)
+        {
+            Invoke = () => invoke().Result;
+        }
+        public int Execute(params string[] args)
+        {
+            CommandLineApplication command = this;
+            CommandOption option = null;
+            IEnumerator<CommandArgument> arguments = null;
+
+            for (var index = 0; index < args.Length; index++)
+            {
+                var arg = args[index];
+                var processed = false;
+                if (!processed && option == null)
+                {
+                    string[] longOption = null;
+                    string[] shortOption = null;
+
+                    if (arg.StartsWith("--"))
+                    {
+                        longOption = arg.Substring(2).Split(new[] { ':', '=' }, 2);
+                    }
+                    else if (arg.StartsWith("-"))
+                    {
+                        shortOption = arg.Substring(1).Split(new[] { ':', '=' }, 2);
+                    }
+                    if (longOption != null)
+                    {
+                        processed = true;
+                        var longOptionName = longOption[0];
+                        option = command.GetOptions().SingleOrDefault(opt => string.Equals(opt.LongName, longOptionName, StringComparison.Ordinal));
+
+                        if (option == null)
+                        {
+                            if (string.IsNullOrEmpty(longOptionName) && !command._throwOnUnexpectedArg  && AllowArgumentSeparator)
+                            {
+                                // skip over the '--' argument separator
+                                index++;
+                            }
+
+                            HandleUnexpectedArg(command, args, index, argTypeName: "option");
+                            break;
+                        }
+
+                        // If we find a help/version option, show information and stop parsing
+                        if (command.OptionHelp == option)
+                        {
+                            command.ShowHelp();
+                            return 0;
+                        }
+                        else if (command.OptionVersion == option)
+                        {
+                            command.ShowVersion();
+                            return 0;
+                        }
+
+                        if (longOption.Length == 2)
+                        {
+                            if (!option.TryParse(longOption[1]))
+                            {
+                                command.ShowHint();
+                                throw new CommandParsingException(command, $"Unexpected value '{longOption[1]}' for option '{option.LongName}'");
+                            }
+                            option = null;
+                        }
+                        else if (option.OptionType == CommandOptionType.NoValue)
+                        {
+                            // No value is needed for this option
+                            option.TryParse(null);
+                            option = null;
+                        }
+                    }
+                    if (shortOption != null)
+                    {
+                        processed = true;
+                        option = command.GetOptions().SingleOrDefault(opt => string.Equals(opt.ShortName, shortOption[0], StringComparison.Ordinal));
+
+                        // If not a short option, try symbol option
+                        if (option == null)
+                        {
+                            option = command.GetOptions().SingleOrDefault(opt => string.Equals(opt.SymbolName, shortOption[0], StringComparison.Ordinal));
+                        }
+
+                        if (option == null)
+                        {
+                            HandleUnexpectedArg(command, args, index, argTypeName: "option");
+                            break;
+                        }
+
+                        // If we find a help/version option, show information and stop parsing
+                        if (command.OptionHelp == option)
+                        {
+                            command.ShowHelp();
+                            return 0;
+                        }
+                        else if (command.OptionVersion == option)
+                        {
+                            command.ShowVersion();
+                            return 0;
+                        }
+
+                        if (shortOption.Length == 2)
+                        {
+                            if (!option.TryParse(shortOption[1]))
+                            {
+                                command.ShowHint();
+                                throw new CommandParsingException(command, $"Unexpected value '{shortOption[1]}' for option '{option.LongName}'");
+                            }
+                            option = null;
+                        }
+                        else if (option.OptionType == CommandOptionType.NoValue)
+                        {
+                            // No value is needed for this option
+                            option.TryParse(null);
+                            option = null;
+                        }
+                    }
+                }
+
+                if (!processed && option != null)
+                {
+                    processed = true;
+                    if (!option.TryParse(arg))
+                    {
+                        command.ShowHint();
+                        throw new CommandParsingException(command, $"Unexpected value '{arg}' for option '{option.LongName}'");
+                    }
+                    option = null;
+                }
+
+                if (!processed && arguments == null)
+                {
+                    var currentCommand = command;
+                    foreach (var subcommand in command.Commands)
+                    {
+                        if (string.Equals(subcommand.Name, arg, StringComparison.OrdinalIgnoreCase))
+                        {
+                            processed = true;
+                            command = subcommand;
+                            break;
+                        }
+                    }
+
+                    // If we detect a subcommand
+                    if (command != currentCommand)
+                    {
+                        processed = true;
+                    }
+                }
+                if (!processed)
+                {
+                    if (arguments == null)
+                    {
+                        arguments = new CommandArgumentEnumerator(command.Arguments.GetEnumerator());
+                    }
+                    if (arguments.MoveNext())
+                    {
+                        processed = true;
+                        arguments.Current.Values.Add(arg);
+                    }
+                }
+                if (!processed)
+                {
+                    HandleUnexpectedArg(command, args, index, argTypeName: "command or argument");
+                    break;
+                }
+            }
+
+            if (option != null)
+            {
+                command.ShowHint();
+                throw new CommandParsingException(command, $"Missing value for option '{option.LongName}'");
+            }
+
+            return command.Invoke();
+        }
+
+        // Helper method that adds a help option
+        public CommandOption HelpOption(string template)
+        {
+            // Help option is special because we stop parsing once we see it
+            // So we store it separately for further use
+            OptionHelp = Option(template, "Show help information", CommandOptionType.NoValue);
+
+            return OptionHelp;
+        }
+
+        public CommandOption VersionOption(string template,
+            string shortFormVersion,
+            string longFormVersion = null)
+        {
+            if (longFormVersion == null)
+            {
+                return VersionOption(template, () => shortFormVersion);
+            }
+            else
+            {
+                return VersionOption(template, () => shortFormVersion, () => longFormVersion);
+            }
+        }
+
+        // Helper method that adds a version option
+        public CommandOption VersionOption(string template,
+            Func<string> shortFormVersionGetter,
+            Func<string> longFormVersionGetter = null)
+        {
+            // Version option is special because we stop parsing once we see it
+            // So we store it separately for further use
+            OptionVersion = Option(template, "Show version information", CommandOptionType.NoValue);
+            ShortVersionGetter = shortFormVersionGetter;
+            LongVersionGetter = longFormVersionGetter ?? shortFormVersionGetter;
+
+            return OptionVersion;
+        }
+
+        // Show short hint that reminds users to use help option
+        public void ShowHint()
+        {
+            if (OptionHelp != null)
+            {
+                Out.WriteLine(string.Format("Specify --{0} for a list of available options and commands.", OptionHelp.LongName));
+            }
+        }
+
+        // Show full help
+        public void ShowHelp(string commandName = null)
+        {
+            for (var cmd = this; cmd != null; cmd = cmd.Parent)
+            {
+                cmd.IsShowingInformation = true;
+            }
+
+            Out.WriteLine(GetHelpText(commandName));
+        }
+
+        public virtual string GetHelpText(string commandName = null)
+        {
+            var headerBuilder = new StringBuilder("Usage:");
+            for (var cmd = this; cmd != null; cmd = cmd.Parent)
+            {
+                headerBuilder.Insert(6, string.Format(" {0}", cmd.Name));
+            }
+
+            CommandLineApplication target;
+
+            if (commandName == null || string.Equals(Name, commandName, StringComparison.OrdinalIgnoreCase))
+            {
+                target = this;
+            }
+            else
+            {
+                target = Commands.SingleOrDefault(cmd => string.Equals(cmd.Name, commandName, StringComparison.OrdinalIgnoreCase));
+
+                if (target != null)
+                {
+                    headerBuilder.AppendFormat(" {0}", commandName);
+                }
+                else
+                {
+                    // The command name is invalid so don't try to show help for something that doesn't exist
+                    target = this;
+                }
+
+            }
+
+            var optionsBuilder = new StringBuilder();
+            var commandsBuilder = new StringBuilder();
+            var argumentsBuilder = new StringBuilder();
+
+            var arguments = target.Arguments.Where(a => a.ShowInHelpText).ToList();
+            if (arguments.Any())
+            {
+                headerBuilder.Append(" [arguments]");
+
+                argumentsBuilder.AppendLine();
+                argumentsBuilder.AppendLine("Arguments:");
+                var maxArgLen = arguments.Max(a => a.Name.Length);
+                var outputFormat = string.Format("  {{0, -{0}}}{{1}}", maxArgLen + 2);
+                foreach (var arg in arguments)
+                {
+                    argumentsBuilder.AppendFormat(outputFormat, arg.Name, arg.Description);
+                    argumentsBuilder.AppendLine();
+                }
+            }
+
+            var options = target.GetOptions().Where(o => o.ShowInHelpText).ToList();
+            if (options.Any())
+            {
+                headerBuilder.Append(" [options]");
+
+                optionsBuilder.AppendLine();
+                optionsBuilder.AppendLine("Options:");
+                var maxOptLen = options.Max(o => o.Template.Length);
+                var outputFormat = string.Format("  {{0, -{0}}}{{1}}", maxOptLen + 2);
+                foreach (var opt in options)
+                {
+                    optionsBuilder.AppendFormat(outputFormat, opt.Template, opt.Description);
+                    optionsBuilder.AppendLine();
+                }
+            }
+
+            var commands = target.Commands.Where(c => c.ShowInHelpText).ToList();
+            if (commands.Any())
+            {
+                headerBuilder.Append(" [command]");
+
+                commandsBuilder.AppendLine();
+                commandsBuilder.AppendLine("Commands:");
+                var maxCmdLen = commands.Max(c => c.Name.Length);
+                var outputFormat = string.Format("  {{0, -{0}}}{{1}}", maxCmdLen + 2);
+                foreach (var cmd in commands.OrderBy(c => c.Name))
+                {
+                    commandsBuilder.AppendFormat(outputFormat, cmd.Name, cmd.Description);
+                    commandsBuilder.AppendLine();
+                }
+
+                if (OptionHelp != null)
+                {
+                    commandsBuilder.AppendLine();
+                    commandsBuilder.AppendFormat($"Use \"{target.Name} [command] --{OptionHelp.LongName}\" for more information about a command.");
+                    commandsBuilder.AppendLine();
+                }
+            }
+
+            if (target.AllowArgumentSeparator)
+            {
+                headerBuilder.Append(" [[--] <arg>...]");
+            }
+
+            headerBuilder.AppendLine();
+
+            var nameAndVersion = new StringBuilder();
+            nameAndVersion.AppendLine(GetFullNameAndVersion());
+            nameAndVersion.AppendLine();
+
+            return nameAndVersion.ToString()
+                + headerBuilder.ToString()
+                + argumentsBuilder.ToString()
+                + optionsBuilder.ToString()
+                + commandsBuilder.ToString()
+                + target.ExtendedHelpText;
+        }
+
+        public void ShowVersion()
+        {
+            for (var cmd = this; cmd != null; cmd = cmd.Parent)
+            {
+                cmd.IsShowingInformation = true;
+            }
+
+            Out.WriteLine(FullName);
+            Out.WriteLine(LongVersionGetter());
+        }
+
+        public string GetFullNameAndVersion()
+        {
+            return ShortVersionGetter == null ? FullName : string.Format("{0} {1}", FullName, ShortVersionGetter());
+        }
+
+        public void ShowRootCommandFullNameAndVersion()
+        {
+            var rootCmd = this;
+            while (rootCmd.Parent != null)
+            {
+                rootCmd = rootCmd.Parent;
+            }
+
+            Out.WriteLine(rootCmd.GetFullNameAndVersion());
+            Out.WriteLine();
+        }
+
+        private void HandleUnexpectedArg(CommandLineApplication command, string[] args, int index, string argTypeName)
+        {
+            if (command._throwOnUnexpectedArg)
+            {
+                command.ShowHint();
+                throw new CommandParsingException(command, $"Unrecognized {argTypeName} '{args[index]}'");
+            }
+            else
+            {
+                // All remaining arguments are stored for further use
+                command.RemainingArguments.AddRange(new ArraySegment<string>(args, index, args.Length - index));
+            }
+        }
+
+        private class CommandArgumentEnumerator : IEnumerator<CommandArgument>
+        {
+            private readonly IEnumerator<CommandArgument> _enumerator;
+
+            public CommandArgumentEnumerator(IEnumerator<CommandArgument> enumerator)
+            {
+                _enumerator = enumerator;
+            }
+
+            public CommandArgument Current
+            {
+                get
+                {
+                    return _enumerator.Current;
+                }
+            }
+
+            object IEnumerator.Current
+            {
+                get
+                {
+                    return Current;
+                }
+            }
+
+            public void Dispose()
+            {
+                _enumerator.Dispose();
+            }
+
+            public bool MoveNext()
+            {
+                if (Current == null || !Current.MultipleValues)
+                {
+                    return _enumerator.MoveNext();
+                }
+
+                // If current argument allows multiple values, we don't move forward and
+                // all later values will be added to current CommandArgument.Values
+                return true;
+            }
+
+            public void Reset()
+            {
+                _enumerator.Reset();
+            }
+        }
+    }
+}

--- a/shared/Microsoft.Extensions.CommandLineUtils.Sources/CommandLine/CommandOption.cs
+++ b/shared/Microsoft.Extensions.CommandLineUtils.Sources/CommandLine/CommandOption.cs
@@ -1,0 +1,108 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.Extensions.CommandLineUtils
+{
+    internal class CommandOption
+    {
+        public CommandOption(string template, CommandOptionType optionType)
+        {
+            Template = template;
+            OptionType = optionType;
+            Values = new List<string>();
+
+            foreach (var part in Template.Split(new[] { ' ', '|' }, StringSplitOptions.RemoveEmptyEntries))
+            {
+                if (part.StartsWith("--"))
+                {
+                    LongName = part.Substring(2);
+                }
+                else if (part.StartsWith("-"))
+                {
+                    var optName = part.Substring(1);
+
+                    // If there is only one char and it is not an English letter, it is a symbol option (e.g. "-?")
+                    if (optName.Length == 1 && !IsEnglishLetter(optName[0]))
+                    {
+                        SymbolName = optName;
+                    }
+                    else
+                    {
+                        ShortName = optName;
+                    }
+                }
+                else if (part.StartsWith("<") && part.EndsWith(">"))
+                {
+                    ValueName = part.Substring(1, part.Length - 2);
+                }
+                else
+                {
+                    throw new ArgumentException($"Invalid template pattern '{template}'", nameof(template));
+                }
+            }
+
+            if (string.IsNullOrEmpty(LongName) && string.IsNullOrEmpty(ShortName) && string.IsNullOrEmpty(SymbolName))
+            {
+                throw new ArgumentException($"Invalid template pattern '{template}'", nameof(template));
+            }
+        }
+
+        public string Template { get; set; }
+        public string ShortName { get; set; }
+        public string LongName { get; set; }
+        public string SymbolName { get; set; }
+        public string ValueName { get; set; }
+        public string Description { get; set; }
+        public List<string> Values { get; private set; }
+        public CommandOptionType OptionType { get; private set; }
+        public bool ShowInHelpText { get; set; } = true;
+        public bool Inherited { get; set; }
+
+        public bool TryParse(string value)
+        {
+            switch (OptionType)
+            {
+                case CommandOptionType.MultipleValue:
+                    Values.Add(value);
+                    break;
+                case CommandOptionType.SingleValue:
+                    if (Values.Any())
+                    {
+                        return false;
+                    }
+                    Values.Add(value);
+                    break;
+                case CommandOptionType.NoValue:
+                    if (value != null)
+                    {
+                        return false;
+                    }
+                    // Add a value to indicate that this option was specified
+                    Values.Add("on");
+                    break;
+                default:
+                    break;
+            }
+            return true;
+        }
+
+        public bool HasValue()
+        {
+            return Values.Any();
+        }
+
+        public string Value()
+        {
+            return HasValue() ? Values[0] : null;
+        }
+
+        private bool IsEnglishLetter(char c)
+        {
+            return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z');
+        }
+    }
+}

--- a/shared/Microsoft.Extensions.CommandLineUtils.Sources/CommandLine/CommandOptionType.cs
+++ b/shared/Microsoft.Extensions.CommandLineUtils.Sources/CommandLine/CommandOptionType.cs
@@ -1,0 +1,13 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+
+namespace Microsoft.Extensions.CommandLineUtils
+{
+    internal enum CommandOptionType
+    {
+        MultipleValue,
+        SingleValue,
+        NoValue
+    }
+}

--- a/shared/Microsoft.Extensions.CommandLineUtils.Sources/CommandLine/CommandParsingException.cs
+++ b/shared/Microsoft.Extensions.CommandLineUtils.Sources/CommandLine/CommandParsingException.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.Extensions.CommandLineUtils
+{
+    internal class CommandParsingException : Exception
+    {
+        public CommandParsingException(CommandLineApplication command, string message)
+            : base(message)
+        {
+            Command = command;
+        }
+
+        public CommandLineApplication Command { get; }
+    }
+}

--- a/shared/Microsoft.Extensions.CommandLineUtils.Sources/Utilities/ArgumentEscaper.cs
+++ b/shared/Microsoft.Extensions.CommandLineUtils.Sources/Utilities/ArgumentEscaper.cs
@@ -1,0 +1,109 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Microsoft.Extensions.CommandLineUtils
+{
+    /// <summary>
+    /// A utility for escaping arguments for new processes.
+    /// </summary>
+    internal static class ArgumentEscaper
+    {
+        /// <summary>
+        /// Undo the processing which took place to create string[] args in Main, so that the next process will
+        /// receive the same string[] args.
+        /// </summary>
+        /// <remarks>
+        /// See https://blogs.msdn.microsoft.com/twistylittlepassagesallalike/2011/04/23/everyone-quotes-command-line-arguments-the-wrong-way/
+        /// </remarks>
+        /// <param name="args"></param>
+        /// <returns></returns>
+        public static string EscapeAndConcatenate(IEnumerable<string> args)
+            => string.Join(" ", args.Select(EscapeSingleArg));
+
+        private static string EscapeSingleArg(string arg)
+        {
+            var sb = new StringBuilder();
+
+            var needsQuotes = ShouldSurroundWithQuotes(arg);
+            var isQuoted = needsQuotes || IsSurroundedWithQuotes(arg);
+
+            if (needsQuotes)
+            {
+                sb.Append('"');
+            }
+
+            for (int i = 0; i < arg.Length; ++i)
+            {
+                var backslashes = 0;
+
+                // Consume all backslashes
+                while (i < arg.Length && arg[i] == '\\')
+                {
+                    backslashes++;
+                    i++;
+                }
+
+                if (i == arg.Length && isQuoted)
+                {
+                    // Escape any backslashes at the end of the arg when the argument is also quoted.
+                    // This ensures the outside quote is interpreted as an argument delimiter
+                    sb.Append('\\', 2 * backslashes);
+                }
+                else if (i == arg.Length)
+                {
+                    // At then end of the arg, which isn't quoted,
+                    // just add the backslashes, no need to escape
+                    sb.Append('\\', backslashes);
+                }
+                else if (arg[i] == '"')
+                {
+                    // Escape any preceding backslashes and the quote
+                    sb.Append('\\', (2 * backslashes) + 1);
+                    sb.Append('"');
+                }
+                else
+                {
+                    // Output any consumed backslashes and the character
+                    sb.Append('\\', backslashes);
+                    sb.Append(arg[i]);
+                }
+            }
+
+            if (needsQuotes)
+            {
+                sb.Append('"');
+            }
+
+            return sb.ToString();
+        }
+
+        private static bool ShouldSurroundWithQuotes(string argument)
+        {
+            // Don't quote already quoted strings
+            if (IsSurroundedWithQuotes(argument))
+            {
+                return false;
+            }
+
+            // Only quote if whitespace exists in the string
+            return ContainsWhitespace(argument);
+        }
+
+        private static bool IsSurroundedWithQuotes(string argument)
+        {
+            if (argument.Length <= 1)
+            {
+                return false;
+            }
+
+            return argument[0] == '"' && argument[argument.Length - 1] == '"';
+        }
+
+        private static bool ContainsWhitespace(string argument)
+            => argument.IndexOfAny(new [] { ' ', '\t', '\n' }) >= 0;
+    }
+}

--- a/shared/Microsoft.Extensions.CommandLineUtils.Sources/Utilities/DotNetMuxer.cs
+++ b/shared/Microsoft.Extensions.CommandLineUtils.Sources/Utilities/DotNetMuxer.cs
@@ -1,0 +1,82 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+// System.AppContext.GetData is not available in these frameworks
+#if !NET451 && !NET452 && !NET46 && !NET461
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.Extensions.CommandLineUtils
+{
+    /// <summary>
+    /// Utilities for finding the "dotnet.exe" file from the currently running .NET Core application
+    /// </summary>
+    internal static class DotNetMuxer
+    {
+        private const string MuxerName = "dotnet";
+
+        static DotNetMuxer()
+        {
+            MuxerPath = TryFindMuxerPath();
+        }
+
+        /// <summary>
+        /// The full filepath to the .NET Core muxer.
+        /// </summary>
+        public static string MuxerPath { get; }
+
+        /// <summary>
+        /// Finds the full filepath to the .NET Core muxer,
+        /// or returns a string containing the default name of the .NET Core muxer ('dotnet').
+        /// </summary>
+        /// <returns>The path or a string named 'dotnet'</returns>
+        public static string MuxerPathOrDefault()
+            => MuxerPath ?? MuxerName;
+
+        private static string TryFindMuxerPath()
+        {
+            var fileName = MuxerName;
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                fileName += ".exe";
+            }
+
+            var mainModule = Process.GetCurrentProcess().MainModule;
+            if (!string.IsNullOrEmpty(mainModule?.FileName)
+                && Path.GetFileName(mainModule.FileName).Equals(fileName, StringComparison.OrdinalIgnoreCase))
+            {
+                return mainModule.FileName;
+            }
+
+            // if Process.MainModule is not available or it does not equal "dotnet(.exe)?", fallback to navigating to the muxer
+            // by using the location of the shared framework
+
+            var fxDepsFile = AppContext.GetData("FX_DEPS_FILE") as string;
+
+            if (string.IsNullOrEmpty(fxDepsFile))
+            {
+                return null;
+            }
+
+            var muxerDir = new FileInfo(fxDepsFile) // Microsoft.NETCore.App.deps.json
+                .Directory? // (version)
+                .Parent? // Microsoft.NETCore.App
+                .Parent? // shared
+                .Parent; // DOTNET_HOME
+
+            if (muxerDir == null)
+            {
+                return null;
+            }
+
+            var muxer = Path.Combine(muxerDir.FullName, fileName);
+            return File.Exists(muxer)
+                ? muxer
+                : null;
+        }
+    }
+}
+#endif

--- a/src/ApiCheck.Console/ApiCheck.Console.csproj
+++ b/src/ApiCheck.Console/ApiCheck.Console.csproj
@@ -14,8 +14,6 @@
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.0' ">
-    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
-
     <!-- Don't try to compile the *.cs files on netstandard1.0. -->
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
@@ -32,15 +30,12 @@
     <PublishDir>$(IntermediatePackDir)$(TargetFramework)\</PublishDir>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.0' ">
-    <PackageReference Include="NETStandard.Library" Version="$(NetStandardPackageVersion)" PrivateAssets="All" />
-  </ItemGroup>
-
   <ItemGroup Condition=" '$(TargetFramework)' != 'netstandard1.0' ">
-    <PackageReference Include="Microsoft.Extensions.CommandLineUtils.Sources" Version="$(AspNetCoreVersion)" PrivateAssets="All" />
+    <Compile Include="..\..\shared\Microsoft.Extensions.CommandLineUtils.Sources\**\*.cs" />
+
     <PackageReference Include="Newtonsoft.Json" Version="$(JsonNetVersion)" />
     <PackageReference Include="NuGet.ProjectModel" Version="$(NuGetPackagesVersion)" />
-    <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="1.1.0" />
+    <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="$(MicrosoftDotNetPlatformAbstractionsVersion)" />
   </ItemGroup>
 
   <Target Name="PublishAll">

--- a/src/ApiCheck.Console/Microsoft.AspNetCore.BuildTools.ApiCheck.nuspec
+++ b/src/ApiCheck.Console/Microsoft.AspNetCore.BuildTools.ApiCheck.nuspec
@@ -13,6 +13,6 @@
     <file src="build\**" target="build\" />
     <file src="$publishDir$\net46\**" target="tools\net46\" />
     <file src="$publishDir$\netcoreapp2.0\**" target="tools\netcoreapp2.0\" />
-    <file src="$taskBuildDir$\netstandard1.6\*.dll" target="tools\netstandard1.6\" />
+    <file src="$taskBuildDir$\netstandard2.0\*.dll" target="tools\netstandard2.0\" />
   </files>
 </package>

--- a/src/ApiCheck.Console/build/Microsoft.AspNetCore.BuildTools.ApiCheck.props
+++ b/src/ApiCheck.Console/build/Microsoft.AspNetCore.BuildTools.ApiCheck.props
@@ -4,7 +4,7 @@
 -->
 <Project>
   <PropertyGroup>
-    <_ApiCheckTaskAssembly>$(MSBuildThisFileDirectory)..\tools\netstandard1.6\Microsoft.AspNetCore.BuildTools.ApiCheck.Task.dll</_ApiCheckTaskAssembly>
+    <_ApiCheckTaskAssembly>$(MSBuildThisFileDirectory)..\tools\netstandard2.0\Microsoft.AspNetCore.BuildTools.ApiCheck.Task.dll</_ApiCheckTaskAssembly>
   </PropertyGroup>
 
   <UsingTask TaskName="Microsoft.AspNetCore.BuildTools.ApiCheck.Task.ApiCheckTask"

--- a/src/ApiCheck.Task/ApiCheck.Task.csproj
+++ b/src/ApiCheck.Task/ApiCheck.Task.csproj
@@ -2,16 +2,18 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.6</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <AssemblyName>Microsoft.AspNetCore.BuildTools.ApiCheck.Task</AssemblyName>
     <RootNamespace>Microsoft.AspNetCore.BuildTools.ApiCheck.Task</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\..\shared\Microsoft.Extensions.CommandLineUtils.Sources\**\*.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildVersion)" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildVersion)" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildVersion)" />
-    <PackageReference Include="Microsoft.Extensions.CommandLineUtils.Sources" Version="$(AspNetCoreVersion)" PrivateAssets="All" />
   </ItemGroup>
 </Project>

--- a/src/Internal.AspNetCore.Sdk/Internal.AspNetCore.Sdk.csproj
+++ b/src/Internal.AspNetCore.Sdk/Internal.AspNetCore.Sdk.csproj
@@ -19,13 +19,12 @@
   <ItemGroup>
     <Compile Include="$(BuildToolsPath)*.cs" />
     <Compile Include="$(BuildToolsPath)Utilities\*.cs" />
+    <Compile Include="..\..\shared\Microsoft.Extensions.CommandLineUtils.Sources\**\*.cs" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildVersion)" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildVersion)" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildVersion)" />
-    <PackageReference Include="Microsoft.Extensions.CommandLineUtils.Sources" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(JsonNetInMSBuildVersion)" />
     <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" PrivateAssets="All" />
     <PackageReference Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataVersion)" PrivateAssets="All" />

--- a/src/VersionTool/VersionTool.csproj
+++ b/src/VersionTool/VersionTool.csproj
@@ -9,10 +9,13 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\..\shared\Microsoft.Extensions.CommandLineUtils.Sources\**\*.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <!-- Pinned while we wait for https://github.com/aspnet/BuildTools/issues/270 -->
     <PackageReference Include="Microsoft.DotNet.Cli.Utils" Version="1.0.0-preview2-1-003177" />
     <PackageReference Include="Microsoft.DotNet.ProjectModel" Version="$(DotNetProjectModelVersion)" />
-    <PackageReference Include="Microsoft.Extensions.CommandLineUtils.Sources" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
 
  <!-- packaging settings -->

--- a/test/BuildTools.Tasks.Tests/BuildTools.Tasks.Tests.csproj
+++ b/test/BuildTools.Tasks.Tests/BuildTools.Tasks.Tests.csproj
@@ -14,7 +14,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildVersion)" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildVersion)" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildVersion)" />
     <PackageReference Include="Microsoft.DotNet.Cli.Utils" Version="$(DotNetCliUtilsVersion)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />

--- a/test/KoreBuild.FunctionalTests/KoreBuild.FunctionalTests.csproj
+++ b/test/KoreBuild.FunctionalTests/KoreBuild.FunctionalTests.csproj
@@ -7,7 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.CommandLineUtils.Sources" Version="$(AspNetCoreVersion)" PrivateAssets="All" />
+    <Compile Include="..\..\shared\Microsoft.Extensions.CommandLineUtils.Sources\**\*.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />


### PR DESCRIPTION
Solves the 🐔 and 🍳 problem of building BuildTools if aspnetcore-ci-dev were to be cleared.

This required duplicating Microsoft.Extensions.CommandLineUtils.Sources into this repo.

cc @mikeharder - build from source