### PR TITLE
Execute test assemblies in parallel

### DIFF
--- a/build/tasks/RepoTasks.csproj
+++ b/build/tasks/RepoTasks.csproj
@@ -9,10 +9,13 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\..\shared\Microsoft.Extensions.CommandLineUtils.Sources\Utilities\*.cs" />
     <Compile Include="..\..\shared\Utilities\MSBuildListSplitter.cs" />
     <Compile Include="..\..\modules\BuildTools.Tasks\Utilities\**" />
     <Compile Include="..\..\modules\BuildTools.Tasks\GetGitCommitInfo.cs" />
     <Compile Include="..\..\modules\BuildTools.Tasks\GenerateFileFromTemplate.cs" />
+    <Compile Include="..\..\modules\BuildTools.Tasks\RunBase.cs" />
+    <Compile Include="..\..\modules\BuildTools.Tasks\RunDotNet.cs" />
     <Compile Include="..\..\modules\BuildTools.Tasks\ZipArchive.cs" />
   </ItemGroup>
 

--- a/build/tasks/RepoTasks.tasks
+++ b/build/tasks/RepoTasks.tasks
@@ -5,6 +5,7 @@
 
   <UsingTask TaskName="Microsoft.AspNetCore.BuildTools.GetGitCommitInfo" AssemblyFile="$(_RepoTaskAssembly)" />
   <UsingTask TaskName="Microsoft.AspNetCore.BuildTools.GenerateFileFromTemplate" AssemblyFile="$(_RepoTaskAssembly)" />
+  <UsingTask TaskName="Microsoft.AspNetCore.BuildTools.RunDotNet" AssemblyFile="$(_RepoTaskAssembly)" />
   <UsingTask TaskName="Microsoft.AspNetCore.BuildTools.ZipArchive" AssemblyFile="$(_RepoTaskAssembly)" />
   <UsingTask TaskName="RepoTasks.GenerateBadge" AssemblyFile="$(_RepoTaskAssembly)" />
 </Project>

--- a/files/KoreBuild/modules/vstest/Project.Inspection.targets
+++ b/files/KoreBuild/modules/vstest/Project.Inspection.targets
@@ -1,0 +1,28 @@
+<Project>
+
+  <PropertyGroup>
+    <GetTestAssemblyDependsOn Condition="'$(TargetFramework)' != ''">GetTargetPath</GetTestAssemblyDependsOn>
+    <TestGroupName Condition="'$(TestGroupName)' == ''">UnitTests</TestGroupName>
+  </PropertyGroup>
+
+  <Target Name="GetTestAssembly" DependsOnTargets="$(GetTestAssemblyDependsOn)" Returns="@(TestAssembly)">
+    <ItemGroup Condition=" '$(IsTestProject)' == 'true' ">
+      <TestAssembly Include="@(TargetPathWithTargetPlatformMoniker)">
+        <TargetFramework>$(TargetFramework)</TargetFramework>
+        <TestGroupName>$(TestGroupName)</TestGroupName>
+      </TestAssembly>
+    </ItemGroup>
+
+    <ItemGroup>
+      <_TargetFramework Include="$(TargetFrameworks)" />
+    </ItemGroup>
+
+    <MSBuild Targets="GetTestAssembly"
+             Projects="$(MSBuildProjectFullPath)"
+             Properties="TargetFramework=%(_TargetFramework.Identity)"
+             Condition=" '$(TargetFrameworks)' != '' AND '$(TargetFramework)' == '' ">
+      <Output TaskParameter="TargetOutputs" ItemName="TestAssembly" />
+    </MSBuild>
+  </Target>
+
+</Project>

