### PR TITLE
Add GeneratePackageVersionPropsFile task

### DIFF
--- a/modules/KoreBuild.Tasks/GeneratePackageVersionPropsFile.cs
+++ b/modules/KoreBuild.Tasks/GeneratePackageVersionPropsFile.cs
@@ -59,21 +59,16 @@ namespace KoreBuild.Tasks
                     packageVarName = GetVariableName(pkg.ItemSpec);
                 }
 
-                var packageTfm = pkg.GetMetadata("TargetFramework");
-                var key = $"{packageVarName}/{packageTfm}";
-                if (varNames.ContainsKey(key))
+                if (varNames.ContainsKey(packageVarName))
                 {
-                    Log.LogError("Multiple packages would produce {0} in the generated dependencies.props file. Set VariableName to differentiate the packages manually", key);
+                    Log.LogError("Multiple packages would produce {0} in the generated dependencies.props file. Set VariableName to differentiate the packages manually", packageVarName);
                     continue;
                 }
+
                 var elem = projectRoot.CreatePropertyElement(packageVarName);
                 elem.Value = packageVersion;
                 elem.Label = pkg.ItemSpec;
-                if (!string.IsNullOrEmpty(packageTfm))
-                {
-                    elem.Condition = $" '$(TargetFramework)' == '{packageTfm}' ";
-                }
-                varNames.Add(key, elem);
+                varNames.Add(packageVarName, elem);
             }
 
             foreach (var item in varNames)

--- a/modules/KoreBuild.Tasks/GeneratePackageVersionPropsFile.cs
+++ b/modules/KoreBuild.Tasks/GeneratePackageVersionPropsFile.cs
@@ -1,0 +1,115 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Microsoft.Build.Construction;
+using Microsoft.Build.Evaluation;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace KoreBuild.Tasks
+{
+    public class GeneratePackageVersionPropsFile : Task
+    {
+        [Required]
+        public ITaskItem[] Packages { get; set; }
+
+        [Required]
+        public string OutputPath { get; set; }
+
+        public override bool Execute()
+        {
+            OutputPath = OutputPath.Replace('\\', '/');
+            Directory.CreateDirectory(Path.GetDirectoryName(OutputPath));
+
+            var projectRoot = ProjectRootElement.Create(NewProjectFileOptions.None);
+
+            projectRoot.AddPropertyGroup().AddProperty("MSBuildAllProjects", "$(MSBuildAllProjects);$(MSBuildThisFileFullPath)");
+
+            var packageVersions = projectRoot.AddPropertyGroup();
+            packageVersions.Label = "Package Versions";
+
+            var varNames = new SortedDictionary<string, ProjectPropertyElement>();
+            foreach (var pkg in Packages)
+            {
+                var packageVersion = pkg.GetMetadata("Version");
+
+                if (string.IsNullOrEmpty(packageVersion))
+                {
+                    Log.LogError("Package {0} is missing the Version metadata", pkg.ItemSpec);
+                    continue;
+                }
+
+
+                string packageVarName;
+                if (!string.IsNullOrEmpty(pkg.GetMetadata("VariableName")))
+                {
+                    packageVarName = pkg.GetMetadata("VariableName");
+                    if (!packageVarName.EndsWith("Version", StringComparison.Ordinal))
+                    {
+                        Log.LogError("VariableName for {0} must end in 'Version'", pkg.ItemSpec);
+                        continue;
+                    }
+                }
+                else
+                {
+                    packageVarName = GetVariableName(pkg.ItemSpec);
+                }
+
+                var packageTfm = pkg.GetMetadata("TargetFramework");
+                var key = $"{packageVarName}/{packageTfm}";
+                if (varNames.ContainsKey(key))
+                {
+                    Log.LogError("Multiple packages would produce {0} in the generated dependencies.props file. Set VariableName to differentiate the packages manually", key);
+                    continue;
+                }
+                var elem = projectRoot.CreatePropertyElement(packageVarName);
+                elem.Value = packageVersion;
+                elem.Label = pkg.ItemSpec;
+                if (!string.IsNullOrEmpty(packageTfm))
+                {
+                    elem.Condition = $" '$(TargetFramework)' == '{packageTfm}' ";
+                }
+                varNames.Add(key, elem);
+            }
+
+            foreach (var item in varNames)
+            {
+                packageVersions.AppendChild(item.Value);
+            }
+
+            projectRoot.Save(OutputPath, Encoding.UTF8);
+            Log.LogMessage(MessageImportance.Normal, $"Generated {OutputPath}");
+            return !Log.HasLoggedErrors;
+        }
+
+        internal string GetVariableName(string packageId)
+        {
+            var sb = new StringBuilder();
+            var first = true;
+            foreach (var ch in packageId)
+            {
+                if (!char.IsLetterOrDigit(ch))
+                {
+                    first = true;
+                    continue;
+                }
+
+                if (first)
+                {
+                    first = false;
+                    sb.Append(char.ToUpperInvariant(ch));
+                }
+                else
+                {
+                    sb.Append(ch);
+                }
+            }
+            sb.Append("PackageVersion");
+            return sb.ToString();
+        }
+    }
+}

