### PR TITLE
Ensure global options for --repo-path and others are available on all subcommands

### DIFF
--- a/files/KoreBuild/scripts/KoreBuild.psm1
+++ b/files/KoreBuild/scripts/KoreBuild.psm1
@@ -344,10 +344,11 @@ function Invoke-KoreBuildCommand(
 
         $korebuildConsoleDll = Get-KoreBuildConsole
 
-        & dotnet $korebuildConsoleDll $Command `
+        & dotnet $korebuildConsoleDll `
             --tools-source $global:KoreBuildSettings.ToolsSource `
             --dotnet-home $global:KoreBuildSettings.DotNetHome `
             --repo-path $global:KoreBuildSettings.RepoPath `
+            $Command `
             @Arguments
     }
 }

--- a/files/KoreBuild/scripts/common.psm1
+++ b/files/KoreBuild/scripts/common.psm1
@@ -1,10 +1,10 @@
-function __exec($cmd) {
-    $cmdName = [IO.Path]::GetFileName($cmd)
+function __exec($_cmd) {
+    $cmdName = [IO.Path]::GetFileName($_cmd)
 
     Write-Host -ForegroundColor Cyan ">>> $cmdName $args"
     $originalErrorPref = $ErrorActionPreference
     $ErrorActionPreference = 'Continue'
-    & $cmd @args
+    & $_cmd @args
     $exitCode = $LASTEXITCODE
     $ErrorActionPreference = $originalErrorPref
     if ($exitCode -ne 0) {

--- a/modules/KoreBuild.Tasks/module.targets
+++ b/modules/KoreBuild.Tasks/module.targets
@@ -7,7 +7,7 @@
       Prepare;
       ResolveSolutions;
     </ApplyNuGetPoliciesDependsOn>
-    
+
     <DisablePackageReferenceRestrictions Condition=" '$(DisablePackageReferenceRestrictions)' == '' ">false</DisablePackageReferenceRestrictions>
     <DependencyVersionsFile Condition="'$(DependencyVersionsFile)' == ''">$(RepositoryRoot)build\dependencies.props</DependencyVersionsFile>
   </PropertyGroup>
@@ -87,8 +87,8 @@
   <Target Name="UpgradeDependencies">
     <Error Text="LineupPackageId was not set." Condition="'$(LineupPackageId)' == ''" />
     <Error Text="LineupPackageRestoreSource was not set." Condition="'$(LineupPackageRestoreSource)' == ''" />
-    
-    <UpgradeDependenciesPropsFile
+
+    <UpgradeDependencies
       DependenciesFile="$(DependencyVersionsFile)"
       LineupPackageId="$(LineupPackageId)"
       LineupPackageVersion="$(LineupPackageVersion)"

--- a/tools/KoreBuild.Console/Commands/CommandContext.cs
+++ b/tools/KoreBuild.Console/Commands/CommandContext.cs
@@ -1,0 +1,169 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using Microsoft.Extensions.CommandLineUtils;
+using Microsoft.Extensions.Tools.Internal;
+
+namespace KoreBuild.Console.Commands
+{
+    internal class CommandContext
+    {
+        private const string _defaultToolsSource = "https://aspnetcore.blob.core.windows.net/buildtools";
+        private const string _dotnetFolderName = ".dotnet";
+
+        private CommandOption _repoPathOption;
+        private CommandOption _dotNetHomeOption;
+        private CommandOption _toolsSourceOption;
+        private CommandOption _verbose;
+
+        private string _koreBuildDir;
+        private CommandOption _korebuildOverrideOpt;
+
+        public CommandContext(CommandLineApplication application)
+        {
+            _korebuildOverrideOpt = application.Option("--korebuild-override <PATH>", "Where is KoreBuild?", CommandOptionType.SingleValue, inherited: true);
+            // for local development only
+            _korebuildOverrideOpt.ShowInHelpText = false;
+
+            _verbose = application.Option("-v|--verbose", "Show verbose output", CommandOptionType.NoValue, inherited: true);
+            _toolsSourceOption = application.Option("--tools-source", "The source to draw tools from.", CommandOptionType.SingleValue, inherited: true);
+            _repoPathOption = application.Option("--repo-path", "The path to the repo to work on.", CommandOptionType.SingleValue, inherited: true);
+            _dotNetHomeOption = application.Option("--dotnet-home", "The place where dotnet lives", CommandOptionType.SingleValue, inherited: true);
+            // TODO: Configure file
+        }
+
+        public string KoreBuildDir
+        {
+            get
+            {
+                if (_koreBuildDir == null)
+                {
+                    _koreBuildDir = FindKoreBuildDirectory();
+                }
+                return _koreBuildDir;
+            }
+        }
+
+        public string ConfigDirectory => Path.Combine(KoreBuildDir, "config");
+        public string RepoPath => _repoPathOption.HasValue() ? _repoPathOption.Value() : Directory.GetCurrentDirectory();
+        public string DotNetHome => GetDotNetHome();
+        public string ToolsSource => _toolsSourceOption.HasValue() ? _toolsSourceOption.Value() : _defaultToolsSource;
+        public string SDKVersion => GetDotnetSDKVersion();
+
+        public IReporter Reporter => new ConsoleReporter(PhysicalConsole.Singleton, _verbose != null, false);
+
+        private string GetDotnetSDKVersion()
+        {
+            var sdkVersionEnv = Environment.GetEnvironmentVariable("KOREBUILD_DOTNET_VERSION");
+            if (sdkVersionEnv != null)
+            {
+                return sdkVersionEnv;
+            }
+            else
+            {
+                var sdkVersionPath = Path.Combine(ConfigDirectory, "sdk.version");
+                return File.ReadAllText(sdkVersionPath).Trim();
+            }
+        }
+
+        private string GetDotNetHome()
+        {
+            var dotnetHome = Environment.GetEnvironmentVariable("DOTNET_HOME");
+            var userProfile = Environment.GetEnvironmentVariable("USERPROFILE");
+            var home = Environment.GetEnvironmentVariable("HOME");
+
+            var result = Path.Combine(Directory.GetCurrentDirectory(), _dotnetFolderName);
+            if (_dotNetHomeOption.HasValue())
+            {
+                result = _dotNetHomeOption.Value();
+            }
+            else if (!string.IsNullOrEmpty(dotnetHome))
+            {
+                result = dotnetHome;
+            }
+            else if (!string.IsNullOrEmpty(userProfile))
+            {
+                result = Path.Combine(userProfile, _dotnetFolderName);
+            }
+            else if (!string.IsNullOrEmpty(home))
+            {
+                result = home;
+            }
+
+            return result;
+        }
+
+        private string FindKoreBuildDirectory()
+        {
+            if (_korebuildOverrideOpt.HasValue())
+            {
+                return Path.GetFullPath(_korebuildOverrideOpt.Value());
+            }
+
+            var executingDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            var root = Directory.GetDirectoryRoot(executingDir);
+            while (executingDir != root)
+            {
+                var files = Directory.EnumerateFiles(executingDir);
+                var koreProj = Path.Combine(executingDir, "KoreBuild.proj");
+                if (files.Contains(koreProj))
+                {
+                    return executingDir;
+                }
+
+                var directories = Directory.EnumerateDirectories(executingDir);
+
+                var fileDir = Path.Combine(executingDir, "files");
+                if (directories.Contains(fileDir))
+                {
+                    return Path.Combine(fileDir, "KoreBuild");
+                }
+
+                executingDir = Directory.GetParent(executingDir).FullName;
+            }
+
+            Reporter.Error("Couldn't find the KoreBuild directory.");
+            throw new DirectoryNotFoundException();
+        }
+
+        public string GetDotNetInstallDir()
+        {
+            var dotnetDir = DotNetHome;
+            if (IsWindows())
+            {
+                dotnetDir = Path.Combine(dotnetDir, GetArchitecture());
+            }
+
+            return dotnetDir;
+        }
+
+        public string GetDotNetExecutable()
+        {
+            var dotnetDir = GetDotNetInstallDir();
+
+            var dotnetFile = "dotnet";
+
+            if (IsWindows())
+            {
+                dotnetFile += ".exe";
+            }
+
+            return Path.Combine(dotnetDir, dotnetFile);
+        }
+
+        public string GetArchitecture()
+        {
+            return Environment.GetEnvironmentVariable("KOREBUILD_DOTNET_ARCH") ?? "x64";
+        }
+
+        public bool IsWindows()
+        {
+            return RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+        }
+    }
+}

--- a/tools/KoreBuild.Console/Commands/DependenciesGenerateCommand.cs
+++ b/tools/KoreBuild.Console/Commands/DependenciesGenerateCommand.cs
@@ -12,6 +12,10 @@ namespace KoreBuild.Console.Commands
         private CommandOption _configOpt;
         private CommandOption _fileOpt;
 
+        public DependenciesGenerateCommand(CommandContext context) : base(context)
+        {
+        }
+
         public override void Configure(CommandLineApplication application)
         {
             application.Description = "Generates a build/dependencies.props file and updates csproj files to use variables";
@@ -41,7 +45,7 @@ MORE INFO:
             var args = new List<string>
             {
                 "msbuild",
-                Path.Combine(KoreBuildDir, "KoreBuild.proj"),
+                Path.Combine(Context.KoreBuildDir, "KoreBuild.proj"),
                 "-t:GenerateDependenciesPropsFile",
             };
 
@@ -66,7 +70,7 @@ MORE INFO:
                 args.Add("-v:n");
             }
 
-            return RunDotnet(args, RepoPath);
+            return RunDotnet(args, Context.RepoPath);
         }
     }
 }

