### PR TITLE
Add support for lineup pinning based on the project's target framework

### DIFF
--- a/BuildTools.sln
+++ b/BuildTools.sln
@@ -16,6 +16,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{60A938B2-D95A-403C-AA7A-3683AD64DFA0}"
+	ProjectSection(SolutionItems) = preProject
+		test\Directory.Build.targets = test\Directory.Build.targets
+	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NuGetPackageVerifier.Console", "modules\NuGetPackageVerifier\console\NuGetPackageVerifier.Console.csproj", "{657AFF5E-164E-493D-8501-8026B7C20808}"
 EndProject

--- a/modules/KoreBuild.Tasks/Internal/MyFrameworks.cs
+++ b/modules/KoreBuild.Tasks/Internal/MyFrameworks.cs
@@ -1,0 +1,14 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using NuGet.Frameworks;
+
+namespace KoreBuild.Tasks
+{
+    internal static class MyFrameworks
+    {
+        // Until NuGet adds this to FrameworkConstants
+        public static readonly NuGetFramework NetCoreApp21 = new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.NetCoreApp, new Version("2.1"));
+    }
+}

--- a/modules/KoreBuild.Tasks/Policies/PackageLineupPolicy.cs
+++ b/modules/KoreBuild.Tasks/Policies/PackageLineupPolicy.cs
@@ -8,11 +8,12 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using KoreBuild.Tasks.Lineup;
+using KoreBuild.Tasks.ProjectModel;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using NuGet.Build;
-using KoreBuild.Tasks.Lineup;
-using KoreBuild.Tasks.ProjectModel;
+using NuGet.Frameworks;
 using NuGet.Versioning;
 using Task = System.Threading.Tasks.Task;
 
@@ -137,7 +138,7 @@ namespace KoreBuild.Tasks.Policies
                         continue;
                     }
 
-                    if (versionSource.TryGetPackageVersion(package.Id, out string version))
+                    if (versionSource.TryGetPackageVersion(package.Id, framework.TargetFramework, out string version))
                     {
                         builder.PinPackageReference(package.Id, version, framework.TargetFramework);
                         Interlocked.Increment(ref _pinned);
@@ -158,7 +159,7 @@ namespace KoreBuild.Tasks.Policies
                     continue;
                 }
 
-                if (versionSource.TryGetPackageVersion(toolPackage.Id, out string version))
+                if (versionSource.TryGetPackageVersion(toolPackage.Id, FrameworkConstants.CommonFrameworks.NetCoreApp20, out string version))
                 {
                     builder.PinCliToolReference(toolPackage, version);
                     Interlocked.Increment(ref _pinned);

--- a/test/Directory.Build.targets
+++ b/test/Directory.Build.targets
@@ -1,0 +1,5 @@
+<Project>
+  <ItemGroup>
+    <None Include="$(MSBuildThisFileDirectory)xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+</Project>

--- a/test/KoreBuild.Tasks.Tests/PackNuSpecTests.cs
+++ b/test/KoreBuild.Tasks.Tests/PackNuSpecTests.cs
@@ -141,6 +141,7 @@ namespace KoreBuild.Tasks.Tests
                 {
                     new TaskItem("OtherPackage", new Hashtable { ["Version"] = "[1.0.0, 2.0.0)"}),
                     new TaskItem("PackageInTfm", new Hashtable { ["TargetFramework"] = "netstandard1.0", ["Version"] = "0.1.0-beta" }),
+                    new TaskItem("PackageInTfm", new Hashtable { ["TargetFramework"] = "netstandard1.1", ["Version"] = "0.2.0-beta" }),
                 }
             };
 
@@ -157,9 +158,14 @@ namespace KoreBuild.Tasks.Tests
                 Assert.Single(noTfmGroup.Packages, p => p.Id == "AlreadyInNuspec" && p.VersionRange.Equals(VersionRange.Parse("[2.0.0]")));
 
                 var netstandard10Group = Assert.Single(metadata.DependencyGroups, d => d.TargetFramework.Equals(FrameworkConstants.CommonFrameworks.NetStandard10));