--- a/files/KoreBuild/modules/vstest/module.targets
+++ b/files/KoreBuild/modules/vstest/module.targets
@@ -64,13 +64,11 @@ Runs the VSTest on all projects in the ProjectsToTest itemgroup.
   <PropertyGroup>
     <TrxFile>$(ArtifactsDir)tests\$(TestGroupName)-$(TargetFramework)-$(BuildNumber).trx</TrxFile>
     <VSTestLogger Condition=" '$(VSTestLogger)' == '' AND '$(TEAMCITY_VERSION)' != '' ">trx;LogFileName=$(TrxFile)</VSTestLogger>
-    <VSTestAutoReporters Condition=" '$(VSTestAutoReporters)' == '' AND '$(VSTestLogger)' != '' ">false</VSTestAutoReporters>
-    <VSTestAutoReporters Condition=" '$(VSTestAutoReporters)' == '' ">true</VSTestAutoReporters>
     <!--
       Disable other test reporters if trx logging is enabled.
-      VSTestCLIRunSettings is a space-separated list of key=value pairs.
     -->
-    <VSTestCLIRunSettings Condition=" '$(VSTestAutoReporters)' != 'true' ">RunConfiguration.NoAutoReporters=true $(VSTestCLIRunSettings)</VSTestCLIRunSettings>
+    <VSTestAutoReporters Condition=" '$(VSTestAutoReporters)' == '' AND '$(VSTestLogger)' != '' ">false</VSTestAutoReporters>
+    <VSTestAutoReporters Condition=" '$(VSTestAutoReporters)' == '' ">true</VSTestAutoReporters>
   </PropertyGroup>
 
   <Target Name="_ExecuteTestAssemblies">
@@ -79,21 +77,25 @@ Runs the VSTest on all projects in the ProjectsToTest itemgroup.
     </ItemGroup>
 
     <PropertyGroup>
-      <VSTestArgs />
-      <VSTestArgs>--Parallel</VSTestArgs>
-      <VSTestArgs>$(VSTestArgs) --Framework:$(TargetFrameworkIdentifier),Version=v$(TargetFrameworkVersion)</VSTestArgs>
-      <VSTestArgs Condition="'$(VSTestLogger)' != ''">$(VSTestArgs) --Logger:$(VSTestLogger)</VSTestArgs>
       <TestAdapterPath>%(TestAssemblies.RootDir)%(TestAssemblies.Directory)</TestAdapterPath>
-      <VSTestArgs Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' ">$(VSTestArgs) --TestAdapterPath:$(TestAdapterPath)</VSTestArgs>
-      <VSTestArgs>$(VSTestArgs) @(TestAssemblies, ' ')</VSTestArgs>
-      <VSTestArgs Condition="'$(VSTestCLIRunSettings)' != ''">$(VSTestArgs) -- $(VSTestCLIRunSettings)</VSTestArgs>
     </PropertyGroup>
+
+    <ItemGroup>
+      <VSTestArgs Remove="@(VSTestArgs)" />
+      <VSTestArgs Include="vstest" />
+      <VSTestArgs Include="--Parallel" />
+      <VSTestArgs Include="--Framework:$(TargetFrameworkIdentifier),Version=v$(TargetFrameworkVersion)" />
+      <VSTestArgs Include="--Logger:$(VSTestLogger)" Condition="'$(VSTestLogger)' != ''" />
+      <VSTestArgs Include="--TestAdapterPath:$(TestAdapterPath)" Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' " />
+      <VSTestArgs Include="@(TestAssemblies)" />
+      <VSTestArgs Include="--;RunConfiguration.NoAutoReporters=true" Condition="'$(VSTestAutoReporters)' != 'true'" />
+    </ItemGroup>
 
     <Message Text="%0AStarting test group: $(TestGroupName)/$(TargetFramework)" Importance="High" />
 
-    <Exec Command="dotnet vstest $(VSTestArgs)" UseCommandProcessor="false" IgnoreStandardErrorWarningFormat="true" IgnoreExitCode="true">
+    <RunDotNet Arguments="@(VSTestArgs)" IgnoreExitCode="true">
       <Output TaskParameter="ExitCode" PropertyName="VsTestExitCode" />
