### PR TITLE
Remove reference to /t:Pin

### DIFF
--- a/modules/KoreBuild.Tasks/module.targets
+++ b/modules/KoreBuild.Tasks/module.targets
@@ -62,7 +62,7 @@
   </Target>
 
   <!-- See also DependenciesGenerateCommand.cs in KoreBuild.Console for a more discoverable way to run this. -->
-  <Target Name="GenerateDependenciesPropsFile" DependsOnTargets="ResolveSolutions;Pin">
+  <Target Name="GenerateDependenciesPropsFile" DependsOnTargets="ResolveSolutions">
     <ItemGroup>
       <CommonlyImportedFiles Remove="@(CommonlyImportedFiles)" Condition="!Exists(%(CommonlyImportedFiles.Identity))" />
     </ItemGroup>


### PR DESCRIPTION
The target doesn't exist anymore, so `.\run.ps1 generate deps` fails.