### PR TITLE
Fix #379 - /t:resx is broken

### DIFF
--- a/modules/BuildTools.Tasks/module.targets
+++ b/modules/BuildTools.Tasks/module.targets
@@ -45,7 +45,7 @@ Generates resource files
 
     <MSBuild Targets="_GenerateResx"
       Projects="@(Solutions)"
-      Properties="#(_ResxSlnProps)"
+      Properties="$(_ResxSlnProps)"
       BuildInParallel="$(BuildInParallel)"
       Condition="'@(Solutions)' != ''" />
   </Target>


### PR DESCRIPTION
Looks like a typo. Tested this fix locally against the Razor repo and it
resolves the issue.