--- a/modules/KoreBuild.Tasks/GeneratePackageVersionPropsFile.cs
+++ b/modules/KoreBuild.Tasks/GeneratePackageVersionPropsFile.cs
@@ -20,6 +20,8 @@ namespace KoreBuild.Tasks
         [Required]
         public string OutputPath { get; set; }
 
+        public bool AddOverrideImport { get; set; }
+
         public override bool Execute()
         {
             OutputPath = OutputPath.Replace('\\', '/');
@@ -74,6 +76,12 @@ namespace KoreBuild.Tasks
             foreach (var item in varNames)
             {
                 packageVersions.AppendChild(item.Value);
+            }
+
+            if (AddOverrideImport)
+            {
+                var import = projectRoot.AddImport("$(DotNetPackageVersionPropsPath)");
+                import.Condition = " '$(DotNetPackageVersionPropsPath)' != '' ";
             }
 
             projectRoot.Save(OutputPath, Encoding.UTF8);

--- a/modules/KoreBuild.Tasks/KoreBuild.Tasks.csproj
+++ b/modules/KoreBuild.Tasks/KoreBuild.Tasks.csproj
@@ -15,6 +15,8 @@
   <ItemGroup>
     <!-- set as private assets all so these assemblies get resolved from the version bundled in the .NET Core SDK -->
     <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildVersion)" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildVersion)" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildVersion)" PrivateAssets="All" />
     <PackageReference Include="NuGet.Build.Tasks" Version="$(NuGetInMSBuildVersion)" PrivateAssets="All" />
     <PackageReference Include="Newtonsoft.Json" Version="$(JsonNetInMSBuildVersion)" PrivateAssets="All" />

--- a/modules/KoreBuild.Tasks/module.props
+++ b/modules/KoreBuild.Tasks/module.props
@@ -1,6 +1,7 @@
 <Project>
   <UsingTask TaskName="KoreBuild.Tasks.ApplyNuGetPolicies" AssemblyFile="$(MSBuildThisFileDirectory)Internal.AspNetCore.KoreBuild.Tasks.dll" />
   <UsingTask TaskName="KoreBuild.Tasks.DownloadNuGetPackages" AssemblyFile="$(MSBuildThisFileDirectory)Internal.AspNetCore.KoreBuild.Tasks.dll" />
+  <UsingTask TaskName="KoreBuild.Tasks.GeneratePackageVersionPropsFile" AssemblyFile="$(MSBuildThisFileDirectory)Internal.AspNetCore.KoreBuild.Tasks.dll" />
   <UsingTask TaskName="KoreBuild.Tasks.InstallDotNet" AssemblyFile="$(MSBuildThisFileDirectory)Internal.AspNetCore.KoreBuild.Tasks.dll" />
   <UsingTask TaskName="KoreBuild.Tasks.PackNuSpec" AssemblyFile="$(MSBuildThisFileDirectory)Internal.AspNetCore.KoreBuild.Tasks.dll" />
   <UsingTask TaskName="KoreBuild.Tasks.PushNuGetPackages" AssemblyFile="$(MSBuildThisFileDirectory)Internal.AspNetCore.KoreBuild.Tasks.dll" />

