### PR TITLE
Add InstallDotNet task and stop installing 1.x by default

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,6 +13,7 @@ insert_final_newline = true
 
 [*.{cs}]
 indent_size = 4
+dotnet_sort_system_directives_first = true:warning
 
 [*.{xml,config,*proj,nuspec,props,resx,targets,yml,tasks}]
 indent_size = 2

--- a/BuildTools.sln
+++ b/BuildTools.sln
@@ -1,11 +1,12 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26730.0
+VisualStudioVersion = 15.0.26730.10
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{A4F4353B-C3D2-40B0-909A-5B48A748EA76}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{BF3E9C90-F129-4CE6-8F3B-F96831E4429B}"
 	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
 		build\common.props = build\common.props
 		build\dependencies.props = build\dependencies.props
 		global.json = global.json

--- a/files/KoreBuild/scripts/KoreBuild.psm1
+++ b/files/KoreBuild/scripts/KoreBuild.psm1
@@ -190,12 +190,6 @@ function Install-Tools(
         $runtimeVersion = $env:KOREBUILD_DOTNET_SHARED_RUNTIME_VERSION
     }
 
-    # Temporarily install these runtimes to prevent build breaks for repos not yet converted
-    # 1.0.5 - for tools
-    __install_shared_runtime $scriptPath $installDir -arch $arch -version "1.0.5" -channel "preview"
-    # 1.1.2 - for test projects which haven't yet been converted to netcoreapp2.0
-    __install_shared_runtime $scriptPath $installDir -arch $arch -version "1.1.2" -channel "release/1.1.0"
-
     if ($runtimeVersion) {
         __install_shared_runtime $scriptPath $installDir -arch $arch -version $runtimeVersion -channel $runtimeChannel
     }

--- a/files/KoreBuild/scripts/dotnet-install.cmd
+++ b/files/KoreBuild/scripts/dotnet-install.cmd
@@ -1,0 +1,2 @@
+@ECHO OFF
+PowerShell -NoProfile -NoLogo -ExecutionPolicy unrestricted -Command "[System.Threading.Thread]::CurrentThread.CurrentCulture = ''; [System.Threading.Thread]::CurrentThread.CurrentUICulture = '';& '%~dp0dotnet-install.ps1' %*; exit $LASTEXITCODE"

--- a/files/KoreBuild/scripts/dotnet-install.ps1
+++ b/files/KoreBuild/scripts/dotnet-install.ps1
@@ -58,6 +58,9 @@
 .PARAMETER ProxyUseDefaultCredentials
     Default: false
     Use default credentials, when using proxy address.
