### PR TITLE
Add repo version info into KoreBuild

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -21,7 +21,6 @@
   <PropertyGroup>
     <RepositoryUrl>https://github.com/aspnet/BuildTools</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <VersionSuffix Condition="'$(VersionSuffix)' != '' AND '$(BuildNumber)' != ''">$(VersionSuffix)-$(BuildNumber)</VersionSuffix>
   </PropertyGroup>
 
 </Project>

--- a/build/repo.props
+++ b/build/repo.props
@@ -1,11 +1,5 @@
 <Project>
-  <Import Project="..\version.props" />
-
   <PropertyGroup>
-    <Version>$(VersionPrefix)</Version>
-    <Version Condition="'$(VersionSuffix)' != ''">$(Version)-$(VersionSuffix)</Version>
-    <Version Condition="'$(BuildNumber)' != ''">$(Version)-$(BuildNumber)</Version>
-
     <DisableSharedSources>true</DisableSharedSources>
   </PropertyGroup>
 

--- a/files/KoreBuild/KoreBuild.Common.targets
+++ b/files/KoreBuild/KoreBuild.Common.targets
@@ -2,6 +2,26 @@
 
 <!--
 ###################################################################
+Standard lifecycle properties.
+
+This is intentionally in .targets as these properties are evaluated
+after all other property imports.
+###################################################################
+-->
+  <PropertyGroup Condition=" '$(Version)' == '' ">
+    <VersionPrefix Condition=" '$(VersionPrefix)' == '' ">1.0.0</VersionPrefix>
+    <Version Condition=" '$(VersionSuffix)' != '' ">$(VersionPrefix)-$(VersionSuffix)</Version>
+    <Version Condition=" '$(Version)' == '' ">$(VersionPrefix)</Version>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <PackageVersion Condition="'$(PackageVersion)' == '' AND '$(Version)' != '' ">$(Version)</PackageVersion>
+    <SolutionProperties>$(SolutionProperties);RepoVersion=$(Version);RepoPackageVersion=$(PackageVersion)</SolutionProperties>
+    <SolutionProperties Condition=" ! Exists('$(RepositoryRoot)version.props') ">$(SolutionProperties);VerifyVersion=false</SolutionProperties>
+  </PropertyGroup>
+
+<!--
+###################################################################
 Standard lifecycle targets.
 
 When extending the solution build, chain off one of these by
@@ -21,5 +41,15 @@ extending the *DependsOn property
   <!-- Additional common targets. -->
   <Target Name="Clean"   DependsOnTargets="$(CleanDependsOn)" />
   <Target Name="Rebuild" DependsOnTargets="$(RebuildDependsOn)" />
+
+  <Target Name="GetRepoInfo" Returns="@(RepoInfo)">
+    <ItemGroup>
+      <RepoInfo Include="$(RepositoryRoot)">
+        <Version>$(Version)</Version>
+        <PackageVersion>$(PackageVersion)</PackageVersion>
+        <BuildNumber>$(BuildNumber)</BuildNumber>
+      </RepoInfo>
+    </ItemGroup>
+  </Target>
 
 </Project>

--- a/files/KoreBuild/KoreBuild.proj
+++ b/files/KoreBuild/KoreBuild.proj
@@ -1,4 +1,3 @@
-<?xml version="1.0" ?>
 <Project DefaultTargets="Build">
   <!--
     Usage Notes:
@@ -15,6 +14,8 @@
   <Import Project="KoreBuild.Common.props" />
   <Import Project="modules\*\module.props" />
   <Import Project="$(CustomKoreBuildModulesPath)\*\module.props" Condition="Exists('$(CustomKoreBuildModulesPath)')" />
+
+  <Import Project="$(RepositoryRoot)version.props" Condition="Exists('$(RepositoryRoot)version.props')" />
   <Import Project="$(RepositoryRoot)build\repo.props" Condition="Exists('$(RepositoryRoot)build\repo.props')" />
   <Import Project="$(RepositoryRoot)build\tasks\*.tasks" Condition="Exists('$(RepositoryRoot)build\tasks\')" />
 