-    </Exec>
+    </RunDotNet>
 
     <Message Text="##teamcity[importData type='vstest' path='$(TrxFile)']" Condition="'$(TEAMCITY_VERSION)' != ''" Importance="High" />
     <Error Text="Test group $(TestGroupName)/$(TargetFramework) failed" Condition=" $(VsTestExitCode) != 0 " />
@@ -109,7 +111,7 @@ Runs the VSTest on all projects in the ProjectsToTest itemgroup.
       <Output TaskParameter="TargetOutputs" PropertyName="ExecPath" />
     </MSBuild>
 
-    <Exec Command="dotnet $(ExecPath) * --validate-fast" IgnoreStandardErrorWarningFormat="true" />
+    <RunDotNet Command="$(ExecPath) * --validate-fast" />
   </Target>
 
 </Project>

--- a/files/KoreBuild/modules/vstest/module.targets
+++ b/files/KoreBuild/modules/vstest/module.targets
@@ -20,40 +20,83 @@ Runs the VSTest on all projects in the ProjectsToTest itemgroup.
 -->
   <PropertyGroup>
     <TestDependsOn>$(TestDependsOn);TestProjects;ValidateBenchmarks</TestDependsOn>
-    <VSTestLogger Condition=" '$(VSTestLogger)' == '' AND '$(TEAMCITY_VERSION)' != '' ">trx</VSTestLogger>
-    <VSTestAutoReporters Condition=" '$(VSTestAutoReporters)' == '' AND '$(VSTestLogger)' != '' ">false</VSTestAutoReporters>
-    <VSTestAutoReporters Condition=" '$(VSTestAutoReporters)' == '' ">true</VSTestAutoReporters>
     <IgnoreFailingTestProjects>false</IgnoreFailingTestProjects>
     <IgnoreFailingTestProjects Condition="'$(KOREBUILD_IGNORE_DOTNET_TEST_EXIT_CODE)' == '1'">true</IgnoreFailingTestProjects>
   </PropertyGroup>
 
-  <Target Name="TestProjects" DependsOnTargets="ResolveSolutions">
-    <RemoveDuplicates Inputs="@(ProjectsToTest)">
-      <Output TaskParameter="Filtered" ItemName="_TestProjectItems" />
-    </RemoveDuplicates>
-
-    <Message Text="%0ARunning tests for:%0A@(_TestProjectItems -> '%(FileName)','%0A')%0A"
-      Importance="High"
-      Condition="'@(_TestProjectItems)' != ''" />
-
+  <Target Name="GetTestAssemblies" DependsOnTargets="ResolveSolutions" Returns="@(TestAssembly)">
     <PropertyGroup>
-      <!--
-        Disable other test reporters if trx logging is enabled.
-        VSTestCLIRunSettings is a space-separated list of key=value pairs.
-      -->
-      <VSTestCLIRunSettings Condition=" '$(VSTestAutoReporters)' != 'true' ">RunConfiguration.NoAutoReporters=true $(VSTestCLIRunSettings)</VSTestCLIRunSettings>
-      <VSTestNoBuild Condition="'$(VSTestNoBuild)' == ''">$(_SolutionWasBuilt)</VSTestNoBuild>
+      <_InspectionTargetsFile>$(MSBuildThisFileDirectory)Project.Inspection.targets</_InspectionTargetsFile>
+    </PropertyGroup>
+
+    <MSBuild Projects="@(ProjectsToTest)"
+      Targets="GetTestAssembly"
+      Properties="$(SolutionProperties);CustomAfterMicrosoftCommonTargets=$(_InspectionTargetsFile);CustomAfterMicrosoftCommonCrossTargetingTargets=$(_InspectionTargetsFile);%(ProjectsToTest.AdditionalProperties)"
+      Condition="@(ProjectsToTest->Count()) != 0"
+      RemoveProperties="$(_BuildPropertiesToRemove)">
+      <Output TaskParameter="TargetOutputs" ItemName="TestAssembly" />
+    </MSBuild>
+  </Target>
+
+  <Target Name="TestProjects" DependsOnTargets="GetTestAssemblies">
+    <PropertyGroup>
       <_TestContinueOnError Condition="'$(IgnoreFailingTestProjects)' == 'true'">ErrorAndContinue</_TestContinueOnError>
       <_TestContinueOnError Condition="'$(IgnoreFailingTestProjects)' != 'true'">ErrorAndStop</_TestContinueOnError>
     </PropertyGroup>
 
