### PR TITLE
Set DOTNET_MULTILEVEL_LOOKUP=0

### DIFF
--- a/files/KoreBuild/KoreBuild.sh
+++ b/files/KoreBuild/KoreBuild.sh
@@ -106,3 +106,9 @@ if [ "$(uname)" = "Darwin" ]; then
     # increase file descriptor limit
     ulimit -n 5000
 fi
+
+# Set required environment variables
+
+# This disables automatic rollforward to /usr/local/dotnet and other global locations.
+# We want to ensure are tests are running against the exact runtime specified by the project.
+export DOTNET_MULTILEVEL_LOOKUP=0

--- a/files/KoreBuild/scripts/KoreBuild.psm1
+++ b/files/KoreBuild/scripts/KoreBuild.psm1
@@ -30,6 +30,12 @@ if ($env:KOREBUILD_DOTNET_FEED_CREDENTIAL) {
     $script:config.'dotnet.feed.credential' = $env:KOREBUILD_DOTNET_FEED_CREDENTIAL
 }
 
+# Set required environment variables
+
+# This disables automatic rollforward to C:\Program Files\ and other global locations.
+# We want to ensure are tests are running against the exact runtime specified by the project.
+$env:DOTNET_MULTILEVEL_LOOKUP=0
+
 <#
 .SYNOPSIS
 Builds a repository


### PR DESCRIPTION
Set DOTNET_MULTILEVEL_LOOKUP=0 to prevent roll-forward to frameworks outside of DOTNET_HOME.

This was recently a source of grief in the patch build because tests would pass on some machines and not others, depending on the version of Visual Studio installed.

At the very least, this will make failures consistent.