### PR TITLE
Unify version prefix between Internal.AspNetCore.Sdk and the rest of build tools

### DIFF
--- a/src/Internal.AspNetCore.Sdk/Internal.AspNetCore.Sdk.csproj
+++ b/src/Internal.AspNetCore.Sdk/Internal.AspNetCore.Sdk.csproj
@@ -3,8 +3,6 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <VersionPrefix>2.1.1</VersionPrefix>
-    <VerifyVersion>false</VerifyVersion>
     <TargetFrameworks>netcoreapp2.0;net46</TargetFrameworks>
     <DefineConstants>$(DefineConstants);SDK</DefineConstants>
     <Serviceable>false</Serviceable>


### PR DESCRIPTION
Even though build tools is 2.1.0-preview-\*, this package was 2.1.1-\* because of weird historical reasons and floating packages versions. This doesn't matter anymore now that repos either use PackageLineup or they hard code versions. (Yay for no more floating!)