### PR TITLE
Remove dependency on Microsoft.DotNet.Cli.Utils

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -1,6 +1,5 @@
 <Project>
   <PropertyGroup>
-    <DotNetCliUtilsVersion>1.0.1</DotNetCliUtilsVersion>
     <HtmlAgilityPackVersion>1.5.1</HtmlAgilityPackVersion>
     <!-- This one is OK for console tools that bundle their own version of JSON.NET -->
     <JsonNetVersion>10.0.1</JsonNetVersion>

--- a/test/BuildTools.Tasks.Tests/BuildTools.Tasks.Tests.csproj
+++ b/test/BuildTools.Tasks.Tests/BuildTools.Tasks.Tests.csproj
@@ -16,7 +16,6 @@
     <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" />
     <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildVersion)" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildVersion)" />
-    <PackageReference Include="Microsoft.DotNet.Cli.Utils" Version="$(DotNetCliUtilsVersion)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />

--- a/test/BuildTools.Tasks.Tests/GetDotNetHostTest.cs
+++ b/test/BuildTools.Tasks.Tests/GetDotNetHostTest.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Diagnostics;
 using System.IO;
 using Microsoft.AspNetCore.BuildTools;
-using Microsoft.DotNet.Cli.Utils;
 using Xunit;
 
 namespace BuildTools.Tasks.Tests
@@ -19,7 +19,7 @@ namespace BuildTools.Tasks.Tests
             };
 
             Assert.True(task.Execute(), "Task failed");
-            var muxer = new Muxer().MuxerPath;
+            var muxer = Process.GetCurrentProcess().MainModule.FileName;
             Assert.Equal(muxer, task.ExecutablePath);
             Assert.Equal(Path.GetDirectoryName(muxer) + Path.DirectorySeparatorChar, task.DotNetDirectory);
         }


### PR DESCRIPTION
Avoid future issues such as the auto-rollforward one we hit in #474 