--- a/test/KoreBuild.Tasks.Tests/ApplyNuGetPoliciesTests.cs
+++ b/test/KoreBuild.Tasks.Tests/ApplyNuGetPoliciesTests.cs
@@ -15,16 +15,18 @@ using Xunit.Abstractions;
 
 namespace KoreBuild.Tasks.Tests
 {
+    [Collection(nameof(MSBuildTestCollection))]
     public class ApplyNuGetPoliciesTests : IDisposable
     {
         private readonly string _tmpDir;
         private readonly ITestOutputHelper _output;
 
-        public ApplyNuGetPoliciesTests(ITestOutputHelper output)
+        public ApplyNuGetPoliciesTests(ITestOutputHelper output, MSBuildTestCollectionFixture fixture)
         {
             _output = output;
             _tmpDir = Path.Combine(Path.GetTempPath(), "korebuild", Path.GetRandomFileName());
             Directory.CreateDirectory(_tmpDir);
+            fixture.InitializeEnvironment(output);
         }
 
         [Fact]
@@ -135,7 +137,6 @@ EndGlobal
                 new TaskItem(sln, new Hashtable { ["AdditionalProperties"] = "Configuration=ReleaseNoVSIX" }),
             };
 
-            MSBuildEnvironmentHelper.InitializeEnvironment(_output);
             var task = new ApplyNuGetPolicies
             {
                 ProjectProperties = new[] { "BuildNumber=123", "Configuration=Release" },

--- a/test/KoreBuild.Tasks.Tests/GeneratePackageVersionPropsFileTests.cs
+++ b/test/KoreBuild.Tasks.Tests/GeneratePackageVersionPropsFileTests.cs
@@ -13,15 +13,17 @@ using Xunit.Abstractions;
 
 namespace KoreBuild.Tasks.Tests
 {
+    [Collection(nameof(MSBuildTestCollection))]
     public class GeneratePackageVersionPropsFileTests : IDisposable
     {
         private readonly ITestOutputHelper _output;
         private readonly string _tempFile;
 
-        public GeneratePackageVersionPropsFileTests(ITestOutputHelper output)
+        public GeneratePackageVersionPropsFileTests(ITestOutputHelper output, MSBuildTestCollectionFixture fixture)
         {
             _output = output;
             _tempFile = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            fixture.InitializeEnvironment(output);
         }
 
         [Theory]

--- a/test/KoreBuild.Tasks.Tests/GeneratePackageVersionPropsFileTests.cs
+++ b/test/KoreBuild.Tasks.Tests/GeneratePackageVersionPropsFileTests.cs
@@ -73,7 +73,7 @@ namespace KoreBuild.Tasks.Tests
                     Assert.Equal("AnotherPackagePackageVersion", p.Name);
                     Assert.Equal("Another.Package", p.Label);
                     Assert.Equal("0.0.1", p.Value);
-                    Assert.Equal(" '$(TargetFramework)' == 'netstandard1.0' ", p.Condition);
+                    Assert.Empty(p.Condition);
                 },
                 p =>
                 {

--- a/test/KoreBuild.Tasks.Tests/GeneratePackageVersionPropsFileTests.cs
+++ b/test/KoreBuild.Tasks.Tests/GeneratePackageVersionPropsFileTests.cs
@@ -1,0 +1,102 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections;
+using System.IO;
+using BuildTools.Tasks.Tests;
+using Microsoft.Build.Construction;
+using Microsoft.Build.Utilities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace KoreBuild.Tasks.Tests
+{
+    public class GeneratePackageVersionPropsFileTests : IDisposable
+    {
+        private readonly ITestOutputHelper _output;
+        private readonly string _tempFile;
+
+        public GeneratePackageVersionPropsFileTests(ITestOutputHelper output)
+        {
+            _output = output;
+            _tempFile = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        }
+
+        [Theory]
+        [InlineData("Microsoft.Data.Sqlite", "MicrosoftDataSqlitePackageVersion")]
+        [InlineData("SQLitePCLRaw.bundle_green", "SQLitePCLRawBundleGreenPackageVersion")]
+        [InlineData("runtime.win-x64.Microsoft.NETCore", "RuntimeWinX64MicrosoftNETCorePackageVersion")]
+        public void ItGeneratesVariableName(string id, string varName)
+        {
+            var task = new GeneratePackageVersionPropsFile();
+            Assert.Equal(varName, task.GetVariableName(id));
+        }
+
+        [Fact]
+        public void ItGeneratesFile()
+        {
+            var engine = new MockEngine(_output);
+            var task = new GeneratePackageVersionPropsFile
+            {
+                BuildEngine = engine,
+                Packages = new[]
+                {
+                    // Order is important. These are intentionally reverse sorted to ensure the generated file sorts properties by prop name
+                    new TaskItem("Newtonsoft.Json", new Hashtable{["Version"] = "10.0.3", ["VariableName"] = "JsonNetVersion"}),
+                    new TaskItem("Microsoft.Azure", new Hashtable{["Version"] = "1.2.0"}),
+                    new TaskItem("Another.Package", new Hashtable{["Version"] = "0.0.1", ["TargetFramework"] = "netstandard1.0"}),
+                },
+                OutputPath = _tempFile,
+            };
+
+            Assert.True(task.Execute(), "Task is expected to pass");
+
+            var project = ProjectRootElement.Open(_tempFile);
+            _output.WriteLine(File.ReadAllText(_tempFile));
+
+            Assert.Empty(project.Imports);
+            Assert.Empty(project.ImportGroups);
+
+            var defaultPropGroup = Assert.Single(project.PropertyGroups, pg => string.IsNullOrEmpty(pg.Label));
+            var allProjectsProp = Assert.Single(defaultPropGroup.Properties);
+            Assert.Equal("MSBuildAllProjects", allProjectsProp.Name);
+            Assert.Empty(allProjectsProp.Condition);
+            Assert.Equal("$(MSBuildAllProjects);$(MSBuildThisFileFullPath)", allProjectsProp.Value);
+
+            var versions = Assert.Single(project.PropertyGroups, pg => pg.Label == "Package Versions");
+
+            // Order is important. These should be sorted.
+            Assert.Collection(versions.Properties,
+                p =>
+                {
+                    Assert.Equal("AnotherPackagePackageVersion", p.Name);
+                    Assert.Equal("Another.Package", p.Label);
+                    Assert.Equal("0.0.1", p.Value);
+                    Assert.Equal(" '$(TargetFramework)' == 'netstandard1.0' ", p.Condition);
+                },
+                p =>
+                {
+                    Assert.Equal("JsonNetVersion", p.Name);
+                    Assert.Equal("Newtonsoft.Json", p.Label);
+                    Assert.Equal("10.0.3", p.Value);
+                    Assert.Empty(p.Condition);
+                },
+                p =>
+                {
+                    Assert.Equal("MicrosoftAzurePackageVersion", p.Name);
+                    Assert.Equal("Microsoft.Azure", p.Label);
+                    Assert.Equal("1.2.0", p.Value);
+                    Assert.Empty(p.Condition);
+                });
+        }
+
+        public void Dispose()
+        {
+            if (File.Exists(_tempFile))
+            {
+                File.Delete(_tempFile);
+            }
+        }
+    }
+}

--- a/test/KoreBuild.Tasks.Tests/KoreBuild.Tasks.Tests.csproj
+++ b/test/KoreBuild.Tasks.Tests/KoreBuild.Tasks.Tests.csproj
@@ -13,6 +13,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildVersion)" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildVersion)" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildVersion)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
     <PackageReference Include="Moq" Version="$(MoqVersion)" />


### PR DESCRIPTION
Given a set of items, this task will produce a file that looks like this:

```xml
<Project>
  <PropertyGroup>
    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
  </PropertyGroup>
  <PropertyGroup Label="Package Versions">
    <AnotherPackagePackageVersion Label="Another.Package" Condition=" '$(TargetFramework)' == 'netstandard1.0' ">0.0.1</AnotherPackagePackageVersion>
    <JsonNetVersion Label="Newtonsoft.Json">10.0.3</JsonNetVersion>
    <MicrosoftAzurePackageVersion Label="Microsoft.Azure">1.2.0</MicrosoftAzurePackageVersion>
  </PropertyGroup>
</Project>
```