+.PARAMETER SkipNonVersionedFiles
+    Default: false
+    Skips installing non-versioned files if they already exist, such as dotnet.exe.
 #>
 [cmdletbinding()]
 param(
@@ -71,7 +74,8 @@ param(
    [string]$AzureFeed="https://dotnetcli.azureedge.net/dotnet",
    [string]$UncachedFeed="https://dotnetcli.blob.core.windows.net/dotnet",
    [string]$ProxyAddress,
-   [switch]$ProxyUseDefaultCredentials
+   [switch]$ProxyUseDefaultCredentials,
+   [switch]$SkipNonVersionedFiles
 )
 
 Set-StrictMode -Version Latest
@@ -82,7 +86,7 @@ $BinFolderRelativePath=""
 
 # example path with regex: shared/1.0.0-beta-12345/somepath
 $VersionRegEx="/\d+\.\d+[^/]+/"
-$OverrideNonVersionedFiles=$true
+$OverrideNonVersionedFiles = !$SkipNonVersionedFiles
 
 function Say($str) {
     Write-Host "dotnet-install: $str"

--- a/files/KoreBuild/scripts/dotnet-install.sh
+++ b/files/KoreBuild/scripts/dotnet-install.sh
@@ -121,7 +121,7 @@ get_current_os_name() {
             return 0
         fi
     fi
-    
+
     say_err "OS name could not be detected: $ID.$VERSION_ID"
     return 1
 }
@@ -146,7 +146,7 @@ get_distro_specific_os_name() {
             fi
         fi
     fi
-    
+
     say_verbose "Distribution specific OS name and version could not be detected: $ID.$VERSION_ID"
     return 1
 }
@@ -176,7 +176,7 @@ check_min_reqs() {
 
 check_pre_reqs() {
     eval $invocation
-    
+
     local failing=false;
 
     if [ "${DOTNET_INSTALL_SKIP_PREREQS:-}" = "1" ]; then
@@ -199,7 +199,7 @@ check_pre_reqs() {
     if [ "$failing" = true ]; then
        return 1
     fi
-    
+
     return 0
 }
 
@@ -207,7 +207,7 @@ check_pre_reqs() {
 # input - $1
 to_lowercase() {
     #eval $invocation
-    
+
     echo "$1" | tr '[:upper:]' '[:lower:]'
     return 0
 }
@@ -216,7 +216,7 @@ to_lowercase() {
 # input - $1
 remove_trailing_slash() {
     #eval $invocation
-    
+
     local input=${1:-}
     echo "${input%/}"
     return 0
@@ -226,7 +226,7 @@ remove_trailing_slash() {
 # input - $1
 remove_beginning_slash() {
     #eval $invocation
-    
+
     local input=${1:-}
     echo "${input#/}"
     return 0
@@ -237,13 +237,13 @@ remove_beginning_slash() {
 # child_path - $2 - this parameter can be empty
 combine_paths() {
     eval $invocation
-    
+
     # TODO: Consider making it work with any number of paths. For now:
     if [ ! -z "${3:-}" ]; then
         say_err "combine_paths: Function takes two parameters."
         return 1
     fi
-    
+
     local root_path=$(remove_trailing_slash $1)
     local child_path=$(remove_beginning_slash ${2:-})
     say_verbose "combine_paths: root_path=$root_path"
@@ -254,7 +254,7 @@ combine_paths() {
 
 get_machine_architecture() {
     eval $invocation
-    
+
     # Currently the only one supported
     echo "x64"
     return 0
@@ -264,7 +264,7 @@ get_machine_architecture() {
 # architecture - $1
 get_normalized_architecture_from_architecture() {
     eval $invocation
-    
+
     local architecture=$(to_lowercase $1)
     case $architecture in
         \<auto\>)
@@ -280,7 +280,7 @@ get_normalized_architecture_from_architecture() {
             return 1
             ;;
     esac
-   
+
     say_err "Architecture \`$architecture\` not supported. If you think this is a bug, please report it at https://github.com/dotnet/cli/issues"
     return 1
 }
@@ -294,7 +294,7 @@ get_normalized_architecture_from_architecture() {
 # version_text - stdin
 get_version_from_version_info() {
     eval $invocation
-    
+
     cat | tail -n 1
     return 0
 }
@@ -303,7 +303,7 @@ get_version_from_version_info() {
 # version_text - stdin
 get_commit_hash_from_version_info() {
     eval $invocation
-    
+
     cat | head -n 1
     return 0
 }
@@ -314,14 +314,14 @@ get_commit_hash_from_version_info() {
 # specific_version - $3
 is_dotnet_package_installed() {
     eval $invocation
-    
+
     local install_root=$1
     local relative_path_to_package=$2
     local specific_version=${3//[$'\t\r\n']}
-    
+
     local dotnet_package_path=$(combine_paths $(combine_paths $install_root $relative_path_to_package) $specific_version)
     say_verbose "is_dotnet_package_installed: dotnet_package_path=$dotnet_package_path"
-    
+
     if [ -d "$dotnet_package_path" ]; then
         return 0
     else
@@ -335,7 +335,7 @@ is_dotnet_package_installed() {
 # normalized_architecture - $3
 get_latest_version_info() {
     eval $invocation
-    
+
     local azure_feed=$1
     local channel=$2
     local normalized_architecture=$3
@@ -352,7 +352,7 @@ get_latest_version_info() {
         fi
     fi
     say_verbose "get_latest_version_info: latest url: $version_file_url"
-    
+
     download $version_file_url
     return $?
 }
@@ -364,7 +364,7 @@ get_latest_version_info() {
 # version - $4
 get_specific_version_from_version() {
     eval $invocation
-    
+
     local azure_feed=$1
     local channel=$2
     local normalized_architecture=$3
@@ -399,12 +399,12 @@ get_specific_version_from_version() {
 # specific_version - $4
 construct_download_link() {
     eval $invocation
-    
+
     local azure_feed=$1
     local channel=$2
     local normalized_architecture=$3
     local specific_version=${4//[$'\t\r\n']}
-    
+
     local osname
     osname=$(get_current_os_name) || return 1
 
@@ -414,7 +414,7 @@ construct_download_link() {
     else
         download_link="$azure_feed/Sdk/$specific_version/dotnet-sdk-$specific_version-$osname-$normalized_architecture.tar.gz"
     fi
-    
+
     echo "$download_link"
     return 0
 }
@@ -426,7 +426,7 @@ construct_download_link() {
 # specific_version - $4
 construct_legacy_download_link() {
     eval $invocation
-    
+
     local azure_feed=$1
     local channel=$2
     local normalized_architecture=$3
@@ -448,7 +448,7 @@ construct_legacy_download_link() {
 
 get_user_install_path() {
     eval $invocation
-    
+
     if [ ! -z "${DOTNET_INSTALL_DIR:-}" ]; then
         echo $DOTNET_INSTALL_DIR
     else
@@ -461,7 +461,7 @@ get_user_install_path() {
 # install_dir - $1
 resolve_installation_path() {
     eval $invocation
-    
+
     local install_dir=$1
     if [ "$install_dir" = "<auto>" ]; then
         local user_install_path=$(get_user_install_path)
@@ -469,7 +469,7 @@ resolve_installation_path() {
         echo "$user_install_path"
         return 0
     fi
-    
+
     echo "$install_dir"
     return 0
 }
@@ -478,7 +478,7 @@ resolve_installation_path() {
 # install_root - $1
 get_installed_version_info() {
     eval $invocation
-    
+
     local install_root=$1
     local version_file=$(combine_paths "$install_root" "$local_version_file_relative_path")
     say_verbose "Local version file: $version_file"
@@ -487,7 +487,7 @@ get_installed_version_info() {
         echo "$version_info"
         return 0
     fi
-    
+
     say_verbose "Local version file not found."
     return 0
 }
@@ -496,7 +496,7 @@ get_installed_version_info() {
 # relative_or_absolute_path - $1
 get_absolute_path() {
     eval $invocation
-    
+
     local relative_or_absolute_path=$1
     echo $(cd $(dirname "$1") && pwd -P)/$(basename "$1")
     return 0
@@ -514,7 +514,7 @@ copy_files_or_dirs_from_list() {
     local out_path=$(remove_trailing_slash $2)
     local override=$3
     local override_switch=$(if [ "$override" = false ]; then printf -- "-n"; fi)
-    
+
     cat | uniq | while read -r file_path; do
         local path=$(remove_beginning_slash ${file_path#$root_path})
         local target=$out_path/$path
@@ -530,21 +530,21 @@ copy_files_or_dirs_from_list() {
 # out_path - $2
 extract_dotnet_package() {
     eval $invocation
-    
+
     local zip_path=$1
     local out_path=$2
-    
+
     local temp_out_path=$(mktemp -d $temporary_file_template)
-    
+
     local failed=false
     tar -xzf "$zip_path" -C "$temp_out_path" > /dev/null || failed=true
-    
+
     local folders_with_version_regex='^.*/[0-9]+\.[0-9]+[^/]+/'
     find $temp_out_path -type f | grep -Eo $folders_with_version_regex | copy_files_or_dirs_from_list $temp_out_path $out_path false
-    find $temp_out_path -type f | grep -Ev $folders_with_version_regex | copy_files_or_dirs_from_list $temp_out_path $out_path true
-    
+    find $temp_out_path -type f | grep -Ev $folders_with_version_regex | copy_files_or_dirs_from_list $temp_out_path $out_path $override_non_versioned_files
+
     rm -rf $temp_out_path
-    
+
     if [ "$failed" = true ]; then
         say_err "Extraction failed"
         return 1
@@ -617,14 +617,14 @@ calculate_vars() {
 
     normalized_architecture=$(get_normalized_architecture_from_architecture "$architecture")
     say_verbose "normalized_architecture=$normalized_architecture"
-    
+
     specific_version=$(get_specific_version_from_version $azure_feed $channel $normalized_architecture $version)
     say_verbose "specific_version=$specific_version"
     if [ -z "$specific_version" ]; then
         say_err "Could not get version information."
         return 1
     fi
-    
+
     download_link=$(construct_download_link $azure_feed $channel $normalized_architecture $specific_version)
     say_verbose "download_link=$download_link"
 
@@ -648,7 +648,7 @@ install_dotnet() {
         say ".NET SDK version $specific_version is already installed."
         return 0
     fi
-    
+
     mkdir -p $install_root
     zip_path=$(mktemp $temporary_file_template)
     say_verbose "Zip path: $zip_path"
@@ -665,10 +665,10 @@ install_dotnet() {
         say "Downloading legacy link: $download_link"
         download "$download_link" $zip_path
     fi
-    
+
     say "Extracting zip from $download_link"
     extract_dotnet_package $zip_path $install_root
-    
+
     return 0
 }
 
@@ -687,6 +687,7 @@ uncached_feed="https://dotnetcli.blob.core.windows.net/dotnet"
 verbose=false
 shared_runtime=false
 runtime_id=""
+override_non_versioned_files=true
 
 while [ $# -ne 0 ]
 do
@@ -732,6 +733,10 @@ do
             shift
             runtime_id="$1"
             ;;
+        --skip-non-versioned-files|-[Ss]kip[Nn]on[Vv]ersioned[Ff]iles)
+            shift
+            override_non_versioned_files=false
+            ;;
         -?|--?|-h|--help|-[Hh]elp)
             script_name="$(basename $0)"
             echo ".NET Tools Installer"
@@ -764,6 +769,8 @@ do
             echo "      --arch,-Architecture,-Arch"
             echo "  --shared-runtime               Installs just the shared runtime bits, not the entire SDK."
             echo "      -SharedRuntime"
+            echo "  --skip-non-versioned-files     Skips non-versioned files if they already exist, such as the dotnet executable."
+            echo "      -SkipNonVersionedFiles"
             echo "  --dry-run,-DryRun              Do not perform installation. Display download link."
             echo "  --no-path, -NoPath             Do not set PATH for the current process."
             echo "  --verbose,-Verbose             Display diagnostics information."

--- a/files/KoreBuild/scripts/get-dotnet.sh
+++ b/files/KoreBuild/scripts/get-dotnet.sh
@@ -74,15 +74,6 @@ runtime_version=$(< "$__script_dir/../config/runtime.version" head -1 | sed -e '
 
 chmod +x "$__script_dir/dotnet-install.sh"
 
-# Hack to enable runtimestore on Ubuntu 10. A low-cost alternative until we implement https://github.com/aspnet/BuildTools/issues/347
-if [ -z "${KOREBUILD_SKIP_OLD_RUNTIME_INSTALL:-}" ]; then
-    # Temporarily install these runtimes to prevent build breaks for repos not yet converted
-    # 1.0.5 - for tools
-    __install_shared_runtime "$install_dir" "1.0.5" "preview"
-    # 1.1.2 - for test projects which haven't yet been converted to netcoreapp2.0
-    __install_shared_runtime "$install_dir" "1.1.2" "release/1.1.0"
-fi
-
 if [ "$runtime_version" != "" ]; then
     __install_shared_runtime "$install_dir" "$runtime_version" "$runtime_channel"
 fi

--- a/modules/KoreBuild.Tasks/InstallDotNet.cs
+++ b/modules/KoreBuild.Tasks/InstallDotNet.cs
@@ -251,7 +251,7 @@ namespace KoreBuild.Tasks
                 all.Add(request);
             }
 
-            // installs SDKs first, which often bundle a shared runtime...making the shared runtime download unecessary.
+            // installs SDKs first, which often bundle a shared runtime...making the shared runtime download unnecessary.
             return all.Where(r => !r.IsSharedRuntime)
                 .Concat(all.Where(r => r.IsSharedRuntime));
         }

--- a/modules/KoreBuild.Tasks/InstallDotNet.cs
+++ b/modules/KoreBuild.Tasks/InstallDotNet.cs
@@ -1,0 +1,259 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Build.Framework;
+using Microsoft.Extensions.CommandLineUtils;
+
+namespace KoreBuild.Tasks
+{
+    /// <summary>
+    /// Shim for executing dotnet-install.{sh,ps1}, allowing repos to specify the required .NET Core runtimes or to programmatically add new ones.
+    /// </summary>
+    public class InstallDotNet : Microsoft.Build.Utilities.Task, ICancelableTask
+    {
+        public readonly CancellationTokenSource _cts = new CancellationTokenSource();
+
+        /// <summary>
+        /// The .NET Core runtimes or SDKs to be installed.
+        ///
+        /// Supported metadata:
+        ///   Channel: default is ''
+        ///   Arch: default is 'x64'
+        ///   SharedRuntime: default is 'false'
+        ///   InstallDir: default is ''. When not specified <see cref="DotNetHome"/> and the location of the currently executing dotnet.exe process will be used to determine the install path.
+        /// </summary>
+        [Required]
+        public ITaskItem[] Assets { get; set; }
+
+        /// <summary>
+        /// Location of the dotnet-install.{sh,ps1} script
+        /// </summary>
+        [Required]
+        public string InstallScript { get; set; }
+
+        /// <summary>
+        /// Optionally overwrite the default installation directory. This is ignored if <see cref="Assets"/> specify the 'InstallDir' metadata value.
+        /// </summary>
+        public string DotNetHome { get; set; }
+
+        /// <summary>
+        /// Timeout per install request.
+        /// </summary>
+        public int TimeoutSeconds { get; set; } = 240;
+
+        public void Cancel()
+        {
+            _cts.Cancel();
+        }
+
+        public override bool Execute()
+        {
+            return ExecuteAsync().GetAwaiter().GetResult();
+        }
+
+        private async Task<bool> ExecuteAsync()
+        {
+            if (Assets.Length == 0)
+            {
+                return true;
+            }
+
+            if (!File.Exists(InstallScript))
+            {
+                Log.LogError($"Could not install .NET Core. Expected the install script to be in '{InstallScript}'");
+                return false;
+            }
+
+            var requests = CreateAssetRequests();
+            var (exe, defaultArgs) = GetDefaultArgs();
+
+            foreach (var request in requests)
+            {
+                if (_cts.IsCancellationRequested)
+                {
+                    return false;
+                }
+
+                var arguments = new List<string>();
+                arguments.AddRange(defaultArgs);
+
+                var arch = string.IsNullOrEmpty(request.Arch)
+                    ? "x64"
+                    : request.Arch;
+                arguments.Add("-Architecture");
+                arguments.Add(arch);
+
+                var installDir = string.IsNullOrEmpty(request.InstallDir)
+                    ? GetInstallDir(arch)
+                    : request.InstallDir;
+
+                arguments.Add("-InstallDir");
+                arguments.Add(installDir);
+
+                if (request.IsSharedRuntime)
+                {
+                    arguments.Add("-SharedRuntime");
+                }
+
+                arguments.Add("-Version");
+                arguments.Add(request.Version);
+                var isFloatingVersion = request.Version.Equals("latest", StringComparison.OrdinalIgnoreCase)
+                    || request.Version.Equals("coherent", StringComparison.OrdinalIgnoreCase);
+
+                var assetName = $".NET Core { (request.IsSharedRuntime ? "runtime" : "sdk") } ({arch}) {request.Version}";
+
+                if (!string.IsNullOrEmpty(request.Channel))
+                {
+                    arguments.Add("-Channel");
+                    arguments.Add(request.Channel);
+                    assetName += $"/{request.Channel}";
+                }
+
+                var expectedPath = request.IsSharedRuntime && !isFloatingVersion
+                    ? Path.Combine(installDir, "shared", "Microsoft.NETCore.App", request.Version, ".version")
+                    : Path.Combine(installDir, "sdk", request.Version, "dotnet.dll");
+
+                if (File.Exists(expectedPath))
+                {
+                    Log.LogMessage(MessageImportance.Normal, $"{assetName} is already installed. Skipping installation.");
+                    continue;
+                }
+
+                Log.LogMessage(MessageImportance.High, $"Installing {assetName}");
+
+                if (isFloatingVersion)
+                {
+                    Log.LogKoreBuildWarning(KoreBuildErrors.DotNetAssetVersionIsFloating, $"The version of {assetName} being installed is a floating version. This may result in irreproducible builds. Consider specifying an exact version number instead.");
+                }
+
+                using (var process = new Process
+                {
+                    StartInfo =
+                    {
+                        FileName = exe,
+                        Arguments = ArgumentEscaper.EscapeAndConcatenate(arguments),
+                        RedirectStandardError = true,
+                        RedirectStandardOutput = true,
+                    },
+                    EnableRaisingEvents = true,
+                })
+                {
+                    Log.LogMessage(MessageImportance.Normal, $"Executing {process.StartInfo.FileName} {process.StartInfo.Arguments}");
+
+                    var collectedOutput = new List<string>();
+                    process.OutputDataReceived += (o, e) => collectedOutput.Add(e.Data ?? string.Empty);
+                    process.ErrorDataReceived += (o, e) => collectedOutput.Add(e.Data ?? string.Empty);
+
+                    var processFinished = new TaskCompletionSource<object>();
+                    process.Exited += (o, e) => processFinished.TrySetResult(null);
+
+                    process.Start();
+                    process.BeginErrorReadLine();
+                    process.BeginOutputReadLine();
+
+                    _cts.Token.Register(() => process.Kill());
+
+                    var timeout = Task.Delay(TimeSpan.FromSeconds(TimeoutSeconds));
+
+                    var finished = await Task.WhenAny(timeout, processFinished.Task);
+
+                    process.CancelErrorRead();
+                    process.CancelOutputRead();
+
+                    if (ReferenceEquals(finished, timeout))
+                    {
+                        Log.LogError($"dotnet-install of {assetName} timed out after {TimeoutSeconds} seconds.\n"
+                            + $"Output:\n{string.Join("\n", collectedOutput)}");
+                        return false;
+                    }
+
+                    if (process.ExitCode != 0)
+                    {
+                        Log.LogError($"dotnet-install failed on {assetName}.\n"
+                            + $"Arguments: {process.StartInfo.FileName} {process.StartInfo.Arguments}\n"
+                            + $"Output:\n{string.Join("\n", collectedOutput)}");
+                        return false;
+                    }
+                }
+            }
+
+            return true;
+        }
+
+        private (string exe, IReadOnlyList<string> args) GetDefaultArgs()
+        {
+            var defaultArgs = new List<string>();
+            var ext = Path.GetExtension(InstallScript).ToLowerInvariant();
+            string exe;
+            if (ext == ".sh")
+            {
+                exe = "bash";
+                defaultArgs.Add(InstallScript);
+            }
+            else if (ext == ".cmd")
+            {
+                exe = InstallScript;
+            }
+            else
+            {
+                throw new InvalidOperationException("Unexpected dotnet-install script type");
+            }
+
+            // required, otherwise it may attempt to overwrite the dotnet.exe file that is executing this MSBuild process
+            defaultArgs.Add("-SkipNonVersionedFiles");
+
+            // don't modify PATH
+            defaultArgs.Add("-NoPath");
+
+            // we capture stdout/stderr, so verbose output will only appear in the verbose MSBuild log
+            defaultArgs.Add("-Verbose");
+
+            return (exe, defaultArgs);
+        }
+
+        private string GetInstallDir(string arch)
+        {
+            if (string.IsNullOrEmpty(DotNetHome))
+            {
+                var dotnetPath = Path.GetDirectoryName(DotNetMuxer.MuxerPath);
+                return RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                    ? Path.Combine(Path.GetDirectoryName(dotnetPath), arch)
+                    : dotnetPath;
+            }
+            else
+            {
+                return RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                    ? Path.Combine(DotNetHome, arch)
+                    : DotNetHome;
+            }
+        }
+
+        private IEnumerable<DotNetAssetRequest> CreateAssetRequests()
+        {
+            var all = new List<DotNetAssetRequest>();
+            foreach (var item in Assets)
+            {
+                var request = new DotNetAssetRequest(item.ItemSpec)
+                {
+                    IsSharedRuntime = bool.TryParse(item.GetMetadata("SharedRuntime"), out var sharedRuntime) && sharedRuntime,
+                    Channel = item.GetMetadata("Channel"),
+                    InstallDir = item.GetMetadata("InstallDir"),
+                    Arch = item.GetMetadata("Arch"),
+                };
+                all.Add(request);
+            }
+
+            // installs SDKs first, which often bundle a shared runtime...making the shared runtime download unecessary.
+            return all.Where(r => !r.IsSharedRuntime)
+                .Concat(all.Where(r => r.IsSharedRuntime));
+        }
+    }
+}

--- a/modules/KoreBuild.Tasks/Internal/DotNetAssetRequest.cs
+++ b/modules/KoreBuild.Tasks/Internal/DotNetAssetRequest.cs
@@ -1,0 +1,21 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace KoreBuild.Tasks
+{
+    internal class DotNetAssetRequest
+    {
+        public DotNetAssetRequest(string version)
+        {
+            Version = version ?? throw new ArgumentNullException(nameof(version));
+        }
+
+        public string Version { get; }
+        public bool IsSharedRuntime { get; internal set; }
+        public string Channel { get; internal set; }
+        public string InstallDir { get; internal set; }
+        public string Arch { get; internal set; }
+    }
+}

--- a/modules/KoreBuild.Tasks/Internal/DotNetAssetRequest.cs
+++ b/modules/KoreBuild.Tasks/Internal/DotNetAssetRequest.cs
@@ -13,9 +13,9 @@ namespace KoreBuild.Tasks
         }
 
         public string Version { get; }
-        public bool IsSharedRuntime { get; internal set; }
-        public string Channel { get; internal set; }
-        public string InstallDir { get; internal set; }
-        public string Arch { get; internal set; }
+        public bool IsSharedRuntime { get; set; }
+        public string Channel { get; set; }
+        public string InstallDir { get; set; }
+        public string Arch { get; set; }
     }
 }

--- a/modules/KoreBuild.Tasks/Internal/KoreBuildErrors.cs
+++ b/modules/KoreBuild.Tasks/Internal/KoreBuildErrors.cs
@@ -10,13 +10,16 @@ namespace KoreBuild.Tasks
         // Typically used in repos in Directory.Build.targets
         public const int PackagesHaveNotYetBeenPinned = 1001;
 
-        public const int InvalidNuspecFile = 4001;
+        // Warnings
+        public const int DotNetAssetVersionIsFloating = 2000;
 
+        // NuGet errors
+        public const int InvalidNuspecFile = 4001;
         public const int PackageReferenceHasVersion = 4002;
         public const int DotNetCliReferenceReferenceHasVersion = 4003;
-
         public const int PackageVersionNotFoundInLineup = 4004;
 
+        // Other unknown errors
         public const int PolicyFailedToApply = 5000;
         public const int UnknownPolicyType = 5001;
     }

--- a/modules/KoreBuild.Tasks/Internal/LoggingExtensions.cs
+++ b/modules/KoreBuild.Tasks/Internal/LoggingExtensions.cs
@@ -14,5 +14,13 @@ namespace KoreBuild.Tasks
         {
             logger.LogError(null, KoreBuildErrors.Prefix + code, null, filename, 0, 0, 0, 0, message, messageArgs: messageArgs);
         }
+
+        public static void LogKoreBuildWarning(this TaskLoggingHelper logger, int code, string message, params object[] messageArgs)
+            => LogKoreBuildWarning(logger, null, code, message, messageArgs: messageArgs);
+
+        public static void LogKoreBuildWarning(this TaskLoggingHelper logger, string filename, int code, string message, params object[] messageArgs)
+        {
+            logger.LogWarning(null, KoreBuildErrors.Prefix + code, null, filename, 0, 0, 0, 0, message, messageArgs: messageArgs);
+        }
     }
 }

--- a/modules/KoreBuild.Tasks/KoreBuild.Tasks.csproj
+++ b/modules/KoreBuild.Tasks/KoreBuild.Tasks.csproj
@@ -8,6 +8,7 @@
   <ItemGroup>
     <Content Include="*.props" CopyToPublishDirectory="PreserveNewest" />
     <Content Include="*.targets" CopyToPublishDirectory="PreserveNewest" />
+    <Compile Include="..\..\shared\Microsoft.Extensions.CommandLineUtils.Sources\Utilities\*.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/modules/KoreBuild.Tasks/module.props
+++ b/modules/KoreBuild.Tasks/module.props
@@ -1,9 +1,38 @@
 <Project>
   <UsingTask TaskName="KoreBuild.Tasks.ApplyNuGetPolicies" AssemblyFile="$(MSBuildThisFileDirectory)Internal.AspNetCore.KoreBuild.Tasks.dll" />
+  <UsingTask TaskName="KoreBuild.Tasks.InstallDotNet" AssemblyFile="$(MSBuildThisFileDirectory)Internal.AspNetCore.KoreBuild.Tasks.dll" />
   <UsingTask TaskName="KoreBuild.Tasks.PackNuSpec" AssemblyFile="$(MSBuildThisFileDirectory)Internal.AspNetCore.KoreBuild.Tasks.dll" />
   <UsingTask TaskName="KoreBuild.Tasks.PushNuGetPackages" AssemblyFile="$(MSBuildThisFileDirectory)Internal.AspNetCore.KoreBuild.Tasks.dll" />
 
   <ItemDefinitionGroup>
+    <!--
+      Specifies a required .NET Core runtime.
+
+      Examples:
+        <DotNetCoreRuntime Include="1.0.5" />
+        <DotNetCoreRuntime Include="latest" Channel="1.0" />
+        <DotNetCoreRuntime Include="2.0.0" Arch="x64" InstallDir="C:\custom\" />
+    -->
+    <DotNetCoreRuntime>
+      <Arch>x64</Arch>
+      <SharedRuntime>true</SharedRuntime>
+      <Channel></Channel>
+      <InstallDir></InstallDir>
+    </DotNetCoreRuntime>
+
+    <!--
+      Specifies a required .NET Core SDK.
+
+      Examples:
+        <DotNetCoreSdk Include="coherent" Channel="master" InstallDir="$(RepositoryRoot)\.siteextension\" />
+    -->
+    <DotNetCoreSdk>
+      <Arch>x64</Arch>
+      <SharedRuntime>false</SharedRuntime>
+      <Channel></Channel>
+      <InstallDir></InstallDir>
+    </DotNetCoreSdk>
+    
     <!--
       Adds an import to Policy.VersionRestrictions.targets and configures the error level based on the project configuration. This restricts using "Version" on PackageReference
 

--- a/modules/KoreBuild.Tasks/module.props
+++ b/modules/KoreBuild.Tasks/module.props
@@ -4,6 +4,11 @@
   <UsingTask TaskName="KoreBuild.Tasks.PackNuSpec" AssemblyFile="$(MSBuildThisFileDirectory)Internal.AspNetCore.KoreBuild.Tasks.dll" />
   <UsingTask TaskName="KoreBuild.Tasks.PushNuGetPackages" AssemblyFile="$(MSBuildThisFileDirectory)Internal.AspNetCore.KoreBuild.Tasks.dll" />
 
+  <PropertyGroup>
+    <DefaultDotNetAssetArch>$(KOREBUILD_DOTNET_ARCH)</DefaultDotNetAssetArch>
+    <DefaultDotNetAssetArch Condition="'$(DefaultDotNetAssetArch)' == ''">x64</DefaultDotNetAssetArch>
+  </PropertyGroup>
+
   <ItemDefinitionGroup>
     <!--
       Specifies a required .NET Core runtime.
@@ -14,7 +19,7 @@
         <DotNetCoreRuntime Include="2.0.0" Arch="x64" InstallDir="C:\custom\" />
     -->
     <DotNetCoreRuntime>
-      <Arch>x64</Arch>
+      <Arch>$(DefaultDotNetAssetArch)</Arch>
       <SharedRuntime>true</SharedRuntime>
       <Channel></Channel>
       <InstallDir></InstallDir>
@@ -27,12 +32,12 @@
         <DotNetCoreSdk Include="coherent" Channel="master" InstallDir="$(RepositoryRoot)\.siteextension\" />
     -->
     <DotNetCoreSdk>
-      <Arch>x64</Arch>
+      <Arch>$(DefaultDotNetAssetArch)</Arch>
       <SharedRuntime>false</SharedRuntime>
       <Channel></Channel>
       <InstallDir></InstallDir>
     </DotNetCoreSdk>
-    
+
     <!--
       Adds an import to Policy.VersionRestrictions.targets and configures the error level based on the project configuration. This restricts using "Version" on PackageReference
 

--- a/modules/KoreBuild.Tasks/module.targets
+++ b/modules/KoreBuild.Tasks/module.targets
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <RestoreDependsOn>ApplyNuGetPolicies;$(RestoreDependsOn)</RestoreDependsOn>
+    <RestoreDependsOn>ApplyNuGetPolicies;InstallDotNet;$(RestoreDependsOn)</RestoreDependsOn>
     <ApplyNuGetPoliciesDependsOn>
       $(ApplyNuGetPoliciesDependsOn);
       ResolveSolutions;
@@ -38,6 +38,19 @@
       RestoreNoCache="$(PolicyRestoreNoCache)"
       RestoreIgnoreFailedSources="$(PolicyRestoreIgnoreFailedSources)" />
 
+  </Target>
+
+  <Target Name="InstallDotNet">
+    <PropertyGroup>
+      <_DotNetInstall>$(MSBuildThisFileDirectory)..\..\scripts\dotnet-install</_DotNetInstall>
+      <_DotNetInstall Condition="$([MSBuild]::IsOSUnixLike())">$(_DotNetInstall).sh</_DotNetInstall>
+      <_DotNetInstall Condition="$([MSBuild]::IsOSPlatform('Windows'))">$(_DotNetInstall).cmd</_DotNetInstall>
+    </PropertyGroup>
+
+    <InstallDotNet
+      Assets="@(DotNetCoreSdk);@(DotNetCoreRuntime)"
+      DotNetHome="$(DOTNET_HOME)"
+      InstallScript="$(_DotNetInstall)"/>
   </Target>
 
 </Project>

--- a/test/KoreBuild.Tasks.Tests/InstallDotNetTests.cs
+++ b/test/KoreBuild.Tasks.Tests/InstallDotNetTests.cs
@@ -1,0 +1,87 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections;
+using System.IO;
+using System.Runtime.InteropServices;
+using BuildTools.Tasks.Tests;
+using Microsoft.Build.Utilities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace KoreBuild.Tasks.Tests
+{
+    public class InstallDotNetTests
+    {
+        private readonly ITestOutputHelper _output;
+
+        public InstallDotNetTests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [Fact]
+        public void InstallsDotnetCoreRuntime()
+        {
+            var path = Path.Combine(AppContext.BaseDirectory, ".installtest");
+            if (Directory.Exists(path))
+            {
+                Directory.Delete(path, recursive: true);
+            }
+
+            var request = new TaskItem("1.0.5", new Hashtable
+            {
+                ["SharedRuntime"] = "true",
+                ["InstallDir"] = path
+            });
+
+            var script = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                ? Path.Combine(AppContext.BaseDirectory, "dotnet-install.cmd")
+                : Path.Combine(AppContext.BaseDirectory, "dotnet-install.sh");
+
+            var task = new InstallDotNet
+            {
+                BuildEngine = new MockEngine(_output),
+                Assets = new[] { request },
+                InstallScript = script,
+            };
+
+            var expected = Path.Combine(path, "shared", "Microsoft.NETCore.App", "1.0.5", ".version");
+            Assert.False(File.Exists(expected), "Test folder should have been deleted");
+
+            Assert.True(task.Execute(), "Task should pass");
+
+            Assert.True(File.Exists(expected), "Runtime should have been installed");
+        }
+
+        [Fact]
+        public void FailsForBadInstall()
+        {
+            var path = Path.Combine(AppContext.BaseDirectory, ".installtest");
+            if (Directory.Exists(path))
+            {
+                Directory.Delete(path, recursive: true);
+            }
+
+            var request = new TaskItem("999.999.999", new Hashtable
+            {
+                ["SharedRuntime"] = "true",
+                ["InstallDir"] = path
+            });
+
+            var script = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                ? Path.Combine(AppContext.BaseDirectory, "dotnet-install.cmd")
+                : Path.Combine(AppContext.BaseDirectory, "dotnet-install.sh");
+
+            var task = new InstallDotNet
+            {
+                BuildEngine = new MockEngine(_output) { ContinueOnError = true },
+                Assets = new[] { request },
+                InstallScript = script,
+            };
+
+            Assert.False(task.Execute(), "Task should not have passed");
+        }
+    }
+}

--- a/test/KoreBuild.Tasks.Tests/KoreBuild.Tasks.Tests.csproj
+++ b/test/KoreBuild.Tasks.Tests/KoreBuild.Tasks.Tests.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <Compile Include="..\shared\*" />
+    <Content Include="..\..\files\KoreBuild\scripts\dotnet-install.*" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <ItemGroup>

--- a/testassets/SimpleRepo/build/repo.props
+++ b/testassets/SimpleRepo/build/repo.props
@@ -2,4 +2,8 @@
   <PropertyGroup>
     <_EnableKoreBuildBundledPackages>true</_EnableKoreBuildBundledPackages>
   </PropertyGroup>
+
+  <ItemGroup>
+    <DotNetCoreRuntime Include="1.1.2" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Resolves #347. Apps that need 1.x runtimes must add these explicitly to their repo.props files.

Depends on #378 

cc @smitpatel @pakrym 