-                var package = Assert.Single(netstandard10Group.Packages);
-                Assert.Equal("PackageInTfm", package.Id);
-                Assert.Equal(VersionRange.Parse("0.1.0-beta"), package.VersionRange);
+                var package1 = Assert.Single(netstandard10Group.Packages);
+                Assert.Equal("PackageInTfm", package1.Id);
+                Assert.Equal(VersionRange.Parse("0.1.0-beta"), package1.VersionRange);
+
+                var netstandard11Group = Assert.Single(metadata.DependencyGroups, d => d.TargetFramework.Equals(FrameworkConstants.CommonFrameworks.NetStandard11));
+                var package2 = Assert.Single(netstandard11Group.Packages);
+                Assert.Equal("PackageInTfm", package2.Id);
+                Assert.Equal(VersionRange.Parse("0.2.0-beta"), package2.VersionRange);
             }
         }
 

--- a/test/KoreBuild.Tasks.Tests/PackageVersionSourceTests.cs
+++ b/test/KoreBuild.Tasks.Tests/PackageVersionSourceTests.cs
@@ -1,0 +1,85 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using KoreBuild.Tasks.Lineup;
+using NuGet.Common;
+using NuGet.Frameworks;
+using NuGet.Packaging;
+using NuGet.Packaging.Core;
+using NuGet.Versioning;
+using Xunit;
+
+namespace KoreBuild.Tasks.Tests
+{
+    public class PackageVersionSourceTests
+    {
+        [Fact]
+        public void PicksTheRightNetCoreAppVersion()
+        {
+            const string pkgId = "Microsoft.NETCore.App";
+            var netcoreappPackages = new(NuGetFramework tfm, string version)[]
+            {
+                (FrameworkConstants.CommonFrameworks.NetCoreApp10, "1.0.5"),
+                (FrameworkConstants.CommonFrameworks.NetCoreApp11, "1.1.2"),
+                (FrameworkConstants.CommonFrameworks.NetCoreApp20, "2.0.0"),
+                (MyFrameworks.NetCoreApp21, "2.1.0-preview1"),
+            };
+
+            var source = new PackageVersionSource(NullLogger.Instance);
+            source.AddPackagesFromLineup("TestLineup", NuGetVersion.Parse("1.0.0"), netcoreappPackages.Select(pair =>
+                    new PackageDependencyGroup(pair.tfm, new[] { new PackageDependency(pkgId, VersionRange.Parse(pair.version)) })).ToArray());
+
+            foreach (var pair in netcoreappPackages)
+            {
+                Assert.True(source.TryGetPackageVersion(pkgId, pair.tfm, out var selectedVersion));
+                Assert.Equal(pair.version, selectedVersion);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(FrameworkLineupData))]
+        public void PicksTheMostCompatibleFramework(NuGetFramework targetFramework, string expectedVersion)
+        {
+            const string pkgId = "Test";
+            var source = new PackageVersionSource(NullLogger.Instance);
+            source.AddPackagesFromLineup("TestLineup", NuGetVersion.Parse("1.0.0"), new[]
+            {
+                new PackageDependencyGroup(FrameworkConstants.CommonFrameworks.NetStandard16, new[] { new PackageDependency(pkgId, VersionRange.Parse("1.6.0")) }),
+                new PackageDependencyGroup(FrameworkConstants.CommonFrameworks.NetStandard20, new[] { new PackageDependency(pkgId, VersionRange.Parse("2.0.0")) }),
+                new PackageDependencyGroup(FrameworkConstants.CommonFrameworks.Net461, new[] { new PackageDependency(pkgId, VersionRange.Parse("3.0.0")) }),
+                new PackageDependencyGroup(NuGetFramework.AnyFramework, new[] { new PackageDependency(pkgId, VersionRange.Parse("1.0.0")) }),
+            });
+
+            source.TryGetPackageVersion(pkgId, targetFramework, out var selectedVersion);
+            Assert.Equal(expectedVersion, selectedVersion);
+        }
+
+        public static TheoryData<NuGetFramework, string> FrameworkLineupData
+            => new TheoryData<NuGetFramework, string>
+            {
+                { FrameworkConstants.CommonFrameworks.NetStandard13, "1.0.0" },
+                { FrameworkConstants.CommonFrameworks.NetStandard16, "1.6.0" },
+                { FrameworkConstants.CommonFrameworks.NetCoreApp11, "1.6.0" },
+                { FrameworkConstants.CommonFrameworks.NetCoreApp20, "2.0.0" },
+                { FrameworkConstants.CommonFrameworks.Net46, "1.0.0" },
+                { FrameworkConstants.CommonFrameworks.Net461, "3.0.0" },
+            };
+
+        [Fact]
+        public void DoesNotPickAVersionForIncompatibleFramework()
+        {
+            const string pkgId = "Test";
+            var source = new PackageVersionSource(NullLogger.Instance);
+            source.AddPackagesFromLineup("TestLineup", NuGetVersion.Parse("1.0.0"), new[]
+            {
+                new PackageDependencyGroup(FrameworkConstants.CommonFrameworks.NetStandard16, new[] { new PackageDependency(pkgId, VersionRange.Parse("1.0.0")) })
+            });
+
+            Assert.False(source.TryGetPackageVersion(pkgId, NuGetFramework.AgnosticFramework, out var _));
+            Assert.False(source.TryGetPackageVersion(pkgId, FrameworkConstants.CommonFrameworks.NetStandard15, out var _));
+            Assert.False(source.TryGetPackageVersion(pkgId, FrameworkConstants.CommonFrameworks.Net45, out var _));
+        }
+    }
+}

