### PR TITLE
Don't use TTY

### DIFF
--- a/tools/KoreBuild.Console/Commands/DockerBuildCommand.cs
+++ b/tools/KoreBuild.Console/Commands/DockerBuildCommand.cs
@@ -83,7 +83,7 @@ namespace KoreBuild.Console.Commands
 
                 var containerName = $"{Owner}_{DateTime.Now.ToString("yyyyMMddHHmmss")}";
 
-                var runArgs = new List<string> { "run", "--rm", "-it", "--name", containerName, Tag };
+                var runArgs = new List<string> { "run", "--rm", "-i", "--name", containerName, Tag };
 
                 runArgs.AddRange(new[] { "-ToolsSource", dockerToolsSource });
 


### PR DESCRIPTION
TTy causes exceptions in some circumstances and I don't know of any advantage to using it, so let's remove it.