### PR TITLE
Upgrade Cecil, NuGet, xunit, and HtmlAgilityPack to latest stable versions

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -2,17 +2,18 @@
   <PropertyGroup>
     <DotNetCliUtilsVersion>1.0.1</DotNetCliUtilsVersion>
     <DotNetProjectModelVersion>1.0.0-rc3-1-003177</DotNetProjectModelVersion>
-    <HtmlAgilityPackVersion>1.5.0-beta8</HtmlAgilityPackVersion>
+    <HtmlAgilityPackVersion>1.5.1</HtmlAgilityPackVersion>
     <!-- This one is OK for console tools that bundle their own version of JSON.NET -->
     <JsonNetVersion>10.0.1</JsonNetVersion>
-    <MicrosoftDotNetPlatformAbstractionsVersion>1.1.0</MicrosoftDotNetPlatformAbstractionsVersion>
-    <MonoCecilVersion>0.10.0-beta1-v2</MonoCecilVersion>
+    <MicrosoftDotNetPlatformAbstractionsVersion>2.0.0</MicrosoftDotNetPlatformAbstractionsVersion>
+    <MonoCecilVersion>0.10.0-beta6</MonoCecilVersion>
     <MoqVersion>4.7.99</MoqVersion>
-    <NuGetPackagesVersion>4.0.0</NuGetPackagesVersion>
+    <NuGetPackagesVersion>4.3.0</NuGetPackagesVersion>
     <SystemCollectionsImmutableVersion>1.4.0</SystemCollectionsImmutableVersion>
     <SystemReflectionMetadataVersion>1.5.0</SystemReflectionMetadataVersion>
     <TestSdkVersion>15.3.0</TestSdkVersion>
-    <XunitVersion>2.3.0-beta3-build3705</XunitVersion>
+    <XunitVersion>2.3.0-beta4-build3742</XunitVersion>
+    <XunitAnalyzersVersion>0.6.1</XunitAnalyzersVersion>
   </PropertyGroup>
 
   <!--

