### PR TITLE
Update external dependencies

### DIFF
--- a/modules/KoreBuild.Tasks/UpgradeExternalDependencies.cs
+++ b/modules/KoreBuild.Tasks/UpgradeExternalDependencies.cs
@@ -1,0 +1,57 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using KoreBuild.Tasks.Utilities;
+using Microsoft.Build.Framework;
+using System.Collections.Generic;
+
+namespace KoreBuild.Tasks
+{
+    public class UpgradeExternalDependencies : Microsoft.Build.Utilities.Task
+    {
+
+        [Required]
+        public string UpdateSource { get; set; }
+
+        /// <summary>
+        /// The dependencies.props file to update
+        /// </summary>
+        [Required]
+        public string DependenciesFile { get; set; }
+
+        public override bool Execute()
+        {
+            var latest = GetLatestDeps();
+
+            return UpdateDependencyFile(latest);
+        }
+
+        private IReadOnlyDictionary<string, string> GetLatestDeps()
+        {
+            return DependencyVersionsFile.Load(UpdateSource).VersionVariables;
+        }
+
+        private bool UpdateDependencyFile(IReadOnlyDictionary<string, string> latest)
+        {
+            if (!DependencyVersionsFile.TryLoad(DependenciesFile, out var localVersionsFile))
+            {
+                Log.LogError($"Could not load file from {DependenciesFile}");
+                return false;
+            }
+
+            foreach (var sourceVariable in latest)
+            {
+                if (!localVersionsFile.VersionVariables.ContainsKey(sourceVariable.Key))
+                {
+                    Log.LogWarning($"Creating variable {sourceVariable.Key}");
+                }
+                Log.LogWarning($"Setting '{sourceVariable.Key}' to '{sourceVariable.Value}'",);
+                localVersionsFile.Set(sourceVariable.Key, sourceVariable.Value);
+            }
+
+            localVersionsFile.Save(DependenciesFile);
+
+            return true;
+        }
+    }
+}

