### PR TITLE
Don't clean on build

### DIFF
--- a/files/KoreBuild/modules/solutionbuild/module.targets
+++ b/files/KoreBuild/modules/solutionbuild/module.targets
@@ -10,7 +10,7 @@ FYI: targets, properties, and items that begin with an underscore are meant to b
   </ItemGroup>
 
   <PropertyGroup Condition="'$(DisableDefaultTargets)' != 'true'">
-    <PrepareDependsOn>$(PrepareDependsOn);CleanArtifacts;_PrepareOutputPaths</PrepareDependsOn>
+    <PrepareDependsOn>$(PrepareDependsOn);_PrepareOutputPaths</PrepareDependsOn>
     <RestoreDependsOn>$(RestoreDependsOn);_BeforeRestore;RestoreSolutions</RestoreDependsOn>
     <CompileDependsOn>$(CompileDependsOn);_CreateCommitHashArtifact;BuildSolutions</CompileDependsOn>
     <PackageDependsOn>$(PackageDependsOn);PackageProjects;PackSharedSources</PackageDependsOn>


### PR DESCRIPTION
This messes up orchestrated build. I'm sure we have any good reason to auto-clean on every build. /t:Clean will still invoke CleanArtifacts