### PR TITLE
Show a warning when there is a duplicate package reference instead of failing

### DIFF
--- a/files/KoreBuild/msbuild/KoreBuild.RepoTasks.Sdk/Sdk/Sdk.props
+++ b/files/KoreBuild/msbuild/KoreBuild.RepoTasks.Sdk/Sdk/Sdk.props
@@ -1,6 +1,7 @@
 <Project>
 
   <PropertyGroup>
+    <GenerateFullPaths Condition="'$(VSCODE_PID)' != ''">true</GenerateFullPaths>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 
     <!-- Set explicitly to make it clear that this is not a console app, even though it targets netcoreapp2.0 -->

--- a/modules/KoreBuild.Tasks/ApplyNuGetPolicies.cs
+++ b/modules/KoreBuild.Tasks/ApplyNuGetPolicies.cs
@@ -205,7 +205,7 @@ namespace KoreBuild.Tasks
 
                 try
                 {
-                    projects.Add(ProjectInfoFactory.Create(projectFile));
+                    projects.Add(new ProjectInfoFactory(Log).Create(projectFile));
                 }
                 catch (Exception ex)
                 {

--- a/modules/KoreBuild.Tasks/Internal/KoreBuildErrors.cs
+++ b/modules/KoreBuild.Tasks/Internal/KoreBuildErrors.cs
@@ -12,6 +12,7 @@ namespace KoreBuild.Tasks
 
         // Warnings
         public const int DotNetAssetVersionIsFloating = 2000;
+        public const int DuplicatePackageReference = 2003;
 
         // NuGet errors
         public const int InvalidNuspecFile = 4001;

--- a/modules/KoreBuild.Tasks/Internal/ProjectModel/ProjectFrameworkInfo.cs
+++ b/modules/KoreBuild.Tasks/Internal/ProjectModel/ProjectFrameworkInfo.cs
@@ -10,10 +10,6 @@ namespace KoreBuild.Tasks.ProjectModel
 {
     internal class ProjectFrameworkInfo
     {
-        public ProjectFrameworkInfo(NuGetFramework targetFramework, IEnumerable<PackageReferenceInfo> dependencies)
-            : this(targetFramework, dependencies.ToDictionary(i => i.Id, i => i, StringComparer.OrdinalIgnoreCase))
-        { }
-
         public ProjectFrameworkInfo(NuGetFramework targetFramework, IReadOnlyDictionary<string, PackageReferenceInfo> dependencies)
         {
             TargetFramework = targetFramework ?? throw new ArgumentNullException(nameof(targetFramework));

--- a/test/KoreBuild.Tasks.Tests/PackageLineupPolicyTests.cs
+++ b/test/KoreBuild.Tasks.Tests/PackageLineupPolicyTests.cs
@@ -3,7 +3,9 @@
 
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text;
 using System.Threading;
 using BuildTools.Tasks.Tests;
@@ -97,7 +99,7 @@ namespace KoreBuild.Tasks.Tests
                 new PackageReferenceInfo("Microsoft.NETCore.App", "2.0.0", isImplicitlyDefined: true, noWarn: Array.Empty<string>()),
                 new PackageReferenceInfo("Microsoft.AspNetCore", string.Empty, false, Array.Empty<string>()),
                 new PackageReferenceInfo("xunit", "2.2.0", false, Array.Empty<string>()),
-            };
+            }.ToDictionary(i => i.Id, i => i);
 
             var framework = new[] { new ProjectFrameworkInfo(FrameworkConstants.CommonFrameworks.NetCoreApp20, packageRef) };
             var projectDir = AppContext.BaseDirectory;
@@ -167,7 +169,7 @@ namespace KoreBuild.Tasks.Tests
             _logger);
 
             var frameworks = new[] {
-                new ProjectFrameworkInfo(projectFramework, new[] { new PackageReferenceInfo("Microsoft.NETCore.App", "99.99.99", isImplicitlyDefined: true, noWarn: Array.Empty<string>()) }),
+                new ProjectFrameworkInfo(projectFramework, new [] { new PackageReferenceInfo("Microsoft.NETCore.App", "99.99.99", isImplicitlyDefined: true, noWarn: Array.Empty<string>()) }.ToDictionary(i => i.Id, i => i)),
             };
             var projectDir = AppContext.BaseDirectory;
             var project = new ProjectInfo(Path.Combine(projectDir, "Test.csproj"), null, frameworks, Array.Empty<DotNetCliReferenceInfo>());
@@ -226,7 +228,7 @@ namespace KoreBuild.Tasks.Tests
                             {
                                 new PackageReferenceInfo("TestBundledPkg", string.Empty, false, Array.Empty<string>()),
                                 new PackageReferenceInfo("AnotherBundledPkg", "1.0.0", false, Array.Empty<string>())
-                            })
+                            }.ToDictionary(i => i.Id, i => i))
                         },
                         Array.Empty<DotNetCliReferenceInfo>());
             var context = new PolicyContext


### PR DESCRIPTION
Make it easier to diagnose when multiple PackageReference's for the same package exist