### PR TITLE
Update ApiCheck.Console to use netcoreapp2.1

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -6,6 +6,7 @@
     <JsonNetVersion>10.0.1</JsonNetVersion>
     <MicrosoftDotNetPlatformAbstractionsVersion>2.0.0</MicrosoftDotNetPlatformAbstractionsVersion>
     <MicrosoftNETCoreApp20PackageVersion>2.0.0</MicrosoftNETCoreApp20PackageVersion>
+    <MicrosoftNETCoreApp21PackageVersion>2.1.0-preview1-25907-02</MicrosoftNETCoreApp21PackageVersion>
     <MonoCecilVersion>0.10.0-beta6</MonoCecilVersion>
     <MoqVersion>4.7.99</MoqVersion>
     <NuGetPackagesVersion>4.3.0</NuGetPackagesVersion>

--- a/build/sources.props
+++ b/build/sources.props
@@ -5,6 +5,7 @@
     <RestoreSources>$(DotNetRestoreSources)</RestoreSources>
     <RestoreSources Condition="'$(DotNetBuildOffline)' != 'true'">
       $(RestoreSources);
+      https://dotnet.myget.org/F/dotnet-core/api/v3/index.json;
       https://dotnet.myget.org/F/nuget-build/api/v3/index.json;
       https://dotnet.myget.org/F/msbuild/api/v3/index.json;
       https://api.nuget.org/v3/index.json;

--- a/src/ApiCheck.Console/ApiCheck.Console.csproj
+++ b/src/ApiCheck.Console/ApiCheck.Console.csproj
@@ -2,13 +2,13 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net46</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;net46</TargetFrameworks>
     <AssemblyName>ApiCheck</AssemblyName>
     <RootNamespace>Microsoft.AspNetCore.BuildTools.ApiCheck</RootNamespace>
     <OutputType>exe</OutputType>
     <IncludeSymbols>false</IncludeSymbols>
     <IncludeSource>false</IncludeSource>
-    <RuntimeFrameworkVersion Condition="'$(TargetFramework)' == 'netcoreapp2.0'">$(MicrosoftNETCoreApp20PackageVersion)</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion Condition="'$(TargetFramework)' == 'netcoreapp2.1'">$(MicrosoftNETCoreApp21PackageVersion)</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <!-- packaging settings-->

--- a/src/ApiCheck.Console/Loader/AssemblyLoader.cs
+++ b/src/ApiCheck.Console/Loader/AssemblyLoader.cs
@@ -5,7 +5,7 @@
 using System.IO;
 #endif
 using System.Reflection;
-#if NETCOREAPP2_0
+#if NETCOREAPP2_1
 using NuGet.ProjectModel;
 using ApiCheck.NuGet;
 #endif
@@ -19,7 +19,7 @@ namespace ApiCheck
                 string assetsJson,
                 string framework)
         {
-#if NETCOREAPP2_0
+#if NETCOREAPP2_1
             var lockFile = new LockFileFormat().Read(assetsJson);
             var graph = PackageGraph.Create(lockFile, framework);
             var loader = new CoreClrAssemblyLoader(graph, assemblyPath);

--- a/src/ApiCheck.Console/Loader/CoreClrAssemblyLoader.cs
+++ b/src/ApiCheck.Console/Loader/CoreClrAssemblyLoader.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#if NETCOREAPP2_0
+#if NETCOREAPP2_1
 
 using System;
 using System.Collections.Generic;

--- a/src/ApiCheck.Console/Loader/FullFrameworkAssemblyLoader.cs
+++ b/src/ApiCheck.Console/Loader/FullFrameworkAssemblyLoader.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#if !NETCOREAPP2_0
+#if !NETCOREAPP2_1
 
 using System;
 using System.Collections.Generic;

--- a/src/ApiCheck.Console/Microsoft.AspNetCore.BuildTools.ApiCheck.nuspec
+++ b/src/ApiCheck.Console/Microsoft.AspNetCore.BuildTools.ApiCheck.nuspec
@@ -12,7 +12,7 @@
   <files>
     <file src="build\**" target="build\" />
     <file src="$publishDir$\net46\**" target="tools\net46\" />
-    <file src="$publishDir$\netcoreapp2.0\**" target="tools\netcoreapp2.0\" />
+    <file src="$publishDir$\netcoreapp2.1\**" target="tools\netcoreapp2.1\" />
     <file src="$taskBuildDir$\netstandard2.0\*.dll" target="tools\netstandard2.0\" />
   </files>
 </package>

--- a/src/ApiCheck.Task/ApiCheckTasksBase.cs
+++ b/src/ApiCheck.Task/ApiCheckTasksBase.cs
@@ -129,7 +129,7 @@ namespace Microsoft.AspNetCore.BuildTools.ApiCheck.Task
             if (!Framework.StartsWith("net4", StringComparison.OrdinalIgnoreCase))
             {
                 var taskAssemblyFolder = Path.GetDirectoryName(GetType().GetTypeInfo().Assembly.Location);
-                var toolPath = Path.Combine(taskAssemblyFolder, "..", "netcoreapp2.0", ApiCheckToolName + ".dll");
+                var toolPath = Path.Combine(taskAssemblyFolder, "..", "netcoreapp2.1", ApiCheckToolName + ".dll");
                 arguments = $@"""{Path.GetFullPath(toolPath)}"" ";
             }
 

--- a/test/ApiCheck.Test/ApiCheck.Test.csproj
+++ b/test/ApiCheck.Test/ApiCheck.Test.csproj
@@ -3,8 +3,8 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp2.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/ApiCheckBaseline.V1/ApiCheckBaseline.V1.csproj
+++ b/test/ApiCheckBaseline.V1/ApiCheckBaseline.V1.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.6;net452</TargetFrameworks>
+    <TargetFrameworks>netstandard1.6;net452;netcoreapp2.1</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/test/ApiCheckBaseline.V2/ApiCheckBaseline.V2.csproj
+++ b/test/ApiCheckBaseline.V2/ApiCheckBaseline.V2.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.6;net452</TargetFrameworks>
+    <TargetFrameworks>netstandard1.6;net452;netcoreapp2.1</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 


### PR DESCRIPTION
I just attempted to start using APIs that exist only in netcoreapp2.1 and it turns out API check is busted.

https://github.com/aspnet/KestrelHttpServer/pull/2173

Turns out the API check tool loads assemblies and is written against .NET Core 2.0 so it can't load .NET Core 2.1 things (this shouldn't be a surprise). I don't know how many other tools we have that do this but I see 2 solutions:

1. Stop loading assemblies and rewrite this tool to understand metadata
2. Always update the tools to require the latest runtime so it can load all versions <= the most recent runtime.

The cheapest option would be 2 for now.