### PR TITLE
Make SourceLink use the correct slash

### DIFF
--- a/modules/BuildTools.Tasks/CreateSourceLink.cs
+++ b/modules/BuildTools.Tasks/CreateSourceLink.cs
@@ -35,16 +35,20 @@ namespace Microsoft.AspNetCore.BuildTools
         {
             var rootDirectory = Path.Combine(Path.GetFullPath(RootDirectory), "*");
 
-            rootDirectory = rootDirectory.Replace("/", "\\");
-            rootDirectory = rootDirectory.Replace("\\", "\\\\");
+            var escapedPath = JsonEscapePath(rootDirectory);
 
             var codeSource = ConvertUrl();
 
-            File.WriteAllText(DestinationFile, $"{{\"documents\":{{\"{rootDirectory}\":\"{codeSource}\"}}}}");
+            File.WriteAllText(DestinationFile, $"{{\"documents\":{{\"{escapedPath}\":\"{codeSource}\"}}}}");
 
             SourceLinkFile = DestinationFile;
 
             return true;
+        }
+
+        private string JsonEscapePath(string path)
+        {
+            return path.Replace("\\", "\\\\");
         }
 
         private string ConvertUrl()

--- a/modules/BuildTools.Tasks/CreateSourceLink.cs
+++ b/modules/BuildTools.Tasks/CreateSourceLink.cs
@@ -34,7 +34,7 @@ namespace Microsoft.AspNetCore.BuildTools
         public override bool Execute()
         {
             var rootDirectory = Path.Combine(Path.GetFullPath(RootDirectory), "*");
-            rootDirectory = rootDirectory.Replace("\\", "/");
+            rootDirectory = rootDirectory.Replace("\\", "\\\\");
 
             var codeSource = ConvertUrl();
 
@@ -47,7 +47,7 @@ namespace Microsoft.AspNetCore.BuildTools
 
         private string ConvertUrl()
         {
-            if(!OriginUrl.Contains("github.com"))
+            if (!OriginUrl.Contains("github.com"))
             {
                 throw new ArgumentException("OriginUrl must be for github.com", "OriginUrl");
             }

--- a/modules/BuildTools.Tasks/CreateSourceLink.cs
+++ b/modules/BuildTools.Tasks/CreateSourceLink.cs
@@ -34,6 +34,8 @@ namespace Microsoft.AspNetCore.BuildTools
         public override bool Execute()
         {
             var rootDirectory = Path.Combine(Path.GetFullPath(RootDirectory), "*");
+
+            rootDirectory = rootDirectory.Replace("/", "\\");
             rootDirectory = rootDirectory.Replace("\\", "\\\\");
 
             var codeSource = ConvertUrl();

--- a/test/BuildTools.Tasks.Tests/CreateSourceLinkTest.cs
+++ b/test/BuildTools.Tasks.Tests/CreateSourceLinkTest.cs
@@ -36,7 +36,44 @@ namespace BuildTools.Tasks.Tests
                 Assert.True(File.Exists(destination), "SourceLink file doesn't exist.");
 
                 var expectedUrl = $"https://raw.githubusercontent.com/{repoName}/{commit}/*";
-                var expected = $"{{\"documents\":{{\"{rootDir}*\":\"{expectedUrl}\"}}}}";
+                var expected = $"{{\"documents\":{{\"{GetExpectedRootDirectory()}*\":\"{expectedUrl}\"}}}}";
+
+                var resultText = File.ReadAllText(destination);
+
+                Assert.Equal(expected, resultText);
+            }
+            finally
+            {
+                File.Delete(destination);
+            }
+        }
+
+        [Fact]
+        public void DealsWithBackslash()
+        {
+            var destination = "sourcelink.json";
+
+            var repoName = "aspnet/BuildTools";
+
+            var originUrl = $"git@github.com:{repoName}.git";
+            var commit = "5153bbdfa98dcc27a61d591ce09a0d632875e66f";
+            var rootDir = GetRootDirectory(useBackslash: true);
+
+            var task = new CreateSourceLink
+            {
+                OriginUrl = originUrl,
+                Commit = commit,
+                DestinationFile = destination,
+                RootDirectory = rootDir
+            };
+
+            try
+            {
+                Assert.True(task.Execute(), "The task failed but should have passed.");
+                Assert.True(File.Exists(destination), "SourceLink file doesn't exist.");
+
+                var expectedUrl = $"https://raw.githubusercontent.com/{repoName}/{commit}/*";
+                var expected = $"{{\"documents\":{{\"{GetExpectedRootDirectory()}*\":\"{expectedUrl}\"}}}}";
 
                 var resultText = File.ReadAllText(destination);
 
@@ -73,7 +110,7 @@ namespace BuildTools.Tasks.Tests
                 Assert.True(File.Exists(destination), "SourceLink file doesn't exist.");
 
                 var expectedUrl = $"https://raw.githubusercontent.com/{repoName}/{commit}/*";
-                var expected = $"{{\"documents\":{{\"{rootDir}*\":\"{expectedUrl}\"}}}}";
+                var expected = $"{{\"documents\":{{\"{GetExpectedRootDirectory()}*\":\"{expectedUrl}\"}}}}";
 
                 Assert.Equal(expected, File.ReadAllText(destination));
             }
@@ -83,12 +120,27 @@ namespace BuildTools.Tasks.Tests
             }
         }
 