--- a/modules/KoreBuild.Tasks/UpgradeExternalDependencies.cs
+++ b/modules/KoreBuild.Tasks/UpgradeExternalDependencies.cs
@@ -11,7 +11,6 @@ namespace KoreBuild.Tasks
 {
     public class UpgradeExternalDependencies : Microsoft.Build.Utilities.Task
     {
-
         [Required]
         public string UpdateSource { get; set; }
 

--- a/modules/KoreBuild.Tasks/module.props
+++ b/modules/KoreBuild.Tasks/module.props
@@ -1,14 +1,19 @@
 <Project>
-  <UsingTask TaskName="KoreBuild.Tasks.CheckPackageReferences" AssemblyFile="$(MSBuildThisFileDirectory)Internal.AspNetCore.KoreBuild.Tasks.dll" />
-  <UsingTask TaskName="KoreBuild.Tasks.DownloadNuGetPackages" AssemblyFile="$(MSBuildThisFileDirectory)Internal.AspNetCore.KoreBuild.Tasks.dll" />
-  <UsingTask TaskName="KoreBuild.Tasks.FindVisualStudio" AssemblyFile="$(MSBuildThisFileDirectory)Internal.AspNetCore.KoreBuild.Tasks.dll" />
-  <UsingTask TaskName="KoreBuild.Tasks.GenerateDependenciesPropsFile" AssemblyFile="$(MSBuildThisFileDirectory)Internal.AspNetCore.KoreBuild.Tasks.dll" />
-  <UsingTask TaskName="KoreBuild.Tasks.GeneratePackageVersionPropsFile" AssemblyFile="$(MSBuildThisFileDirectory)Internal.AspNetCore.KoreBuild.Tasks.dll" />
-  <UsingTask TaskName="KoreBuild.Tasks.GetToolsets" AssemblyFile="$(MSBuildThisFileDirectory)Internal.AspNetCore.KoreBuild.Tasks.dll" />
-  <UsingTask TaskName="KoreBuild.Tasks.InstallDotNet" AssemblyFile="$(MSBuildThisFileDirectory)Internal.AspNetCore.KoreBuild.Tasks.dll" />
-  <UsingTask TaskName="KoreBuild.Tasks.PackNuSpec" AssemblyFile="$(MSBuildThisFileDirectory)Internal.AspNetCore.KoreBuild.Tasks.dll" />
-  <UsingTask TaskName="KoreBuild.Tasks.PushNuGetPackages" AssemblyFile="$(MSBuildThisFileDirectory)Internal.AspNetCore.KoreBuild.Tasks.dll" />
-  <UsingTask TaskName="KoreBuild.Tasks.UpgradeDependencies" AssemblyFile="$(MSBuildThisFileDirectory)Internal.AspNetCore.KoreBuild.Tasks.dll" />
+  <PropertyGroup>
+    <KoreBuildTasksDllLocation>$(MSBuildThisFileDirectory)Internal.AspNetCore.KoreBuild.Tasks.dll</KoreBuildTasksDllLocation>
+  </PropertyGroup>
+
+  <UsingTask TaskName="KoreBuild.Tasks.CheckPackageReferences" AssemblyFile="$(KoreBuildTasksDllLocation)" />
+  <UsingTask TaskName="KoreBuild.Tasks.DownloadNuGetPackages" AssemblyFile="$(KoreBuildTasksDllLocation)" />
+  <UsingTask TaskName="KoreBuild.Tasks.FindVisualStudio" AssemblyFile="$(KoreBuildTasksDllLocation)" />
+  <UsingTask TaskName="KoreBuild.Tasks.GenerateDependenciesPropsFile" AssemblyFile="$(KoreBuildTasksDllLocation)" />
+  <UsingTask TaskName="KoreBuild.Tasks.GeneratePackageVersionPropsFile" AssemblyFile="$(KoreBuildTasksDllLocation)" />
+  <UsingTask TaskName="KoreBuild.Tasks.GetToolsets" AssemblyFile="$(KoreBuildTasksDllLocation)" />
+  <UsingTask TaskName="KoreBuild.Tasks.InstallDotNet" AssemblyFile="$(KoreBuildTasksDllLocation)" />
+  <UsingTask TaskName="KoreBuild.Tasks.PackNuSpec" AssemblyFile="$(KoreBuildTasksDllLocation)" />
+  <UsingTask TaskName="KoreBuild.Tasks.PushNuGetPackages" AssemblyFile="$(KoreBuildTasksDllLocation)" />
+  <UsingTask TaskName="KoreBuild.Tasks.UpgradeDependencies" AssemblyFile="$(KoreBuildTasksDllLocation)" />
+  <UsingTask TaskName="KoreBuild.Tasks.UpgradeExternalDependencies" AssemblyFile="$(KoreBuildTasksDllLocation)" />
 
   <PropertyGroup>
     <DefaultDotNetAssetArch>$(KOREBUILD_DOTNET_ARCH)</DefaultDotNetAssetArch>

--- a/modules/KoreBuild.Tasks/module.targets
+++ b/modules/KoreBuild.Tasks/module.targets
@@ -49,6 +49,14 @@
       Properties="$(SolutionProperties)"/>
   </Target>
 
+  <Target Name="UpgradeExternalDependencies">
+    <Error Text="UpdateSource was not set." Condition="'$(UpdateSource)' == ''" />
+    
+    <UpgradeExternalDependencies
+      DependenciesFile="$(DependencyVersionsFile)"
+      UpdateSource="$(UpdateSource)" />
+  </Target>
+  
   <!-- See also DependenciesUpgradeCommand.cs in KoreBuild.Console for a more discoverable way to run this. -->
   <Target Name="UpgradeDependencies">
     <Error Text="LineupPackageId was not set." Condition="'$(LineupPackageId)' == ''" />

--- a/test/KoreBuild.Tasks.Tests/DependenciesTestsBase.cs
+++ b/test/KoreBuild.Tasks.Tests/DependenciesTestsBase.cs
@@ -1,0 +1,44 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using KoreBuild.Tasks.Utilities;
+using Microsoft.Build.Construction;
+using Microsoft.Build.Evaluation;
+using System;
+using System.IO;
+using Xunit.Abstractions;
+
+namespace KoreBuild.Tasks.Tests
+{
+    public class DependenciesTestsBase : IDisposable
+    {
+        protected readonly string _tempDir;
+        protected readonly ITestOutputHelper _output;
+
+        public DependenciesTestsBase(ITestOutputHelper output, MSBuildTestCollectionFixture fixture)
+        {
+            fixture.InitializeEnvironment(output);
+            _tempDir = Path.Combine(AppContext.BaseDirectory, Path.GetRandomFileName());
+            Directory.CreateDirectory(_tempDir);
+            _output = output;
+        }
+
+        protected string CreateProjectDepsFile(params (string varName, string version)[] variables)
+        {
+            var depsFilePath = Path.Combine(_tempDir, "projectdeps.props");
+            var proj = ProjectRootElement.Create(NewProjectFileOptions.None);
+            var originalDepsFile = DependencyVersionsFile.Load(proj);
+            foreach (var item in variables)
+            {
+                originalDepsFile.Set(item.varName, item.version);
+            }
+            originalDepsFile.Save(depsFilePath);
+            return depsFilePath;
+        }
+
+        public void Dispose()
+        {
+            Directory.Delete(_tempDir, recursive: true);
+        }
+    }
+}

--- a/test/KoreBuild.Tasks.Tests/UpgradeDependenciesTests.cs
+++ b/test/KoreBuild.Tasks.Tests/UpgradeDependenciesTests.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.IO;
 using System.Threading.Tasks;
 using BuildTools.Tasks.Tests;
@@ -17,17 +16,11 @@ using Xunit.Abstractions;
 namespace KoreBuild.Tasks.Tests
 {
     [Collection(nameof(MSBuildTestCollection))]
-    public class UpgradeDependenciesTests : IDisposable
+    public class UpgradeDependenciesTests : DependenciesTestsBase
     {
-        private readonly string _tempDir;
-        private readonly ITestOutputHelper _output;
-
         public UpgradeDependenciesTests(ITestOutputHelper output, MSBuildTestCollectionFixture fixture)
+            : base(output, fixture)
         {
-            fixture.InitializeEnvironment(output);
-            _tempDir = Path.Combine(AppContext.BaseDirectory, Path.GetRandomFileName());
-            Directory.CreateDirectory(_tempDir);
-            _output = output;
         }
 
         [Fact]
@@ -129,19 +122,6 @@ namespace KoreBuild.Tasks.Tests
             Assert.Equal(created, File.GetLastWriteTime(depsFilePath));
         }
 
-        private string CreateProjectDepsFile(params (string varName, string version)[] variables)
-        {
-            var depsFilePath = Path.Combine(_tempDir, "projectdeps.props");
-            var proj = ProjectRootElement.Create(NewProjectFileOptions.None);
-            var originalDepsFile = DependencyVersionsFile.Load(proj);
-            foreach (var item in variables)
-            {
-                originalDepsFile.Set(item.varName, item.version);
-            }
-            originalDepsFile.Save(depsFilePath);
-            return depsFilePath;
-        }
-
         private string CreateLineup(PackageIdentity identity, params (string varName, string version)[] variables)
         {
             var output = Path.Combine(_tempDir, $"{identity.Id}.{identity.Version}.nupkg");
@@ -171,11 +151,6 @@ namespace KoreBuild.Tasks.Tests
             }
 
             return output;
-        }
-
-        public void Dispose()
-        {
-            Directory.Delete(_tempDir, recursive: true);
         }
     }
 }