--- a/modules/NuGet.Tasks/Internal/KoreBuildErrors.cs
+++ b/modules/NuGet.Tasks/Internal/KoreBuildErrors.cs
@@ -5,6 +5,9 @@ namespace NuGet.Tasks
 {
     public static class KoreBuildErrors
     {
+        // Typically used in repos in Directory.Build.targets
+        public const int PackagesHaveNotYetBeenPinned = 1001;
+
         public const int InvalidNuspecFile = 4001;
 
         // see Policy.NoVersions.targets

--- a/modules/NuGetPackageVerifier/console/Extensions/PackageArchiveReaderExtensions.cs
+++ b/modules/NuGetPackageVerifier/console/Extensions/PackageArchiveReaderExtensions.cs
@@ -1,0 +1,57 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using NuGet.Packaging;
+using NuGet.Packaging.Core;
+using NuGet.Versioning;
+
+namespace NuGetPackageVerifier
+{
+    public static class PackageArchiveReaderExtensions
+    {
+        /// <summary>
+        /// A package is deemed to be a satellite package if it has a language property set, the id of the package is
+        /// of the format [.*].[Language]
+        /// and it has at least one dependency with an id that maps to the runtime package .
+        /// </summary>
+        public static bool IsSatellitePackage(this IPackageCoreReader packageReader)
+        {
+            // A satellite package has the following properties:
+            //     1) A package suffix that matches the package's language, with a dot preceding it
+            //     2) A dependency on the package with the same Id minus the language suffix
+            //     3) The dependency can be found by Id in the repository (as its path is needed for installation)
+            // Example: foo.ja-jp, with a dependency on foo
+
+            var nuspecReader = new NuspecReader(packageReader.GetNuspec());
+            var packageId = nuspecReader.GetId();
+            var packageLanguage = nuspecReader.GetLanguage();
+
+            if (!string.IsNullOrEmpty(packageLanguage)
+                &&
+                packageId.EndsWith('.' + packageLanguage, StringComparison.OrdinalIgnoreCase))
+            {
+                // The satellite pack's Id is of the format <Core-Package-Id>.<Language>. Extract the core package id using this.
+                // Additionally satellite packages have a strict dependency on the core package
+                var localruntimePackageId = packageId.Substring(0, packageId.Length - packageLanguage.Length - 1);
+
+                foreach (var group in nuspecReader.GetDependencyGroups())
+                {
+                    foreach (var dependencyPackage in group.Packages)
+                    {
+                        if (dependencyPackage.Id.Equals(localruntimePackageId, StringComparison.OrdinalIgnoreCase)
+                            && dependencyPackage.VersionRange != null
+                            && dependencyPackage.VersionRange.MaxVersion == dependencyPackage.VersionRange.MinVersion
+                            && dependencyPackage.VersionRange.IsMaxInclusive
+                            && dependencyPackage.VersionRange.IsMinInclusive)
+                        {
+                            return true;
+                        }
+                    }
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/modules/NuGetPackageVerifier/console/Rules/AssemblyHasDocumentFileRule.cs
+++ b/modules/NuGetPackageVerifier/console/Rules/AssemblyHasDocumentFileRule.cs
@@ -19,7 +19,7 @@ namespace NuGetPackageVerifier.Rules
                 yield break;
             }
 
-            if (!PackageHelper.IsSatellitePackage(context.PackageReader, out var _, out var _))
+            if (!context.PackageReader.IsSatellitePackage())
             {
                 var allXmlFiles =
                     from item in context.PackageReader.GetLibItems()

--- a/modules/NuGetPackageVerifier/console/Rules/SatellitePackageRule.cs
+++ b/modules/NuGetPackageVerifier/console/Rules/SatellitePackageRule.cs
@@ -10,7 +10,7 @@ namespace NuGetPackageVerifier.Rules
     {
         public IEnumerable<PackageVerifierIssue> Validate(PackageAnalysisContext context)
         {
-            if (PackageHelper.IsSatellitePackage(context.PackageReader, out var _, out var _))
+            if (context.PackageReader.IsSatellitePackage())
             {
                 if (context.Metadata.Summary.Contains("{"))
                 {

--- a/test/ApiCheck.Test/ApiCheck.Test.csproj
+++ b/test/ApiCheck.Test/ApiCheck.Test.csproj
@@ -16,6 +16,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
+    <PackageReference Include="xunit.analyzers" Version="$(XunitAnalyzersVersion)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
   </ItemGroup>
 

--- a/test/ApiCheck.Test/ApiListingGenerationTests.cs
+++ b/test/ApiCheck.Test/ApiListingGenerationTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Reflection;
 using ApiCheck.Description;
@@ -178,7 +178,7 @@ namespace ApiCheck.Test
             Assert.NotNull(report);
             Assert.NotNull(report.Types);
             var type = Assert.Single(report.Types, t => t.Id == "public class Scenarios.MethodTypesClass");
-            Assert.False(type.Members.Any(m => m.Id == "protected internal System.String ProtectedInternalStringReturningMethodWithStringParameter(System.String stringParameter)"));
+            Assert.DoesNotContain(type.Members, m => m.Id == "protected internal System.String ProtectedInternalStringReturningMethodWithStringParameter(System.String stringParameter)");
         }
 
         [Fact]
@@ -210,7 +210,7 @@ namespace ApiCheck.Test
             Assert.NotNull(report);
             Assert.NotNull(report.Types);
             var type = Assert.Single(report.Types, t => t.Id == "public class Scenarios.MethodTypesClass");
-            Assert.False(type.Members.Any(m => m.Id == "private System.Boolean PrivateBoolReturningMethodWithOptionalCharParameter(System.Char charParameter = 'c')"));
+            Assert.DoesNotContain(type.Members, m => m.Id == "private System.Boolean PrivateBoolReturningMethodWithOptionalCharParameter(System.Char charParameter = 'c')");
         }
 
         [Fact]
@@ -336,7 +336,7 @@ namespace ApiCheck.Test
             // Assert
             Assert.NotNull(report);
             Assert.NotNull(report.Types);
-            Assert.False(report.Types.Any(t => t.Id == "internal class Scenarios.NestedTypesClass+InternalNestedClass"));
+            Assert.DoesNotContain(report.Types, t => t.Id == "internal class Scenarios.NestedTypesClass+InternalNestedClass");
         }
 
         [Fact]
@@ -351,7 +351,7 @@ namespace ApiCheck.Test
             // Assert
             Assert.NotNull(report);
             Assert.NotNull(report.Types);
-            Assert.False(report.Types.Any(t => t.Id == "private class Scenarios.NestedTypesClass+PrivateNestedClass"));
+            Assert.DoesNotContain(report.Types, t => t.Id == "private class Scenarios.NestedTypesClass+PrivateNestedClass");
         }
 
         [Fact]
@@ -646,7 +646,7 @@ namespace ApiCheck.Test
             Assert.NotNull(report);
             Assert.NotNull(report.Types);
             var type = Assert.Single(report.Types, t => t.Id == "public class Scenarios.ExplicitImplementationClass : Scenarios.IInterfaceForExplicitImplementation");
-            Assert.False(type.Members.Any(m => m.Id == "System.Void Scenarios.IInterfaceForExplicitImplementation.ExplicitImplementationMethod()"));
+            Assert.DoesNotContain(type.Members, m => m.Id == "System.Void Scenarios.IInterfaceForExplicitImplementation.ExplicitImplementationMethod()");
         }
 
         [Fact]
@@ -662,7 +662,7 @@ namespace ApiCheck.Test
             Assert.NotNull(report);
             Assert.NotNull(report.Types);
             var type = Assert.Single(report.Types, t => t.Id == "public class Scenarios.ClassDerivingClassReimplementingInterface : Scenarios.OriginalClassImplementingInterface, Scenarios.IBasicInterfaceForInterfaceReimplementation");
-            Assert.False(type.Members.Any(m => m.Id == "System.Void Scenarios.IBasicInterfaceForInterfaceReimplementation.A()"));
+            Assert.DoesNotContain(type.Members, m => m.Id == "System.Void Scenarios.IBasicInterfaceForInterfaceReimplementation.A()");
         }
 
         [Fact]

--- a/test/BuildTools.Tasks.Tests/BuildTools.Tasks.Tests.csproj
+++ b/test/BuildTools.Tasks.Tests/BuildTools.Tasks.Tests.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="Microsoft.DotNet.Cli.Utils" Version="$(DotNetCliUtilsVersion)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
+    <PackageReference Include="xunit.analyzers" Version="$(XunitAnalyzersVersion)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
   </ItemGroup>
 

--- a/test/KoreBuild.FunctionalTests/KoreBuild.FunctionalTests.csproj
+++ b/test/KoreBuild.FunctionalTests/KoreBuild.FunctionalTests.csproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
+    <PackageReference Include="xunit.analyzers" Version="$(XunitAnalyzersVersion)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
   </ItemGroup>
 

--- a/test/NuGet.Tasks.Tests/NuGet.Tasks.Tests.csproj
+++ b/test/NuGet.Tasks.Tests/NuGet.Tasks.Tests.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="Moq" Version="$(MoqVersion)" />
     <PackageReference Include="NuGet.Build.Tasks" Version="$(NuGetInMSBuildVersion)" />
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
+    <PackageReference Include="xunit.analyzers" Version="$(XunitAnalyzersVersion)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
   </ItemGroup>
 

--- a/test/NuGet.Tasks.Tests/PackNuSpecTests.cs
+++ b/test/NuGet.Tasks.Tests/PackNuSpecTests.cs
@@ -157,8 +157,9 @@ namespace NuGet.Tasks.Tests
                 Assert.Single(noTfmGroup.Packages, p => p.Id == "AlreadyInNuspec" && p.VersionRange.Equals(VersionRange.Parse("[2.0.0]")));
 
                 var netstandard10Group = Assert.Single(metadata.DependencyGroups, d => d.TargetFramework.Equals(FrameworkConstants.CommonFrameworks.NetStandard10));
-                Assert.Equal(1, netstandard10Group.Packages.Count());
-                Assert.Single(netstandard10Group.Packages, p => p.Id == "PackageInTfm" && p.VersionRange.Equals(VersionRange.Parse("0.1.0-beta")));
+                var package = Assert.Single(netstandard10Group.Packages);
+                Assert.Equal("PackageInTfm", package.Id);
+                Assert.Equal(VersionRange.Parse("0.1.0-beta"), package.VersionRange);
             }
         }
 

--- a/testassets/RepoWithLineupPolicy/Directory.Build.targets
+++ b/testassets/RepoWithLineupPolicy/Directory.Build.targets
@@ -1,11 +1,14 @@
 <Project InitialTargets="EnsureKoreBuildRestored">
-  <Target Name="EnsureKoreBuildRestored" Condition=" '$(KoreBuildRestoreTargetsImported)' != 'true'">
-
+  <Target Name="EnsureKoreBuildRestored" Condition=" '$(KoreBuildRestoreTargetsImported)' != 'true' ">
     <PropertyGroup>
       <_BootstrapperFile Condition=" $([MSBuild]::IsOSUnixLike()) ">build.sh</_BootstrapperFile>
       <_BootstrapperFile Condition="! $([MSBuild]::IsOSUnixLike()) ">build.cmd</_BootstrapperFile>
+      <_BootstrapperError>
+        Package references have not been pinned. Run './$(_BootstrapperFile) /t:Pin'.
+        Also, you can run './$(_BootstrapperFile) /t:Restore' which will pin *and* restore packages. '$(_BootstrapperFile)' can be found in '$(MSBuildThisFileDirectory)'.
+      </_BootstrapperError>
     </PropertyGroup>
 
-    <Error Text="Package references have not been pinned. Run './$(_BootstrapperFile) /t:Pin'. Or, './$(_BootstrapperFile) /t:Restore' to pin and restore packages. '$(_BootstrapperFile)' can be found in '$(MSBuildThisFileDirectory)'." />
+    <Error Code="KRB1001" Text="$(_BootstrapperError.Trim())" />
   </Target>
 </Project>

--- a/testassets/RepoWithVersionRestrictionsPolicy/Directory.Build.targets
+++ b/testassets/RepoWithVersionRestrictionsPolicy/Directory.Build.targets
@@ -1,11 +1,14 @@
 <Project InitialTargets="EnsureKoreBuildRestored">
-  <Target Name="EnsureKoreBuildRestored" Condition=" '$(KoreBuildRestoreTargetsImported)' != 'true'">
-
+  <Target Name="EnsureKoreBuildRestored" Condition=" '$(KoreBuildRestoreTargetsImported)' != 'true' ">
     <PropertyGroup>
       <_BootstrapperFile Condition=" $([MSBuild]::IsOSUnixLike()) ">build.sh</_BootstrapperFile>
       <_BootstrapperFile Condition="! $([MSBuild]::IsOSUnixLike()) ">build.cmd</_BootstrapperFile>
+      <_BootstrapperError>
+        Package references have not been pinned. Run './$(_BootstrapperFile) /t:Pin'.
+        Also, you can run './$(_BootstrapperFile) /t:Restore' which will pin *and* restore packages. '$(_BootstrapperFile)' can be found in '$(MSBuildThisFileDirectory)'.
+      </_BootstrapperError>
     </PropertyGroup>
 
-    <Error Text="Package references have not been pinned. Run './$(_BootstrapperFile) /t:Pin'. Or, './$(_BootstrapperFile) /t:Restore' to pin and restore packages. '$(_BootstrapperFile)' can be found in '$(MSBuildThisFileDirectory)'." />
+    <Error Code="KRB1001" Text="$(_BootstrapperError.Trim())" />
   </Target>
 </Project>


### PR DESCRIPTION
Major change required: NuGet made their .IsSatellitePackage() function internal only in 4.3.0.

Also, I tried upgrading to xunit 2.3.0-beta4. It adds new analyzers that found some issues in the tests. I've corrected those here, but left out the actual update to beta4 because xunit crashes with an analyzer error: https://github.com/xunit/xunit/issues/1406