-    <!-- Intentional use of batching ('%') instead of passing items ('@') so that tests fail sooner -->
-    <MSBuild Projects="%(_TestProjectItems.Identity)"
-      Targets="VSTest"
-      Properties="$(SolutionProperties);VSTestLogger=$(VSTestLogger);VSTestNoBuild=$(VSTestNoBuild);VSTestCLIRunSettings=$([MSBuild]::Escape('$(VSTestCLIRunSettings)'));%(_TestProjectItems.AdditionalProperties)"
-      Condition="'@(_TestProjectItems)' != ''"
-      ContinueOnError="$(_TestContinueOnError)"
-      RemoveProperties="$(_BuildPropertiesToRemove)" />
+    <Message Text="%0ATest plan:" Importance="High" />
+    <Message Text="  - %(TestAssembly.TestGroupName)/%(TestAssembly.TargetFramework)%0A    - @(TestAssembly->'%(FileName)', '%0A    - ')" Importance="High" Condition="@(TestAssembly->Count()) != 0" />
+    <Message Text="  - (No test projects found)" Importance="High" Condition="@(TestAssembly->Count()) == 0"  />
+
+    <ItemGroup>
+      <TestGroups Include="$(MSBuildProjectFullPath)" Condition="'%(TestAssembly.TestGroupName)' != ''">
+        <AdditionalProperties>Assemblies=@(TestAssembly);TestGroupName=%(TestAssembly.TestGroupName);TargetFramework=%(TestAssembly.TargetFramework);TargetFrameworkIdentifier=%(TestAssembly.TargetFrameworkIdentifier);TargetFrameworkVersion=%(TestAssembly.TargetFrameworkVersion)</AdditionalProperties>
+      </TestGroups>
+    </ItemGroup>
+
+    <MSBuild Projects="@(TestGroups)"
+             Targets="_ExecuteTestAssemblies"
+             Condition="@(TestGroups->Count()) != 0"
+             ContinueOnError="$(_TestContinueOnError)" />
+  </Target>
+
+  <!-- The 'inner-build' -->
+  <PropertyGroup>
+    <TrxFile>$(ArtifactsDir)tests\$(TestGroupName)-$(TargetFramework)-$(BuildNumber).trx</TrxFile>
+    <VSTestLogger Condition=" '$(VSTestLogger)' == '' AND '$(TEAMCITY_VERSION)' != '' ">trx;LogFileName=$(TrxFile)</VSTestLogger>
+    <VSTestAutoReporters Condition=" '$(VSTestAutoReporters)' == '' AND '$(VSTestLogger)' != '' ">false</VSTestAutoReporters>
+    <VSTestAutoReporters Condition=" '$(VSTestAutoReporters)' == '' ">true</VSTestAutoReporters>
+    <!--
+      Disable other test reporters if trx logging is enabled.
+      VSTestCLIRunSettings is a space-separated list of key=value pairs.
+    -->
+    <VSTestCLIRunSettings Condition=" '$(VSTestAutoReporters)' != 'true' ">RunConfiguration.NoAutoReporters=true $(VSTestCLIRunSettings)</VSTestCLIRunSettings>
+  </PropertyGroup>
+
+  <Target Name="_ExecuteTestAssemblies">
+    <ItemGroup>
+      <TestAssemblies Include="$(Assemblies)" />
+    </ItemGroup>
+
+    <PropertyGroup>
+      <VSTestArgs />
+      <VSTestArgs>--Parallel</VSTestArgs>
+      <VSTestArgs>$(VSTestArgs) --Framework:$(TargetFrameworkIdentifier),Version=v$(TargetFrameworkVersion)</VSTestArgs>
+      <VSTestArgs Condition="'$(VSTestLogger)' != ''">$(VSTestArgs) --Logger:$(VSTestLogger)</VSTestArgs>
+      <TestAdapterPath>%(TestAssemblies.RootDir)%(TestAssemblies.Directory)</TestAdapterPath>
+      <VSTestArgs Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' ">$(VSTestArgs) --TestAdapterPath:$(TestAdapterPath)</VSTestArgs>
+      <VSTestArgs>$(VSTestArgs) @(TestAssemblies, ' ')</VSTestArgs>
+      <VSTestArgs Condition="'$(VSTestCLIRunSettings)' != ''">$(VSTestArgs) -- $(VSTestCLIRunSettings)</VSTestArgs>
+    </PropertyGroup>
+
+    <Message Text="%0AStarting test group: $(TestGroupName)/$(TargetFramework)" Importance="High" />
+
+    <Exec Command="dotnet vstest $(VSTestArgs)" UseCommandProcessor="false" IgnoreStandardErrorWarningFormat="true" IgnoreExitCode="true">
+      <Output TaskParameter="ExitCode" PropertyName="VsTestExitCode" />
+    </Exec>
+
+    <Message Text="##teamcity[importData type='vstest' path='$(TrxFile)']" Condition="'$(TEAMCITY_VERSION)' != ''" Importance="High" />
+    <Error Text="Test group $(TestGroupName)/$(TargetFramework) failed" Condition=" $(VsTestExitCode) != 0 " />
   </Target>
 
   <Target Name="ValidateBenchmarks" DependsOnTargets="ResolveSolutions" Condition=" '$(EnableBenchmarkValidation)' == 'true' ">
