### PR TITLE
Clear DirectoryBuildPropsPath for SharedSources

### DIFF
--- a/files/KoreBuild/modules/sharedsources/module.targets
+++ b/files/KoreBuild/modules/sharedsources/module.targets
@@ -32,7 +32,7 @@ that matches "$(RepositoryRoot)/shared/*.Sources".
 
   <Target Name="_SetSharedSourcesProperties">
     <PropertyGroup>
-      <_SharedSourcesPackageProperties>PackageOutputPath=$(BuildDir);RepositoryRoot=$(RepositoryRoot);BuildNumber=$(BuildNumber);</_SharedSourcesPackageProperties>
+      <_SharedSourcesPackageProperties>PackageOutputPath=$(BuildDir);RepositoryRoot=$(RepositoryRoot);ImportDirectoryBuildProps=false;BuildNumber=$(BuildNumber);</_SharedSourcesPackageProperties>
     </PropertyGroup>
   </Target>
 


### PR DESCRIPTION
OK, this is a weird one. This problem manifests when you have `$Env:DOTNET_HOME` set to the BuildTools repository root. Microsoft.Common.props will try to set and then Import `DirectoryBuildPropsPath` to `$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), '$(_DirectoryBuildPropsFile)` if it's not set or `ImportDirectoryBuildProps` isn't set to true, meaning that when .dotnet is in the RepoRoot, it will walk up the project path for sharedproject.csproj (which is in KoreBuild, and thus stored in .dotnet) looking for `Directory.Build.props` until it finds the one at BuildTools root, imports it, and its versions along with it. Our tests then expect the version number for SimpleRepo, but get the ones for BuildTools as a whole.

I am able to reproduce this problem and have confirmed locally that this PR will fix it, but I'm not convinced it's the correct fix (since this seems like a bug in Microsoft.Common.props).