### PR TITLE
Fix bad error messages and add a few tests to dependencies.props tooling

### DIFF
--- a/modules/KoreBuild.Tasks/CheckPackageReferences.cs
+++ b/modules/KoreBuild.Tasks/CheckPackageReferences.cs
@@ -15,7 +15,7 @@ using NuGet.Versioning;
 namespace KoreBuild.Tasks
 {
     /// <summary>
-    /// Ensures MSBuild files use PackageReference responsibly. 
+    /// Ensures MSBuild files use PackageReference responsibly.
     /// </summary>
     public class CheckPackageReferences : Microsoft.Build.Utilities.Task
     {
@@ -119,7 +119,12 @@ namespace KoreBuild.Tasks
                     continue;
                 }
 
-                var nugetVersion = VersionRange.Parse(versionValue);
+                if (!VersionRange.TryParse(versionValue, out var nugetVersion))
+                {
+                    Log.LogKoreBuildError(pkgRef.Location.File, pkgRef.Location.Line, KoreBuildErrors.InvalidPackageVersion, $"PackageReference to {id} has an invalid version identifier: '{versionValue}'");
+                    continue;
+                }
+
                 if (nugetVersion.IsFloating)
                 {
                     Log.LogKoreBuildError(pkgRef.Location.File, pkgRef.Location.Line, KoreBuildErrors.PackageRefHasFloatingVersion, $"PackageReference to {id} uses a floating version: '{versionValue}'");

--- a/modules/KoreBuild.Tasks/Internal/KoreBuildErrors.cs
+++ b/modules/KoreBuild.Tasks/Internal/KoreBuildErrors.cs
@@ -18,7 +18,7 @@ namespace KoreBuild.Tasks
 
         // NuGet errors
         public const int InvalidNuspecFile = 4001;
-        public const int PackageReferenceHasVersion = 4002;
+        public const int ConflictingPackageReferenceVersions = 4002;
         public const int DotNetCliReferenceReferenceHasVersion = 4003;
         public const int PackageVersionNotFoundInLineup = 4004;
         public const int PackageRefHasLiteralVersion = 4005;
@@ -26,6 +26,7 @@ namespace KoreBuild.Tasks
         public const int PackageRefHasFloatingVersion = 4007;
         public const int PackageRefPropertyGroupNotFound = 4008;
         public const int PackageReferenceDoesNotHaveVersion = 4009;
+        public const int InvalidPackageVersion = 4010;
 
         // Other unknown errors
         public const int PolicyFailedToApply = 5000;

--- a/modules/KoreBuild.Tasks/Internal/ProjectModel/ProjectInfoFactory.cs
+++ b/modules/KoreBuild.Tasks/Internal/ProjectModel/ProjectInfoFactory.cs
@@ -30,6 +30,11 @@ namespace KoreBuild.Tasks.ProjectModel
 
         public IReadOnlyList<ProjectInfo> CreateMany(ITaskItem[] projectItems, string[] properties, bool policyDesignBuild, CancellationToken token)
         {
+            if (projectItems == null)
+            {
+                return Array.Empty<ProjectInfo>();
+            }
+
             var cts = new CancellationTokenSource();
             token.Register(() => cts.Cancel());
             var solutionProps = MSBuildListSplitter.GetNamedProperties(properties);

--- a/modules/KoreBuild.Tasks/Policies/PackageLineupPolicy.cs
+++ b/modules/KoreBuild.Tasks/Policies/PackageLineupPolicy.cs
@@ -21,7 +21,7 @@ namespace KoreBuild.Tasks.Policies
 {
     internal class PackageLineupPolicy : INuGetPolicy
     {
-        private readonly static string NoWarn = KoreBuildErrors.Prefix + KoreBuildErrors.PackageReferenceHasVersion;
+        private readonly static string NoWarn = KoreBuildErrors.Prefix + KoreBuildErrors.ConflictingPackageReferenceVersions;
 
         private readonly IReadOnlyList<ITaskItem> _items;
         private readonly IRestoreLineupCommand _command;

--- a/modules/KoreBuild.Tasks/UpgradeDependencies.cs
+++ b/modules/KoreBuild.Tasks/UpgradeDependencies.cs
@@ -133,11 +133,19 @@ namespace KoreBuild.Tasks
                 var updateCount = 0;
                 foreach (var var in localVersionsFile.VersionVariables)
                 {
-                    if (!remoteDepsVersionFile.VersionVariables.TryGetValue(var.Key, out var newValue))
+                    string newValue;
+                    // special case any package bundled in KoreBuild
+                    if (!string.IsNullOrEmpty(KoreBuildVersion.Current) && var.Key == "InternalAspNetCoreSdkPackageVersion")
+                    {
+                        newValue = KoreBuildVersion.Current;
+                        Log.LogMessage(MessageImportance.Low, "Setting InternalAspNetCoreSdkPackageVersion to the current version of KoreBuild");
+                    }
+                    else if (!remoteDepsVersionFile.VersionVariables.TryGetValue(var.Key, out newValue))
                     {
                         Log.LogKoreBuildWarning(DependenciesFile, KoreBuildErrors.PackageVersionNotFoundInLineup, $"A new version variable for {var.Key} could not be found in {LineupPackageId}. This might be an unsupported external dependency.");
                         continue;
                     }
+
                     if (newValue != var.Value)
                     {
                         updateCount++;

--- a/modules/KoreBuild.Tasks/Utilities/KoreBuildVersion.cs
+++ b/modules/KoreBuild.Tasks/Utilities/KoreBuildVersion.cs
@@ -1,0 +1,30 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO;
+using System.Reflection;
+
+namespace KoreBuild.Tasks
+{
+    internal class KoreBuildVersion
+    {
+        private static string _version;
+
+        public static string Current
+        {
+            get
+            {
+                if (_version == null)
+                {
+                    var assembly = typeof(KoreBuildVersion).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>();
+                    if (assembly != null)
+                    {
+                        _version = assembly.InformationalVersion;
+                    }
+                }
+
+                return _version;
+            }
+        }
+    }
+}

--- a/test/KoreBuild.Tasks.Tests/GenerateDependenciesPropsFileTests.cs
+++ b/test/KoreBuild.Tasks.Tests/GenerateDependenciesPropsFileTests.cs
@@ -1,0 +1,123 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections;
+using System.IO;
+using BuildTools.Tasks.Tests;
+using Microsoft.Build.Construction;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace KoreBuild.Tasks.Tests
+{
+    [Collection(nameof(MSBuildTestCollection))]
+    public class GenerateDependenciesPropsFileTests : IDisposable
+    {
+        private readonly ITestOutputHelper _output;
+        private readonly string _tempDir;
+
+        public GenerateDependenciesPropsFileTests(ITestOutputHelper output, MSBuildTestCollectionFixture fixture)
+        {
+            _output = output;
+            _tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            Directory.CreateDirectory(_tempDir);
+            fixture.InitializeEnvironment(output);
+        }
+
+        [Fact]
+        public void GeneratesVariableName()
+        {
+            var generatedFile = Path.Combine(_tempDir, "deps.props");
+            var csproj = Path.Combine(_tempDir, "test.csproj");
+            CreateProject(csproj, "1.2.3");
+
+            var task = new GenerateDependenciesPropsFile
+            {
+                BuildEngine = new MockEngine(_output),
+                DependenciesFile = generatedFile,
+                Projects = new[] { new TaskItem(csproj) },
+                Properties = Array.Empty<string>(),
+            };
+
+            Assert.True(task.Execute(), "Task is expected to pass");
+            var depsFile = ProjectRootElement.Open(generatedFile);
+            _output.WriteLine(File.ReadAllText(generatedFile));
+            var pg = Assert.Single(depsFile.PropertyGroups, p => p.Label == "Package Versions");
+            var prop = Assert.Single(pg.Properties, p => p.Name == "MyDependencyPackageVersion");
+            Assert.Equal("1.2.3", prop.Value);
+        }
+
+        [Fact]
+        public void FailsWhenConflictingVersions()
+        {
+            var generatedFile = Path.Combine(_tempDir, "deps.props");
+            var csproj1 = Path.Combine(_tempDir, "test1.csproj");
+            var csproj2 = Path.Combine(_tempDir, "test2.csproj");
+            CreateProject(csproj1, "1.2.3");
+            CreateProject(csproj2, "4.5.6");
+
+            var engine = new MockEngine(_output) { ContinueOnError = true };
+            var task = new GenerateDependenciesPropsFile
+            {
+                BuildEngine = engine,
+                DependenciesFile = generatedFile,
+                Projects = new[] { new TaskItem(csproj1), new TaskItem(csproj2) },
+                Properties = Array.Empty<string>(),
+            };
+
+            Assert.False(task.Execute(), "Task is expected to fail");
+            Assert.Single(engine.Errors, e => e.Code == KoreBuildErrors.Prefix + KoreBuildErrors.ConflictingPackageReferenceVersions);
+        }
+
+        [Fact]
+        public void DoesNotFailWhenConflictingVersionsAreSuppressed()
+        {
+            var generatedFile = Path.Combine(_tempDir, "deps.props");
+            var csproj1 = Path.Combine(_tempDir, "test1.csproj");
+            var csproj2 = Path.Combine(_tempDir, "test2.csproj");
+            CreateProject(csproj1, "1.2.3");
+
+            File.WriteAllText(csproj2, $@"
+<Project Sdk=`Microsoft.NET.Sdk`>
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include=`MyDependency` Version=`4.5.6` NoWarn=`KRB4002` />
+  </ItemGroup>
+</Project>".Replace('`', '"'));
+
+            var task = new GenerateDependenciesPropsFile
+            {
+                BuildEngine = new MockEngine(_output),
+                DependenciesFile = generatedFile,
+                Projects = new[] { new TaskItem(csproj1), new TaskItem(csproj2) },
+                Properties = Array.Empty<string>(),
+            };
+
+            Assert.True(task.Execute(), "Task is expected to oass");
+        }
+
+        private static void CreateProject(string csprojFilePath, string version)
+        {
+            File.WriteAllText(csprojFilePath, $@"
+<Project Sdk=`Microsoft.NET.Sdk`>
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include=`MyDependency` Version=`{version}` />
+  </ItemGroup>
+</Project>".Replace('`', '"'));
+        }
+
+
+        public void Dispose()
+        {
+            Directory.Delete(_tempDir, recursive: true);
+        }
+    }
+}

--- a/test/KoreBuild.Tasks.Tests/UpgradeDependenciesTests.cs
+++ b/test/KoreBuild.Tasks.Tests/UpgradeDependenciesTests.cs
@@ -81,6 +81,29 @@ namespace KoreBuild.Tasks.Tests
         }
 
         [Fact]
+        public async Task SnapsInternalAspNetCoreSdkToBuildTools()
+        {
+            // arrange
+            var packageId = new PackageIdentity("Lineup", NuGetVersion.Parse("1.0.0"));
+            var lineupPackagePath = CreateLineup(packageId, ("InternalAspNetCoreSdkPackageVersion", "2.0.0"));
+            var depsFilePath = CreateProjectDepsFile(("InternalAspNetCoreSdkPackageVersion", "1.0.0"));
+
+            // act
+            var task = new UpgradeDependencies
+            {
+                BuildEngine = new MockEngine(_output),
+                DependenciesFile = depsFilePath,
+                LineupPackageId = packageId.Id,
+                LineupPackageRestoreSource = _tempDir,
+            };
+
+            // assert
+            Assert.True(await task.ExecuteAsync(), "Task is expected to pass");
+            var modifiedDepsFile = DependencyVersionsFile.Load(depsFilePath);
+            Assert.Equal(KoreBuildVersion.Current, modifiedDepsFile.VersionVariables["InternalAspNetCoreSdkPackageVersion"]);
+        }
+
+        [Fact]
         public async Task DoesNotModifiesFileIfNoChanges()
         {
             // arrange


### PR DESCRIPTION
Fixes:
 - don't throw NRE when 'otherimports' is empty
 - don't throw when VersionRange.Parse fails in CheckPackageReferences
 - Reassign KRB4002 to represent the suppress version conflicts when generating deps.props files. (Temporary overlap with PackageLineup's warning. The overlap goes away when we delete PackageLineup)