### PR TITLE
Add GetGitCommitHash and GetGitBranch tasks

### DIFF
--- a/build/repo.targets
+++ b/build/repo.targets
@@ -1,6 +1,5 @@
 <Project>
 
-  <!-- resolve using git.exe because the GetGitCommitInfoTask isn't available here -->
   <Target Name="ResolveCommitHash" Condition="'$(CommitHash)'==''" BeforeTargets="Prepare">
 
     <GetGitCommitInfo WorkingDirectory="$(RepositoryRoot)"

--- a/modules/BuildTools.Tasks/BuildTools.Tasks.props
+++ b/modules/BuildTools.Tasks/BuildTools.Tasks.props
@@ -3,6 +3,8 @@
   <UsingTask TaskName="Microsoft.AspNetCore.BuildTools.$(_BuildTasksPrefix)GenerateResxDesignerFiles" AssemblyFile="$(_BuildToolsAssembly)" />
   <UsingTask TaskName="Microsoft.AspNetCore.BuildTools.$(_BuildTasksPrefix)GenerateFileFromTemplate" AssemblyFile="$(_BuildToolsAssembly)" />
   <UsingTask TaskName="Microsoft.AspNetCore.BuildTools.$(_BuildTasksPrefix)GetAssemblyFileVersion" AssemblyFile="$(_BuildToolsAssembly)" />
+  <UsingTask TaskName="Microsoft.AspNetCore.BuildTools.$(_BuildTasksPrefix)GetGitBranch" AssemblyFile="$(_BuildToolsAssembly)" />
+  <UsingTask TaskName="Microsoft.AspNetCore.BuildTools.$(_BuildTasksPrefix)GetGitCommitHash" AssemblyFile="$(_BuildToolsAssembly)" />
   <UsingTask TaskName="Microsoft.AspNetCore.BuildTools.$(_BuildTasksPrefix)GetGitCommitInfo" AssemblyFile="$(_BuildToolsAssembly)" />
   <UsingTask TaskName="Microsoft.AspNetCore.BuildTools.$(_BuildTasksPrefix)GetDotNetHost" AssemblyFile="$(_BuildToolsAssembly)"
     Condition="'$(MSBuildRuntimeType)' == 'Core'"/>