@@ -68,4 +111,5 @@ Runs the VSTest on all projects in the ProjectsToTest itemgroup.
 
     <Exec Command="dotnet $(ExecPath) * --validate-fast" IgnoreStandardErrorWarningFormat="true" />
   </Target>
+
 </Project>

--- a/modules/BuildTools.Tasks/BuildTools.Tasks.props
+++ b/modules/BuildTools.Tasks/BuildTools.Tasks.props
@@ -18,5 +18,7 @@
   <UsingTask TaskName="Microsoft.AspNetCore.BuildTools.$(_BuildTasksPrefix)FindUnusedReferences" AssemblyFile="$(_BuildToolsAssembly)"
     Condition="'$(MSBuildRuntimeType)' == 'Core'" />
   <UsingTask TaskName="Microsoft.AspNetCore.BuildTools.$(_BuildTasksPrefix)CreateSourceLink" AssemblyFile="$(_BuildToolsAssembly)" />
+  <UsingTask TaskName="Microsoft.AspNetCore.BuildTools.$(_BuildTasksPrefix)Run" AssemblyFile="$(_BuildToolsAssembly)" />
+  <UsingTask TaskName="Microsoft.AspNetCore.BuildTools.$(_BuildTasksPrefix)RunDotNet" AssemblyFile="$(_BuildToolsAssembly)" />
 
 </Project>

--- a/modules/BuildTools.Tasks/Run.cs
+++ b/modules/BuildTools.Tasks/Run.cs
@@ -1,0 +1,29 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Build.Framework;
+
+namespace Microsoft.AspNetCore.BuildTools
+{
+    /// <summary>
+    /// A task that runs a process without piping output into the logger.
+    /// See <seealso cref="RunBase" /> for more arguments.
+    /// </summary>
+#if SDK
+    public class Sdk_Run
+#elif BuildTools
+    public class Run
+#else
+#error This must be built either for an SDK or for BuildTools
+#endif
+        : RunBase
+    {
+        /// <summary>
+        /// The executable to run. Can be a file path or a command for an executable on the system PATH.
+        /// </summary>
+        [Required]
+        public string FileName { get; set; }
+
+        protected override string GetExecutable() => FileName;
+    }
+}