--- a/test/xunit.runner.json
+++ b/test/xunit.runner.json
@@ -1,0 +1,3 @@
+{
+  "methodDisplay": "method"
+}

--- a/testassets/RepoWithLineupPolicy/build/TestLineup.nuspec
+++ b/testassets/RepoWithLineupPolicy/build/TestLineup.nuspec
@@ -8,5 +8,13 @@
     <packageTypes>
       <packageType name="lineup" />
     </packageTypes>
+    <dependencies>
+      <group targetFramework=".NETCoreApp1.1">
+        <dependency id="Microsoft.NETCore.App" version="1.1.2" />
+      </group>
+      <group targetFramework=".NETCoreApp2.0">
+        <dependency id="Microsoft.NETCore.App" version="2.0.0" />
+      </group>
+    </dependencies>
   </metadata>
 </package>

--- a/testassets/RepoWithLineupPolicy/build/repo.props
+++ b/testassets/RepoWithLineupPolicy/build/repo.props
@@ -1,6 +1,7 @@
 <Project>
   <ItemGroup>
     <PackageLineup Include="TestLineup" Version="1.0.0" />
+    <DotNetCoreRuntime Include="1.1.2" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/testassets/RepoWithLineupPolicy/test/TestProject1/TestClass1.cs
+++ b/testassets/RepoWithLineupPolicy/test/TestProject1/TestClass1.cs
@@ -9,7 +9,13 @@ namespace TestProject1
         [Fact]
         public void HasVersion220()
         {
+#if NETCOREAPP1_1
+            var xunitVersion = typeof(FactAttribute).GetTypeInfo().Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion;
+#elif NETCOREAPP2_0
             var xunitVersion = typeof(FactAttribute).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion;
+#else
+#error Update target frameworks
+#endif
             Assert.Equal("2.2.0", xunitVersion);
         }
 

--- a/testassets/RepoWithLineupPolicy/test/TestProject1/TestProject1.csproj
+++ b/testassets/RepoWithLineupPolicy/test/TestProject1/TestProject1.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFrameworks>netcoreapp1.1;netcoreapp2.0</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 


### PR DESCRIPTION
Adds support for specifying dependencies whose version vary based on target framework.

For example, a lineup could look like this:
```xml
<?xml version="1.0" encoding="utf-8"?>
<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
  <metadata>
    <id>TestLineup</id>
    <version>1.0.0</version>
    <authors>Test</authors>
    <description>Test</description>
    <packageTypes>
      <packageType name="lineup" />
    </packageTypes>
    <dependencies>
      <group targetFramework=".NETCoreApp1.1">
        <dependency id="Microsoft.NETCore.App" version="1.1.2" />
      </group>
      <group targetFramework=".NETCoreApp2.0">
        <dependency id="Microsoft.NETCore.App" version="2.0.0" />
      </group>
    </dependencies>
  </metadata>
</package>
```

cc @mikeharder @pranavkm 