--- a/modules/BuildTools.Tasks/GetGitBranch.cs
+++ b/modules/BuildTools.Tasks/GetGitBranch.cs
@@ -9,9 +9,9 @@ using Microsoft.Build.Utilities;
 namespace Microsoft.AspNetCore.BuildTools
 {
 #if SDK
-    public class Sdk_GetGitCommitInfo : Task
+    public class Sdk_GetGitBranch : Task
 #elif BuildTools
-    public class GetGitCommitInfo : Task
+    public class GetGitBranch : Task
 #else
 #error This must be built either for an SDK or for BuildTools
 #endif
@@ -30,18 +30,6 @@ namespace Microsoft.AspNetCore.BuildTools
         [Output]
         public string Branch { get; set; }
 
-        /// <summary>
-        /// The full commit SHA of the current commit referenced by HEAD.
-        /// </summary>
-        [Output]
-        public string CommitHash { get; set; }
-
-        /// <summary>
-        /// The folder containing the '.git', not the .git folder itself.
-        /// </summary>
-        [Output]
-        public string RepositoryRootPath { get; set; }
-
         public override bool Execute()
         {
             try
@@ -56,18 +44,17 @@ namespace Microsoft.AspNetCore.BuildTools
 
                 if (repoInfo.DetachedHeadMode)
                 {
-                    Log.LogWarning("The repo in '{0}' appears to be in detached HEAD mode. Unable to determine current git branch.", repoInfo.RepositoryRootPath);
+                    Log.LogError("The current git repo is in detached HEAD mode. It is not possible to determine the branch name.");
+                    return false;
                 }
 
-                if (string.IsNullOrEmpty(repoInfo.CommitHash))
+                if (string.IsNullOrEmpty(repoInfo.Branch))
                 {
-                    Log.LogError("Could not determine the commit hash of the current git repo in '{0}'.", repoInfo.RepositoryRootPath);
+                    Log.LogError("Could not determine the branch name of the current git repo in '{0}'.", repoInfo.RepositoryRootPath);
                     return false;
                 }
 
                 Branch = repoInfo.Branch;
-                CommitHash = repoInfo.CommitHash;
-                RepositoryRootPath = repoInfo.RepositoryRootPath;
                 return true;
             }
             catch (Exception ex)

--- a/modules/BuildTools.Tasks/GetGitCommitHash.cs
+++ b/modules/BuildTools.Tasks/GetGitCommitHash.cs
@@ -9,9 +9,9 @@ using Microsoft.Build.Utilities;
 namespace Microsoft.AspNetCore.BuildTools
 {
 #if SDK
-    public class Sdk_GetGitCommitInfo : Task
+    public class Sdk_GetGitCommitHash : Task
 #elif BuildTools
-    public class GetGitCommitInfo : Task
+    public class GetGitCommitHash : Task
 #else
 #error This must be built either for an SDK or for BuildTools
 #endif
@@ -24,23 +24,10 @@ namespace Microsoft.AspNetCore.BuildTools
         public string WorkingDirectory { get; set; }
 
         /// <summary>
-        /// The name of the branch HEAD is pointed to. Can be null or empty
-        /// for repositories in detached HEAD mode.
-        /// </summary>
-        [Output]
-        public string Branch { get; set; }
-
-        /// <summary>
         /// The full commit SHA of the current commit referenced by HEAD.
         /// </summary>
         [Output]
         public string CommitHash { get; set; }
-
-        /// <summary>
-        /// The folder containing the '.git', not the .git folder itself.
-        /// </summary>
-        [Output]
-        public string RepositoryRootPath { get; set; }
 
         public override bool Execute()
         {
@@ -54,20 +41,13 @@ namespace Microsoft.AspNetCore.BuildTools
                     repoInfo.Branch,
                     repoInfo.CommitHash);
 
-                if (repoInfo.DetachedHeadMode)
-                {
-                    Log.LogWarning("The repo in '{0}' appears to be in detached HEAD mode. Unable to determine current git branch.", repoInfo.RepositoryRootPath);
-                }
-
                 if (string.IsNullOrEmpty(repoInfo.CommitHash))
                 {
                     Log.LogError("Could not determine the commit hash of the current git repo in '{0}'.", repoInfo.RepositoryRootPath);
                     return false;
                 }
 
-                Branch = repoInfo.Branch;
                 CommitHash = repoInfo.CommitHash;
-                RepositoryRootPath = repoInfo.RepositoryRootPath;
                 return true;
             }
             catch (Exception ex)

--- a/modules/BuildTools.Tasks/Utilities/GitRepoInfo.cs
+++ b/modules/BuildTools.Tasks/Utilities/GitRepoInfo.cs
@@ -1,0 +1,164 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Linq;
+
+namespace Microsoft.AspNetCore.BuildTools.Utilities
+{
+    internal class GitRepoInfo
+    {
+        private const string HeadContentStart = "ref: refs/heads/";
+        private const string GitDirRefContentStart = "gitdir:";
+
+        private const int CommitShaLength = 40;
+
+        /// <summary>
+        /// The name of the branch HEAD is pointed to. Can be null or empty
+        /// for repositories in detached HEAD mode.
+        /// </summary>
+        public string Branch { get; set; }
+
+        /// <summary>
+        /// The full commit SHA of the current commit referenced by HEAD.
+        /// </summary>
+        public string CommitHash { get; private set; }
+
+        /// <summary>
+        /// The root folder of the working directory. Not the .git folder itself.
+        /// </summary>
+        public string RepositoryRootPath { get; private set; }
+
+        /// <summary>
+        /// The folder containing the .git folder
+        /// </summary>
+        public string GitDir { get; private set; }
+
+        /// <summary>
+        /// The repo is in detached head mode.
+        /// </summary>
+        public bool DetachedHeadMode { get; private set; }
+
+        /// <summary>
+        /// Full path to the HEAD file.
+        /// </summary>
+        public string HeadFile { get; set; }
+
+        /// <summary>
+        /// Find give info for a folder inside the git project. Does not need to be the top folder.
+        /// This task will search upwards for the .git folder.
+        /// </summary>
+        public static GitRepoInfo Load(string workingDirectory)
+        {
+            var repoRoot = GetRepositoryRoot(workingDirectory);
+            if (repoRoot == null)
+            {
+                throw new DirectoryNotFoundException($"Could not find the git directory for '{workingDirectory}'");
+            }
+
+            var info = new GitRepoInfo
+            {
+                RepositoryRootPath = FileHelpers.EnsureTrailingSlash(repoRoot.FullName)
+            };
+
+            switch (repoRoot.GetFileSystemInfos(".git").FirstOrDefault())
+            {
+                case DirectoryInfo d:
+                    // regular git working directories
+                    info.GitDir = d.FullName;
+                    info.HeadFile = Path.Combine(info.GitDir, "HEAD");
+                    break;
+                case FileInfo f:
+                    // submodules and worktrees
+                    var contents = File.ReadAllText(f.FullName);
+                    if (contents.StartsWith(GitDirRefContentStart, StringComparison.OrdinalIgnoreCase))
+                    {
+                        var gitdirRef = contents.Substring(GitDirRefContentStart.Length).Trim();
+                        var gitDirRoot = Path.IsPathRooted(gitdirRef)
+                            ? new DirectoryInfo(gitdirRef)
+                            : new DirectoryInfo(Path.Combine(f.Directory.FullName, gitdirRef));
+
+                        info.HeadFile = Path.Combine(gitDirRoot.FullName, "HEAD");
+
+                        var commonDir = gitDirRoot.GetFiles("commondir").FirstOrDefault();
+                        if (commonDir != null)
+                        {
+                            // happens in worktrees
+                            var commonDirRef = File.ReadAllText(commonDir.FullName).Trim();
+                            info.GitDir = Path.IsPathRooted(commonDirRef)
+                            ? commonDirRef
+                            : Path.Combine(gitDirRoot.FullName, commonDirRef);
+                        }
+                        else
+                        {
+                            // happens with submodules
+                            info.GitDir = gitDirRoot.FullName;
+                        }
+                    }
+                    else
+                    {
+                        throw new DirectoryNotFoundException($"Unable to determine the location of the .git directory. Unrecognized file format: {f.FullName}");
+                    }
+                    break;
+                case null:
+                default:
+                    throw new ArgumentOutOfRangeException("Unrecognized implementation of FileSystemInfo");
+            }
+
+            if (!File.Exists(info.HeadFile))
+            {
+                throw new FileNotFoundException("Unable to determine the status of the git repo. No HEAD file found.");
+            }
+
+            var content = File.ReadAllText(info.HeadFile).Trim();
+            if (content.StartsWith(HeadContentStart, StringComparison.OrdinalIgnoreCase))
+            {
+                info.Branch = content.Substring(HeadContentStart.Length);
+                info.CommitHash = ResolveHashFromBranch(info.GitDir, info.Branch);
+            }
+            else if (content.Length == CommitShaLength)
+            {
+                info.DetachedHeadMode = true;
+                info.CommitHash = content;
+            }
+            else
+            {
+                throw new InvalidOperationException($"Unable to determine the status of the git repo. THe HEAD file has an unexpected format: '{content}'");
+            }
+
+            return info;
+        }
+
+        private static string ResolveHashFromBranch(string gitDir, string branch)
+        {
+            if (string.IsNullOrEmpty(branch))
+            {
+                throw new InvalidOperationException("Current branch appears to be empty. Failed to retrieve current branch.");
+            }
+
+            var branchFile = Path.Combine(gitDir, "refs", "heads", branch);
+            if (!File.Exists(branchFile))
+            {
+                throw new FileNotFoundException("Unable to determine current git commit hash");
+            }
+
+            return File.ReadAllText(branchFile).Trim();
+        }
+
+        private static DirectoryInfo GetRepositoryRoot(string start)
+        {
+            var dir = new DirectoryInfo(start);
+            while (dir != null)
+            {
+                var dotGit = dir.GetFileSystemInfos(".git").FirstOrDefault();
+                if (dotGit != null)
+                {
+                    return dir;
+                }
+                dir = dir.Parent;
+            }
+            return null;
+        }
+    }
+}

--- a/modules/BuildTools.Tasks/module.targets
+++ b/modules/BuildTools.Tasks/module.targets
@@ -1,27 +1,23 @@
 <Project>
 
   <PropertyGroup>
-    <PrepareDependsOn>$(PrepareDependsOn);_UseVolatileFeed;ResolveGitInfo</PrepareDependsOn>
+    <PrepareDependsOn>$(PrepareDependsOn);_UseVolatileFeed;ResolveCommitHash</PrepareDependsOn>
   </PropertyGroup>
 
-  <Target Name="ResolveGitInfo" Condition="'$(CommitHash)' == ''">
+  <Target Name="ResolveCommitHash" Condition="'$(CommitHash)' == ''">
     <PropertyGroup>
       <CommitHash Condition="'$(APPVEYOR_REPO_COMMIT)' != ''">$(APPVEYOR_REPO_COMMIT)</CommitHash>
-      <GitBranch Condition="'$(APPVEYOR_REPO_BRANCH)' != ''">$(APPVEYOR_REPO_BRANCH)</GitBranch>
       <CommitHash Condition="'$(TRAVIS_COMMIT)' != ''">$(TRAVIS_COMMIT)</CommitHash>
-      <GitBranch Condition="'$(TRAVIS_BRANCH)' != ''">$(TRAVIS_BRANCH)</GitBranch>
     </PropertyGroup>
 
-    <GetGitCommitInfo WorkingDirectory="$(RepositoryRoot)"
+    <GetGitCommitHash WorkingDirectory="$(RepositoryRoot)"
                       Condition="'$(CommitHash)' == ''"
                       ContinueOnError="WarnAndContinue">
       <Output TaskParameter="CommitHash" PropertyName="CommitHash" />
-      <Output TaskParameter="Branch" PropertyName="GitBranch" />
-    </GetGitCommitInfo>
+    </GetGitCommitHash>
 
     <PropertyGroup>
       <SolutionProperties Condition="'$(CommitHash)' != ''">$(SolutionProperties);CommitHash=$(CommitHash)</SolutionProperties>
-      <SolutionProperties Condition="'$(GitBranch)' != ''">$(SolutionProperties);GitBranch=$(GitBranch)</SolutionProperties>
     </PropertyGroup>
   </Target>
 

--- a/src/Internal.AspNetCore.Sdk/build/Git.targets
+++ b/src/Internal.AspNetCore.Sdk/build/Git.targets
@@ -15,11 +15,11 @@
       <CommitHash Condition="'$(TRAVIS_COMMIT)' != ''">$(TRAVIS_COMMIT)</CommitHash>
     </PropertyGroup>
 
-    <Sdk_GetGitCommitInfo WorkingDirectory="$(MSBuildProjectDirectory)"
+    <Sdk_GetGitCommitHash WorkingDirectory="$(MSBuildProjectDirectory)"
                       Condition="'$(CommitHash)' == ''"
                       ContinueOnError="WarnAndContinue">
       <Output TaskParameter="CommitHash" PropertyName="CommitHash" />
-    </Sdk_GetGitCommitInfo>
+    </Sdk_GetGitCommitHash>
   </Target>
 
   <Target Name="CreateSourceLink"


### PR DESCRIPTION
Change default usages of GetGitCommitInfo to GetGitCommitHash.

The property GitBranch is no longer available by default in either the KoreBuild or project build contexts. We rarely if ever use this property, so anyone still using it will need to invoke the GetGitBranch task themselves

Resolves https://github.com/aspnet/Coherence-Signed/issues/622