--- a/modules/BuildTools.Tasks/RunBase.cs
+++ b/modules/BuildTools.Tasks/RunBase.cs
@@ -1,0 +1,197 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using Microsoft.Build.Utilities;
+using Microsoft.Build.Framework;
+using Microsoft.Extensions.CommandLineUtils;
+
+namespace Microsoft.AspNetCore.BuildTools
+{
+    /// <summary>
+    /// A task that runs a process without piping output into the logger.
+    /// </summary>
+    public abstract class RunBase : Task
+    {
+        private static readonly char[] EqualsArray = new[] { '=' };
+
+        private const int OK = 0;
+
+        protected abstract string GetExecutable();
+
+        /// <summary>
+        /// A list of arguments to be passed to the executable. The task will escape them for spaces and quotes.
+        /// Cannot be used with <see cref="Command"/>
+        /// </summary>
+        public ITaskItem[] Arguments { get; set; }
+
+        /// <summary>
+        /// The command to pass to the executable as string.
+        /// Cannot be used with <see cref="Arguments"/>
+        /// </summary>
+        public string Command { get; set; }
+
+        /// <summary>
+        /// Environment variables to set on the process.
+        /// </summary>
+        /// <remarks>
+        /// The item spec will split on '='. Alternatively, it will look for the metadata name "Value".
+        /// </remarks>
+        public ITaskItem[] EnvironmentVariables { get; set; }
+
+        // Additional options
+        /// <summary>
+        /// The current working directory
+        /// </summary>
+        public string WorkingDirectory { get; set; }
+
+        /// <summary>
+        /// Don't fail the task if the command exits with a non-zero code
+        /// </summary>
+        public bool IgnoreExitCode { get; set; }
+
+        /// <summary>
+        /// Repeat the command up to this many times if the exit code is non-zero. Defaults to 0.
+        /// </summary>
+        public int MaxRetries { get; set; }
+
+        /// <summary>
+        /// Set the value for UseShellExecute on the new process.
+        /// </summary>
+        public bool UseShellExecute { get; set; }
+
+        [Output]
+        public int ExitCode { get; set; }
+
+        public override bool Execute()
+        {
+            var exe = GetExecutable();
+
+            if (string.IsNullOrEmpty(exe))
+            {
+                Log.LogError("FileName must be specified.");
+                return false;
+            }
+
+            if (MaxRetries < 0)
+            {
+                Log.LogError("MaxRetries must be a non-negative number.");
+                return false;
+            }
+
+            if (!string.IsNullOrEmpty(WorkingDirectory) && !Directory.Exists(WorkingDirectory))
+            {
+                Log.LogError("WorkingDirectory does not exist: '{0}'", WorkingDirectory);
+                return false;
+            }
+
+            // if path is not rooted, it may be a command on the system PATH
+            if (Path.IsPathRooted(exe) && !File.Exists(exe))
+            {
+                Log.LogError("FileName does not exist: '{0}'", WorkingDirectory);
+                return false;
+            }
+
+            var arguments = string.Empty;
+            var cmd = 0;
+            if (Arguments != null)
+            {
+                arguments = ArgumentEscaper.EscapeAndConcatenate(Arguments.Select(i => i.ItemSpec));
+                cmd++;
+            }
+
+            if (!string.IsNullOrEmpty(Command))
+            {
+                arguments = Command;
+                cmd++;
+            }
+
+            if (cmd > 1)
+            {
+                Log.LogError("Arguments and Command cannot both be used.");
+                return false;
+            }
+
+            var process = new Process
+            {
+                StartInfo =
+                {
+                    FileName = exe,
+                    Arguments = arguments,
+                    WorkingDirectory = WorkingDirectory ?? Directory.GetCurrentDirectory(),
+                    UseShellExecute = UseShellExecute
+                },
+            };
+
+            foreach (var var in GetEnvVars(EnvironmentVariables))
+            {
+                process.StartInfo.Environment[var.Key] = var.Value;
+            }
+
+            var remainingTries = MaxRetries;
+            do
+            {
+                try
+                {
+                    Log.LogMessage(MessageImportance.Low, "Starting process: {0} {1}", process.StartInfo.FileName, process.StartInfo.Arguments);
+                    Log.LogMessage(MessageImportance.Low, "Working directory: {0}", process.StartInfo.WorkingDirectory);
+                    if (remainingTries != MaxRetries)
+                    {
+                        Log.LogMessage(MessageImportance.Normal, "Retrying failed command. Remaining retries {0}", remainingTries);
+                    }
+                    process.Start();
+                }
+                catch (Exception e)
+                {
+                    Log.LogError("Run failed to start the process");
+                    Log.LogError(e.Message);
+                    return false;
+                }
+
+                process.WaitForExit();
+
+                ExitCode = process.ExitCode;
+
+                if (process.ExitCode == OK)
+                {
+                    break;
+                }
+            } while (remainingTries-- > 0);
+
+            var success = IgnoreExitCode || process.ExitCode == OK;
+            if (!success)
+            {
+                Log.LogError("Run exited with a non-zero exit code: {0} {1}", process.StartInfo.FileName, process.StartInfo.Arguments);
+            }
+            return success;
+        }
+
+        private static Dictionary<string, string> GetEnvVars(ITaskItem[] envVars)
+        {
+            var values = new Dictionary<string, string>();
+            if (envVars == null)
+            {
+                return values;
+            }
+
+            foreach (var var in envVars)
+            {
+                var splitSpec = var.ItemSpec.Split(EqualsArray, 2);
+                if (splitSpec.Length > 1)
+                {
+                    values.Add(splitSpec[0], splitSpec[1]);
+                    continue;
+                }
+                var value = var.GetMetadata("Value");
+                values.Add(splitSpec[0], value);
+            }
+
+            return values;
+        }
+    }
+}