--- a/tools/KoreBuild.Console/Commands/DependenciesUpgradeCommand.cs
+++ b/tools/KoreBuild.Console/Commands/DependenciesUpgradeCommand.cs
@@ -14,6 +14,10 @@ namespace KoreBuild.Console.Commands
         private CommandOption _packageVersionOpt;
         private CommandOption _fileOpt;
 
+        public DependenciesUpgradeCommand(CommandContext context) : base(context)
+        {
+        }
+
         public override void Configure(CommandLineApplication application)
         {
             application.Description = "Upgrades the build/dependencies.props file to the latest package versions";
@@ -47,7 +51,7 @@ MORE INFO:
             var args = new List<string>
             {
                 "msbuild",
-                Path.Combine(KoreBuildDir, "KoreBuild.proj"),
+                Path.Combine(Context.KoreBuildDir, "KoreBuild.proj"),
                 "-t:UpgradeDependencies",
             };
 
@@ -82,7 +86,7 @@ MORE INFO:
                 args.Add("-v:n");
             }
 
-            return RunDotnet(args, RepoPath);
+            return RunDotnet(args, Context.RepoPath);
         }
     }
 }

--- a/tools/KoreBuild.Console/Commands/MSBuildCommand.cs
+++ b/tools/KoreBuild.Console/Commands/MSBuildCommand.cs
@@ -10,6 +10,10 @@ namespace KoreBuild.Console.Commands
 {
     internal class MSBuildCommand : SubCommandBase
     {
+        public MSBuildCommand(CommandContext context) : base(context)
+        {
+        }
+
         private bool EnableBinaryLog => Environment.GetEnvironmentVariable("KOREBUILD_ENABLE_BINARY_LOG") == "1";
 
         private List<string> Arguments { get; set; }
@@ -22,27 +26,27 @@ namespace KoreBuild.Console.Commands
 
         protected override int Execute()
         {
-            Reporter.Verbose($"Building {RepoPath}.");
-            Reporter.Verbose($"dotnet = {RepoPath}");
+            Reporter.Verbose($"Building {Context.RepoPath}.");
+            Reporter.Verbose($"dotnet = {Context.RepoPath}");
 
-            if(SDKVersion != "latest")
+            if (Context.SDKVersion != "latest")
             {
-                var globalFile = Path.Combine(RepoPath, "global.json");
-                File.WriteAllText(globalFile, $"{{ \"sdk\": {{ \"version\": \"{SDKVersion}\" }} }}", System.Text.Encoding.ASCII);
+                var globalFile = Path.Combine(Context.RepoPath, "global.json");
+                File.WriteAllText(globalFile, $"{{ \"sdk\": {{ \"version\": \"{Context.SDKVersion}\" }} }}", System.Text.Encoding.ASCII);
             }
             else
             {
-                Reporter.Verbose($"Skipping global.json generation because the SDKVersion = {SDKVersion}");
+                Reporter.Verbose($"Skipping global.json generation because the SDKVersion = {Context.SDKVersion}");
             }
 
-            var makeFileProj = Path.Combine(KoreBuildDir, "KoreBuild.proj");
-            var msBuildArtifactsDir = Path.Combine(RepoPath, "artifacts", "msbuild");
+            var makeFileProj = Path.Combine(Context.KoreBuildDir, "KoreBuild.proj");
+            var msBuildArtifactsDir = Path.Combine(Context.RepoPath, "artifacts", "msbuild");
             var msBuildResponseFile = Path.Combine(msBuildArtifactsDir, "msbuild.rsp");
 
             var msBuildLogArgument = string.Empty;
 
 
-            if(EnableBinaryLog)
+            if (EnableBinaryLog)
             {
                 Reporter.Verbose("Enabling binary logging");
                 var msBuildLogFilePath = Path.Combine(msBuildArtifactsDir, "msbuild.binlog");
@@ -60,7 +64,7 @@ namespace KoreBuild.Console.Commands
             msBuildArguments += $@"
 /nologo
 /m
-/p:RepositoryRoot={RepoPath}\
+/p:RepositoryRoot={Context.RepoPath}\
 {msBuildLogArgument}
 /clp:Summary
 ""{makeFileProj}""
@@ -74,44 +78,44 @@ namespace KoreBuild.Console.Commands
             File.WriteAllText(msBuildResponseFile, msBuildArguments, System.Text.Encoding.ASCII);
             Reporter.Verbose($"Noop = {noop}");
             var firstTime = Environment.GetEnvironmentVariable("DOTNET_SKIP_FIRST_TIME_EXPERIENCE");
-            if(noop)
+            if (noop)
             {
                 Environment.SetEnvironmentVariable("DOTNET_SKIP_FIRST_TIME_EXPERIENCE", "true");
             }
             else
             {
-                var buildTaskResult = BuildTaskProject(RepoPath);
-                if(buildTaskResult != 0)
+                var buildTaskResult = BuildTaskProject(Context.RepoPath);
+                if (buildTaskResult != 0)
                 {
                     return buildTaskResult;
                 }
             }
 
-            return RunDotnet(new[] {"msbuild", $@"@""{msBuildResponseFile}""" });
+            return RunDotnet(new[] { "msbuild", $@"@""{msBuildResponseFile}""" });
         }
 
         private int BuildTaskProject(string path)
         {
-            var taskFolder = Path.Combine(RepoPath, "build", "tasks");
+            var taskFolder = Path.Combine(Context.RepoPath, "build", "tasks");
             var taskProj = Path.Combine(taskFolder, "RepoTasks.csproj");
             var publishFolder = Path.Combine(taskFolder, "bin", "publish");
 
-            if(File.Exists(taskProj))
+            if (File.Exists(taskProj))
             {
-                if(File.Exists(publishFolder))
+                if (File.Exists(publishFolder))
                 {
                     Directory.Delete(publishFolder, recursive: true);
                 }
 
-                var sdkPath = $"/p:RepoTasksSdkPath={Path.Combine(KoreBuildDir, "msbuild", "KoreBuild.RepoTasks.Sdk", "Sdk")}";
+                var sdkPath = $"/p:RepoTasksSdkPath={Path.Combine(Context.KoreBuildDir, "msbuild", "KoreBuild.RepoTasks.Sdk", "Sdk")}";
 
-                var restoreResult = RunDotnet(new[] { "restore", taskProj, sdkPath});
+                var restoreResult = RunDotnet(new[] { "restore", taskProj, sdkPath });
                 if (restoreResult != 0)
                 {
                     return restoreResult;
                 }
 
-                return RunDotnet(new[] { "publish", taskProj, "--configuration", "Release", "--output", publishFolder, "/nologo", sdkPath});
+                return RunDotnet(new[] { "publish", taskProj, "--configuration", "Release", "--output", publishFolder, "/nologo", sdkPath });
             }
 
             return 0;

--- a/tools/KoreBuild.Console/Commands/RootCommand.cs
+++ b/tools/KoreBuild.Console/Commands/RootCommand.cs
@@ -10,17 +10,19 @@ namespace KoreBuild.Console.Commands
     {
         public override void Configure(CommandLineApplication application)
         {
+            var context = new CommandContext(application);
+
             application.FullName = "korebuild";
 
-            application.Command("install-tools", new InstallToolsCommand().Configure, throwOnUnexpectedArg: false);
-            application.Command("msbuild", new MSBuildCommand().Configure, throwOnUnexpectedArg: false);
-            application.Command("docker-build", new DockerBuildCommand().Configure, throwOnUnexpectedArg: false);
+            application.Command("install-tools", new InstallToolsCommand(context).Configure, throwOnUnexpectedArg: false);
+            application.Command("msbuild", new MSBuildCommand(context).Configure, throwOnUnexpectedArg: false);
+            application.Command("docker-build", new DockerBuildCommand(context).Configure, throwOnUnexpectedArg: false);
 
             // Commands that upgrade things
             application.Command("upgrade", c =>
             {
                 c.HelpOption("-h|--help");
-                c.Command("deps", new DependenciesUpgradeCommand().Configure);
+                c.Command("deps", new DependenciesUpgradeCommand(context).Configure);
 
                 c.OnExecute(() =>
                 {
@@ -33,7 +35,7 @@ namespace KoreBuild.Console.Commands
             application.Command("generate", c =>
             {
                 c.HelpOption("-h|--help");
-                c.Command("deps", new DependenciesGenerateCommand().Configure);
+                c.Command("deps", new DependenciesGenerateCommand(context).Configure);
 
                 c.OnExecute(() =>
                 {

--- a/tools/KoreBuild.Console/Commands/SubCommandBase.cs
+++ b/tools/KoreBuild.Console/Commands/SubCommandBase.cs
@@ -1,71 +1,30 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Runtime.InteropServices;
 using Microsoft.Extensions.CommandLineUtils;
 using Microsoft.Extensions.Tools.Internal;
 
 namespace KoreBuild.Console.Commands
 {
-    internal class SubCommandBase : CommandBase
+    internal abstract class SubCommandBase : CommandBase
     {
-        private const string _defaultToolsSource = "https://aspnetcore.blob.core.windows.net/buildtools";
-        private const string _dotnetFolderName = ".dotnet";
-
-        private CommandOption _repoPathOption;
-        private CommandOption _dotNetHomeOption;
-        private CommandOption _toolsSourceOption;
-        private CommandOption _verbose;
-
-        private string _koreBuildDir;
-        private CommandOption _korebuildOverrideOpt;
-
-        public string KoreBuildDir
+        protected SubCommandBase(CommandContext context)
         {
-            get
-            {
-                if (_koreBuildDir == null)
-                {
-                    _koreBuildDir = FindKoreBuildDirectory();
-                }
-                return _koreBuildDir;
-            }
+            Context = context;
         }
 
-        public string ConfigDirectory => Path.Combine(KoreBuildDir, "config");
-        public string RepoPath => _repoPathOption.HasValue() ? _repoPathOption.Value() : Directory.GetCurrentDirectory();
-        public string DotNetHome => GetDotNetHome();
-        public string ToolsSource => _toolsSourceOption.HasValue() ? _toolsSourceOption.Value() : _defaultToolsSource;
-        public string SDKVersion => GetDotnetSDKVersion();
+        protected CommandContext Context { get; }
 
-        public IReporter Reporter => new ConsoleReporter(PhysicalConsole.Singleton, _verbose != null, false);
-
-        public override void Configure(CommandLineApplication application)
-        {
-            base.Configure(application);
-
-            _korebuildOverrideOpt = application.Option("--korebuild-override <PATH>", "Where is KoreBuild?", CommandOptionType.SingleValue);
-            // for local development only
-            _korebuildOverrideOpt.ShowInHelpText = false;
-
-            _verbose = application.Option("-v|--verbose", "Show verbose output", CommandOptionType.NoValue);
-            _toolsSourceOption = application.Option("--tools-source", "The source to draw tools from.", CommandOptionType.SingleValue);
-            _repoPathOption = application.Option("--repo-path", "The path to the repo to work on.", CommandOptionType.SingleValue);
-            _dotNetHomeOption = application.Option("--dotnet-home", "The place where dotnet lives", CommandOptionType.SingleValue);
-            // TODO: Configure file
-        }
+        protected IReporter Reporter => Context.Reporter;
 
         protected override bool IsValid()
         {
-            if(!Directory.Exists(RepoPath))
+            if (!Directory.Exists(Context.RepoPath))
             {
-                Reporter.Error($"The RepoPath '{RepoPath}' doesn't exist.");
+                Context.Reporter.Error($"The RepoPath '{Context.RepoPath}' doesn't exist.");
                 return false;
             }
 
@@ -83,7 +42,7 @@ namespace KoreBuild.Console.Commands
             var dotnet = DotNetMuxer.MuxerPath;
             // if it could not be found, fallback to detecting DOTNET_HOME or PATH
             dotnet = string.IsNullOrEmpty(dotnet) || !Path.IsPathRooted(dotnet)
-                ? GetDotNetExecutable()
+                ? Context.GetDotNetExecutable()
                 : dotnet;
 
             var psi = new ProcessStartInfo
@@ -99,115 +58,6 @@ namespace KoreBuild.Console.Commands
             process.WaitForExit();
 
             return process.ExitCode;
-        }
-
-        private string GetDotnetSDKVersion()
-        {
-            var sdkVersionEnv = Environment.GetEnvironmentVariable("KOREBUILD_DOTNET_VERSION");
-            if (sdkVersionEnv != null)
-            {
-                return sdkVersionEnv;
-            }
-            else
-            {
-                var sdkVersionPath = Path.Combine(ConfigDirectory, "sdk.version");
-                return File.ReadAllText(sdkVersionPath).Trim();
-            }
-        }
-
-        private string GetDotNetHome()
-        {
-            var dotnetHome = Environment.GetEnvironmentVariable("DOTNET_HOME");
-            var userProfile = Environment.GetEnvironmentVariable("USERPROFILE");
-            var home = Environment.GetEnvironmentVariable("HOME");
-
-            var result = Path.Combine(Directory.GetCurrentDirectory(), _dotnetFolderName);
-            if (_dotNetHomeOption.HasValue())
-            {
-                result = _dotNetHomeOption.Value();
-            }
-            else if (!string.IsNullOrEmpty(dotnetHome))
-            {
-                result = dotnetHome;
-            }
-            else if (!string.IsNullOrEmpty(userProfile))
-            {
-                result = Path.Combine(userProfile, _dotnetFolderName);
-            }
-            else if (!string.IsNullOrEmpty(home))
-            {
-                result = home;
-            }
-
-            return result;
-        }
-
-        private string FindKoreBuildDirectory()
-        {
-            if (_korebuildOverrideOpt.HasValue())
-            {
-                return Path.GetFullPath(_korebuildOverrideOpt.Value());
-            }
-
-            var executingDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-            var root = Directory.GetDirectoryRoot(executingDir);
-            while (executingDir != root)
-            {
-                var files = Directory.EnumerateFiles(executingDir);
-                var koreProj = Path.Combine(executingDir, "KoreBuild.proj");
-                if (files.Contains(koreProj))
-                {
-                    return executingDir;
-                }
-
-                var directories = Directory.EnumerateDirectories(executingDir);
-
-                var fileDir = Path.Combine(executingDir, "files");
-                if (directories.Contains(fileDir))
-                {
-                    return Path.Combine(fileDir, "KoreBuild");
-                }
-
-                executingDir = Directory.GetParent(executingDir).FullName;
-            }
-
-            Reporter.Error("Couldn't find the KoreBuild directory.");
-            throw new DirectoryNotFoundException();
-        }
-
-        protected string GetDotNetInstallDir()
-        {
-            var dotnetDir = DotNetHome;
-            if (IsWindows())
-            {
-                dotnetDir = Path.Combine(dotnetDir, GetArchitecture());
-            }
-
-            return dotnetDir;
-        }
-
-        protected string GetDotNetExecutable()
-        {
-            var dotnetDir = GetDotNetInstallDir();
-
-            var dotnetFile = "dotnet";
-
-            if (IsWindows())
-            {
-                dotnetFile += ".exe";
-            }
-
-            return Path.Combine(dotnetDir, dotnetFile);
-        }
-
-        protected static string GetArchitecture()
-        {
-            return Environment.GetEnvironmentVariable("KOREBUILD_DOTNET_ARCH") ?? "x64";
-        }
-
-        protected static bool IsWindows()
-        {
-            return RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
         }
     }
 }


### PR DESCRIPTION
Currently, `run.ps1 upgrade deps` fails with 
```
Exception thrown: 'Microsoft.Extensions.CommandLineUtils.CommandParsingException: Unrecognized option '--tools-source'
```

Instead of all subcommands inheriting `CommandOption`'s from a common class, this sets `CommandOption.Inherited = true` at the top level so everything in the app will always have these options set.

- --tools-source
- --repo-path
- --dotnet-home