--- a/modules/KoreBuild.Tasks/Internal/KoreBuildErrors.cs
+++ b/modules/KoreBuild.Tasks/Internal/KoreBuildErrors.cs
@@ -12,6 +12,8 @@ namespace KoreBuild.Tasks
 
         // Warnings
         public const int DotNetAssetVersionIsFloating = 2000;
+        public const int RepoVersionDoesNotMatchProjectVersion = 2001;
+        public const int RepoPackageVersionDoesNotMatchProjectPackageVersion = 2002;
         public const int DuplicatePackageReference = 2003;
 
         // NuGet errors

--- a/src/Internal.AspNetCore.Sdk/Internal.AspNetCore.Sdk.csproj
+++ b/src/Internal.AspNetCore.Sdk/Internal.AspNetCore.Sdk.csproj
@@ -4,6 +4,7 @@
 
   <PropertyGroup>
     <VersionPrefix>2.1.1</VersionPrefix>
+    <VerifyVersion>false</VerifyVersion>
     <TargetFrameworks>netcoreapp2.0;net46</TargetFrameworks>
     <DefineConstants>$(DefineConstants);SDK</DefineConstants>
     <Serviceable>false</Serviceable>

--- a/src/Internal.AspNetCore.Sdk/build/Common.targets
+++ b/src/Internal.AspNetCore.Sdk/build/Common.targets
@@ -14,9 +14,17 @@ For single-tfm projects, this will be imported from build/Internal.AspNetCore.Sd
   <PropertyGroup>
     <IncludeSymbols Condition="'$(NuspecFile)'!=''">false</IncludeSymbols>
   </PropertyGroup>
-  
+
   <Target Name="_ShowBuildVersion" BeforeTargets="PrepareForBuild">
     <Message Text="Build version: $(AssemblyName)/$(TargetFramework)/$(Version)" Importance="normal" />
+
+    <Warning Text="Version does not match RepoVersion. Version = '$(Version)' and RepoVersion = '$(RepoVersion)'."
+             Code="KRB2001"
+             Condition="'$(RepoVersion)' != '' AND '$(RepoVersion)' != '$(Version)' AND '$(VerifyVersion)' != 'false' " />
+
+    <Warning Text="PackageVersion does not match RepoPackageVersion. PackageVersion = '$(PackageVersion)' and RepoPackageVersion = '$(RepoPackageVersion)'"
+             Code="KRB2002"
+             Condition="'$(RepoPackageVersion)' != '' AND '$(RepoPackageVersion)' != '$(PackageVersion)' AND '$(VerifyVersion)' != 'false' " />
   </Target>
 
   <Target Name="_CoreGenerateCSharpForResources">

--- a/version.props
+++ b/version.props
@@ -3,5 +3,6 @@
     <KoreBuildChannel>dev</KoreBuildChannel>
     <VersionPrefix>2.1.0</VersionPrefix>
     <VersionSuffix>preview1</VersionSuffix>
+    <VersionSuffix Condition="'$(BuildNumber)' != ''">$(VersionSuffix)-$(BuildNumber)</VersionSuffix>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Changes:
 - Import version.props into KoreBuild
 - Issue warnings when package warnings are inconsistent with the repo's version

Changes we should make to projects:

 - version.xml => version.props. I'm having buyers remorse on naming it xml. See also #388 
 - Lift this line from common.props/DB.props into version.props: 
    ```xml
    <VersionSuffix Condition="'$(VersionSuffix)'!='' AND '$(BuildNumber)' != ''">$(VersionSuffix)-$(BuildNumber)</VersionSuffix>
    ```

 - The new version.xml for most repos:
```xml
<Project>
  <PropertyGroup>
    <VersionPrefix>2.1.0</VersionPrefix>
    <VersionSuffix>preview1</VersionSuffix>
    <VersionSuffix Condition=" '$(VersionSuffix)' != '' AND '$(BuildNumber)' != '' ">$(VersionSuffix)-$(BuildNumber)</VersionSuffix>
  </PropertyGroup>
</Project>
```