### PR TITLE
Treat NoWarn as a list of codes, not a boolean

### DIFF
--- a/modules/NuGet.Tasks/Internal/KoreBuildErrors.cs
+++ b/modules/NuGet.Tasks/Internal/KoreBuildErrors.cs
@@ -5,12 +5,13 @@ namespace NuGet.Tasks
 {
     public static class KoreBuildErrors
     {
+        public const string Prefix = "KRB";
+
         // Typically used in repos in Directory.Build.targets
         public const int PackagesHaveNotYetBeenPinned = 1001;
 
         public const int InvalidNuspecFile = 4001;
 
-        // see Policy.NoVersions.targets
         public const int PackageReferenceHasVersion = 4002;
         public const int DotNetCliReferenceReferenceHasVersion = 4003;
 

--- a/modules/NuGet.Tasks/Internal/LoggingExtensions.cs
+++ b/modules/NuGet.Tasks/Internal/LoggingExtensions.cs
@@ -7,14 +7,12 @@ namespace NuGet.Tasks
 {
     public static class LoggingExtensions
     {
-        private const string Prefix = "KRB";
-
         public static void LogKoreBuildError(this TaskLoggingHelper logger, int code, string message, params object[] messageArgs)
             => LogKoreBuildError(logger, null, code, message, messageArgs: messageArgs);
 
         public static void LogKoreBuildError(this TaskLoggingHelper logger, string filename, int code, string message, params object[] messageArgs)
         {
-            logger.LogError(null, Prefix + code, null, filename, 0, 0, 0, 0, message, messageArgs: messageArgs);
+            logger.LogError(null, KoreBuildErrors.Prefix + code, null, filename, 0, 0, 0, 0, message, messageArgs: messageArgs);
         }
     }
 }

--- a/modules/NuGet.Tasks/Internal/MSBuildProjectExtension.cs
+++ b/modules/NuGet.Tasks/Internal/MSBuildProjectExtension.cs
@@ -104,8 +104,7 @@ namespace NuGet.Tasks
             return new XElement(type,
                   new XAttribute("Update", itemSpec),
                   new XAttribute("Version", version),
-                  new XAttribute("AutoVersion", "true"),
-                  // Prevents upgrades from the NuGet GUI in VS, and the NoVersions policy can filter this reference.
+                  // Prevents upgrades from the NuGet GUI in VS, and the version restriction policy can filter this reference.
                   new XAttribute("IsImplicitlyDefined", "true"));
         }
 

--- a/modules/NuGet.Tasks/Internal/ProjectModel/PackageReferenceInfo.cs
+++ b/modules/NuGet.Tasks/Internal/ProjectModel/PackageReferenceInfo.cs
@@ -2,12 +2,13 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 
 namespace NuGet.Tasks.ProjectModel
 {
     internal class PackageReferenceInfo
     {
-        public PackageReferenceInfo(string id, string version, bool isImplicitlyDefined, bool noWarn)
+        public PackageReferenceInfo(string id, string version, bool isImplicitlyDefined, IReadOnlyList<string> noWarn)
         {
             if (string.IsNullOrEmpty(id))
             {
@@ -23,6 +24,6 @@ namespace NuGet.Tasks.ProjectModel
         public string Id { get; }
         public string Version { get; }
         public bool IsImplicitlyDefined { get; }
-        public bool NoWarn { get; }
+        public IReadOnlyList<string> NoWarn { get; }
     }
 }

--- a/modules/NuGet.Tasks/Internal/ProjectModel/ProjectInfoFactory.cs
+++ b/modules/NuGet.Tasks/Internal/ProjectModel/ProjectInfoFactory.cs
@@ -9,6 +9,7 @@ using Microsoft.Build.Construction;
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Execution;
 using NuGet.Frameworks;
+using NuGet.Tasks.Utilties;
 
 namespace NuGet.Tasks.ProjectModel
 {
@@ -68,9 +69,12 @@ namespace NuGet.Tasks.ProjectModel
             return project.GetItems("PackageReference").Select(item =>
             {
                 bool.TryParse(item.GetMetadataValue("IsImplicitlyDefined"), out var isImplicit);
-                bool.TryParse(item.GetMetadataValue("NoWarn"), out var noWarn);
+                var noWarn = item.GetMetadataValue("NoWarn");
+                IReadOnlyList<string> noWarnItems = string.IsNullOrEmpty(noWarn)
+                    ? Array.Empty<string>()
+                    : MSBuildListSplitter.SplitItemList(noWarn).ToArray();
 
-                return new PackageReferenceInfo(item.EvaluatedInclude, item.GetMetadataValue("Version"), isImplicit, noWarn);
+                return new PackageReferenceInfo(item.EvaluatedInclude, item.GetMetadataValue("Version"), isImplicit, noWarnItems);
             });
         }
 

--- a/modules/NuGet.Tasks/Policy.VersionRestrictions.targets
+++ b/modules/NuGet.Tasks/Policy.VersionRestrictions.targets
@@ -10,14 +10,14 @@
     <ItemGroup>
       <PackageReferenceWithVersion Include="@(PackageReference->HasMetadata('Version'))" />
       <PackageReferenceWithVersion Remove="@(PackageReferenceWithVersion->WithMetadataValue('IsImplicitlyDefined', 'true'))" />
-      <PackageReferenceWithVersion Remove="@(PackageReferenceWithVersion->WithMetadataValue('NoWarn', 'true'))" />
+      <PackageReferenceWithVersion Remove="@(PackageReferenceWithVersion->WithMetadataValue('NoWarn', 'KRB4002'))" />
     </ItemGroup>
 
     <PropertyGroup>
       <_PackageWithVersionMessage>
 This project has restricted adding versions to PackageReference items, but the following items have a version.
-  - @(PackageReferenceWithVersion->'%(Identity)/%(Version)', '%0A - ')
-Add 'NoWarn="true"' to the PackageReference to ignore this warning.
+ - @(PackageReferenceWithVersion->'%(Identity)/%(Version)', '%0A - ')
+Add 'NoWarn="KRB4002"' to the PackageReference to ignore this warning.
       </_PackageWithVersionMessage>
     </PropertyGroup>
 

--- a/test/NuGet.Tasks.Tests/ApplyNuGetPoliciesTests.cs
+++ b/test/NuGet.Tasks.Tests/ApplyNuGetPoliciesTests.cs
@@ -125,7 +125,7 @@ EndGlobal
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include=`Abc` Version=`1.1.0` NoWarn=`true` />
+        <PackageReference Include=`Abc` Version=`1.1.0` NoWarn=`KRB4002` />
         <PackageReference Include=`Xyz` />
     </ItemGroup>
 </Project>".Replace('`', '"'));
@@ -151,14 +151,14 @@ EndGlobal
             void AssertAbc(ProjectFrameworkInfo tfm)
             {
                 Assert.True(tfm.Dependencies.TryGetValue("Abc", out var abc));
-                Assert.True(abc.NoWarn, "Abc should not have NoWarn set");
+                Assert.Contains("KRB4002", abc.NoWarn);
                 Assert.Equal("1.1.0", abc.Version);
             }
 
             void AssertXyz(ProjectFrameworkInfo tfm)
             {
                 Assert.True(tfm.Dependencies.TryGetValue("Xyz", out var xyz));
-                Assert.False(xyz.NoWarn, "Xyz should have NoWarn set");
+                Assert.Empty(xyz.NoWarn);
                 Assert.Empty(xyz.Version);
             }
 

--- a/test/NuGet.Tasks.Tests/PackageLineupPolicyTests.cs
+++ b/test/NuGet.Tasks.Tests/PackageLineupPolicyTests.cs
@@ -95,9 +95,9 @@ namespace NuGet.Tasks.Tests
 
             var packageRef = new[]
             {
-                new PackageReferenceInfo("Microsoft.NETCore.App", "2.0.0", isImplicitlyDefined: true, noWarn: false),
-                new PackageReferenceInfo("Microsoft.AspNetCore", string.Empty, false, false),
-                new PackageReferenceInfo("xunit", "2.2.0", false, false),
+                new PackageReferenceInfo("Microsoft.NETCore.App", "2.0.0", isImplicitlyDefined: true, noWarn: Array.Empty<string>()),
+                new PackageReferenceInfo("Microsoft.AspNetCore", string.Empty, false, Array.Empty<string>()),
+                new PackageReferenceInfo("xunit", "2.2.0", false, Array.Empty<string>()),
             };
 
             var framework = new[] { new ProjectFrameworkInfo(FrameworkConstants.CommonFrameworks.NetCoreApp20, packageRef) };
@@ -126,13 +126,13 @@ namespace NuGet.Tasks.Tests
             Assert.Contains("<PackageLineup Include=\"SampleLineup\" Version=\"1.0.0\" />", xml);
 
             // Should pin for PackageRef that has no version on it
-            Assert.Contains("<PackageReference Update=\"Microsoft.AspNetCore\" Version=\"2.0.0\" AutoVersion=\"true\" IsImplicitlyDefined=\"true\" />", xml);
+            Assert.Contains("<PackageReference Update=\"Microsoft.AspNetCore\" Version=\"2.0.0\" IsImplicitlyDefined=\"true\" />", xml);
 
             // Should not overwrite for PackageRef that have Version
             Assert.DoesNotContain("xunit", xml);
 
             // May overwrite for PackageRef that have Version but are defined by the SDK
-            Assert.Contains("<PackageReference Update=\"Microsoft.NETCore.App\" Version=\"99.99.99\" AutoVersion=\"true\" IsImplicitlyDefined=\"true\" />", xml);
+            Assert.Contains("<PackageReference Update=\"Microsoft.NETCore.App\" Version=\"99.99.99\" IsImplicitlyDefined=\"true\" />", xml);
         }
 
         [Fact]
@@ -157,8 +157,8 @@ namespace NuGet.Tasks.Tests
                         {
                             new ProjectFrameworkInfo(FrameworkConstants.CommonFrameworks.NetCoreApp20, new[]
                             {
-                                new PackageReferenceInfo("TestBundledPkg", string.Empty, false, false),
-                                new PackageReferenceInfo("AnotherBundledPkg", "1.0.0", false, false)
+                                new PackageReferenceInfo("TestBundledPkg", string.Empty, false, Array.Empty<string>()),
+                                new PackageReferenceInfo("AnotherBundledPkg", "1.0.0", false, Array.Empty<string>())
                             })
                         },
                         Array.Empty<DotNetCliReferenceInfo>());
@@ -179,7 +179,7 @@ namespace NuGet.Tasks.Tests
             var xml = sb.ToString();
 
             // assert
-            Assert.Contains("<PackageReference Update=\"TestBundledPkg\" Version=\"0.0.1\" AutoVersion=\"true\" IsImplicitlyDefined=\"true\" />", xml);
+            Assert.Contains("<PackageReference Update=\"TestBundledPkg\" Version=\"0.0.1\" IsImplicitlyDefined=\"true\" />", xml);
             Assert.DoesNotContain("AnotherBundledPkg", xml);
 
             Assert.Contains(packageDir + "</RestoreAdditionalProjectSources>", xml);

--- a/testassets/RepoWithVersionRestrictionsPolicy/src/ClassLib1/ClassLib1.csproj
+++ b/testassets/RepoWithVersionRestrictionsPolicy/src/ClassLib1/ClassLib1.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-    <PackageReference Include="Moq" Version="4.7.49" NoWarn="true" />
+    <PackageReference Include="Moq" Version="4.7.49" NoWarn="KRB4002" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
NuGet already supports a "NoWarn" attribute that is a list of properties. This changes KoreBuild to respect this usage instead of requiring this property be a boolean.