-        private static string GetRootDirectory()
+        private static string GetExpectedRootDirectory()
         {
             switch (RuntimeEnvironment.OperatingSystemPlatform)
             {
                 case Platform.Windows:
                     return "C:\\\\";
+                case Platform.Linux:
+                case Platform.Darwin:
+                    return "/home/";
+                default:
+                    throw new NotImplementedException($"SourceLink tests don't yet support {RuntimeEnvironment.OperatingSystemPlatform}.");
+
+            }
+        }
+
+        private static string GetRootDirectory(bool useBackslash = false)
+        {
+            switch (RuntimeEnvironment.OperatingSystemPlatform)
+            {
+                case Platform.Windows:
+                    return "C:" + (useBackslash ? "/" : "\\");
                 case Platform.Linux:
                 case Platform.Darwin:
                     return "/home/";

--- a/test/BuildTools.Tasks.Tests/CreateSourceLinkTest.cs
+++ b/test/BuildTools.Tasks.Tests/CreateSourceLinkTest.cs
@@ -131,7 +131,6 @@ namespace BuildTools.Tasks.Tests
                     return "/home/";
                 default:
                     throw new NotImplementedException($"SourceLink tests don't yet support {RuntimeEnvironment.OperatingSystemPlatform}.");
-
             }
         }
 

--- a/test/BuildTools.Tasks.Tests/CreateSourceLinkTest.cs
+++ b/test/BuildTools.Tasks.Tests/CreateSourceLinkTest.cs
@@ -85,10 +85,10 @@ namespace BuildTools.Tasks.Tests
 
         private static string GetRootDirectory()
         {
-            switch(RuntimeEnvironment.OperatingSystemPlatform)
+            switch (RuntimeEnvironment.OperatingSystemPlatform)
             {
                 case Platform.Windows:
-                    return "C:/";
+                    return "C:\\\\";
                 case Platform.Linux:
                 case Platform.Darwin:
                     return "/home/";


### PR DESCRIPTION
In local testing I found that we needed an escaped `\` instead of a `/` to make VS use SourceLink successfully. This jives with dotnet's documentation [here](https://github.com/dotnet/core/blob/3cc74f3cd7ff6ca2d94e4e1b882e8551b5c32a50/Documentation/diagnostics/source_link.md#examples).

It looked like this slipped through as code cleanup in the PR and likely in testing the old package was accidentally used. I don't know of a way to test this "for real" outside of by-hand in VS, so unit tests and re-verifying once this goes through Universe will have to do.