--- a/modules/BuildTools.Tasks/RunDotNet.cs
+++ b/modules/BuildTools.Tasks/RunDotNet.cs
@@ -1,0 +1,28 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Extensions.CommandLineUtils;
+
+namespace Microsoft.AspNetCore.BuildTools
+{
+    /// <summary>
+    /// A task that runs a dotnet command without piping output into the logger.
+    /// See <seealso cref="RunBase" /> for more arguments.
+    /// </summary>
+#if SDK
+    public class Sdk_RunDotNet
+#elif BuildTools
+    public class RunDotNet
+#else
+#error This must be built either for an SDK or for BuildTools
+#endif
+        : RunBase
+    {
+        protected override string GetExecutable()
+#if NET46
+            => "dotnet";
+#else
+            => DotNetMuxer.MuxerPathOrDefault();
+#endif
+    }
+}


### PR DESCRIPTION
This invokes `dotnet vstest` directly instead of invoking /t:VSTest on projects.

For projects that do not want test assemblies to run in parallel, they can put projects into custom test groups like this:

```xml
<!-- MyTests.csproj-->
<PropertyGroup>
  <TestGroupName>IntegrationTests</TestGroupName>
</PropertyGroup>
```

The default value of TestGroupName is 'UnitTests'.

If you want all tests in a solution to run in serial, you could to this in test/Directory.Build.props so all test/\*/\*.csproj files pick it up.
```xml
<!-- test/Directory.Build.props -->
<PropertyGroup>
  <TestGroupName>$(MSBuildProjectName)</TestGroupName>
</PropertyGroup>
```

Part of #375 