--- a/test/KoreBuild.Tasks.Tests/UpgradeExternalDependenciesTests.cs
+++ b/test/KoreBuild.Tasks.Tests/UpgradeExternalDependenciesTests.cs
@@ -1,0 +1,87 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO;
+using BuildTools.Tasks.Tests;
+using KoreBuild.Tasks.Utilities;
+using Microsoft.Build.Construction;
+using Microsoft.Build.Evaluation;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace KoreBuild.Tasks.Tests
+{
+    [Collection(nameof(MSBuildTestCollection))]
+    public class UpgradeExternalDependenciesTests : DependenciesTestsBase
+    {
+        public UpgradeExternalDependenciesTests(ITestOutputHelper output, MSBuildTestCollectionFixture fixture)
+            : base(output, fixture)
+        {
+        }
+
+        [Fact]
+        public void UpdatesVariableValue()
+        {
+            // Arrange
+            var depsFilePath = CreateProjectDepsFile(("PackageVersionVar", "1.0.0"));
+            var updateSource = CreateUpdateSource(("PackageVersionVar", "2.0.0"));
+
+            var engine = new MockEngine(_output);
+
+            // Act
+            var task = new UpgradeExternalDependencies {
+                BuildEngine = engine,
+                DependenciesFile = depsFilePath,
+                UpdateSource = updateSource
+            };
+
+            // Assert
+            Assert.True(task.Execute(), "Task is expected to pass.");
+            var warning = Assert.Single(engine.Warnings, r => r.Message == "Setting 'PackageVersionVar' to '2.0.0'");
+
+            var modifiedDepsFile = DependencyVersionsFile.Load(depsFilePath);
+            Assert.Equal("2.0.0", modifiedDepsFile.VersionVariables["PackageVersionVar"]);
+        }
+
+        [Fact]
+        public void DoesNotModifyFileIfNoChanges()
+        {
+            // Arrange
+            var depsFilePath = CreateProjectDepsFile(("PackageVersionVar", "1.0.0"));
+            var updateSource = CreateUpdateSource(("PackageVersionVar", "1.0.0"));
+            var created = File.GetLastWriteTime(depsFilePath);
+
+            var engine = new MockEngine(_output);
+
+            // Act
+            var task = new UpgradeExternalDependencies {
+                BuildEngine = engine,
+                DependenciesFile = depsFilePath,
+                UpdateSource = updateSource
+            };
+
+            // Assert
+            Assert.True(task.Execute(), "Task is expected to pass");
+            var modifiedDepsFile = DependencyVersionsFile.Load(depsFilePath);
+            Assert.Equal("1.0.0", modifiedDepsFile.VersionVariables["PackageVersionVar"]);
+            Assert.Equal(created, File.GetLastWriteTime(depsFilePath));
+        }
+
+        private string CreateUpdateSource(params (string varName, string version)[] variables)
+        {
+            var output = Path.Combine(_tempDir, "packageversion.props");
+
+            var proj = ProjectRootElement.Create(NewProjectFileOptions.IncludeAllOptions);
+
+            var variableGroup = proj.AddPropertyGroup();
+            foreach (var variable in variables)
+            {
+                variableGroup.AddProperty(variable.varName, variable.version);
+            }
+
+            proj.Save(output);
+
+            return output;
+        }
+    }
+}


### PR DESCRIPTION
This task would basically only be used by Universe so far, but by putting it here we get to take advantage of a lot of existing code to handle project-type files.