### PR TITLE
Set PathMap for CI builds to make symbol generation deterministic

### DIFF
--- a/modules/BuildTools.Tasks/CreateSourceLink.cs
+++ b/modules/BuildTools.Tasks/CreateSourceLink.cs
@@ -34,20 +34,26 @@ namespace Microsoft.AspNetCore.BuildTools
         public override bool Execute()
         {
             var rootDirectory = Path.Combine(Path.GetFullPath(RootDirectory), "*");
-            rootDirectory = rootDirectory.Replace("\\", "/");
+
+            var escapedPath = JsonEscapePath(rootDirectory);
 
             var codeSource = ConvertUrl();
 
-            File.WriteAllText(DestinationFile, $"{{\"documents\":{{\"{rootDirectory}\":\"{codeSource}\"}}}}");
+            File.WriteAllText(DestinationFile, $"{{\"documents\":{{\"{escapedPath}\":\"{codeSource}\"}}}}");
 
             SourceLinkFile = DestinationFile;
 
             return true;
         }
 
+        private string JsonEscapePath(string path)
+        {
+            return path.Replace("\\", "\\\\");
+        }
+
         private string ConvertUrl()
         {
-            if(!OriginUrl.Contains("github.com"))
+            if (!OriginUrl.Contains("github.com"))
             {
                 throw new ArgumentException("OriginUrl must be for github.com", "OriginUrl");
             }

--- a/src/Internal.AspNetCore.Sdk/build/Git.targets
+++ b/src/Internal.AspNetCore.Sdk/build/Git.targets
@@ -4,8 +4,25 @@
     <GenerateCommitHashAttribute Condition="'$(GenerateCommitHashAttribute)'==''">true</GenerateCommitHashAttribute>
     <GeneratedCommitHashAttributeFile Condition="'$(GeneratedCommitHashAttributeFile)'==''">$(IntermediateOutputPath)$(AssemblyName).CommitHash$(DefaultLanguageSourceExtension)</GeneratedCommitHashAttributeFile>
     <SourceLinkDestination Condition="'$(SourceLinkDestination)' == ''">$(IntermediateOutputPath)sourcelink.json</SourceLinkDestination>
-    <SourceDirectory>$([System.IO.Path]::Combine($(RepositoryRoot.Trim('/')), 'src'))</SourceDirectory>
     <GenerateSourceLinkFile Condition="'$(GenerateSourceLinkFile)' == '' AND '$(IsPackable)' != 'false'">true</GenerateSourceLinkFile>
+    <!--
+      The source root path used for deterministic normalization of source paths.
+
+      If set the value is used in PathMap to instruct the compiler to normalize source paths
+      emitted to the binary and PDB and as a root for Source Link mapping.
+      If set must end with a directory separator.
+
+      The path can't be just a single '/' due to bug in Roslyn compilers:
+      https://github.com/dotnet/roslyn/issues/22815.
+
+      Only set this in CI builds, otherwise it will mess up the debugger.
+    -->
+    <DeterministicSourceRoot Condition=" '$(CI)' == 'true' ">/_/</DeterministicSourceRoot>
+
+    <SourceLinkRoot Condition="'$(DeterministicSourceRoot)' != ''">$(DeterministicSourceRoot)</SourceLinkRoot>
+    <SourceLinkRoot Condition="'$(SourceLinkRoot)' == ''">$([MSBuild]::NormalizeDirectory($(RepositoryRoot)))</SourceLinkRoot>
+
+    <PathMap Condition=" '$(DeterministicSourceRoot)' != '' ">$(RepositoryRoot)=$(DeterministicSourceRoot)</PathMap>
   </PropertyGroup>
 
   <Target Name="ResolveCommitHash" Condition="'$(CommitHash)'==''">
@@ -28,12 +45,12 @@
           Outputs="$(SourceLinkDestination)" >
 
     <Sdk_CreateSourceLink
-          RootDirectory="$(RepositoryRoot)"
+          SourceLinkRoot="$(SourceLinkRoot)"
           OriginUrl="$(RepositoryUrl)"
           Commit="$(CommitHash)"
           DestinationFile="$(SourceLinkDestination)"
           ContinueOnError="WarnAndContinue"
-          Condition="'$(CommitHash)' != '' AND '$(RepositoryUrl)' != '' AND '$(RepositoryRoot)' != ''">
+          Condition="'$(CommitHash)' != '' AND '$(RepositoryUrl)' != '' AND '$(SourceLinkRoot)' != ''">
       <Output TaskParameter="SourceLinkFile" PropertyName="SourceLink" />
     </Sdk_CreateSourceLink>
 
@@ -43,8 +60,8 @@
     <Warning Text="SourceLink not enabled because this is not a git repo."
              Condition="'$(CommitHash)' == ''" />
 
-    <Warning Text="SourceLink not enabled because RepositoryRoot wasn't set."
-             Condition="'$(RepositoryRoot)' == ''" />
+    <Warning Text="SourceLink not enabled because SourceLinkRoot wasn't set."
+             Condition="'$(SourceLinkRoot)' == ''" />
   </Target>
 
 <!--

--- a/test/BuildTools.Tasks.Tests/CreateSourceLinkTest.cs
+++ b/test/BuildTools.Tasks.Tests/CreateSourceLinkTest.cs
@@ -36,7 +36,44 @@ namespace BuildTools.Tasks.Tests
                 Assert.True(File.Exists(destination), "SourceLink file doesn't exist.");
 
                 var expectedUrl = $"https://raw.githubusercontent.com/{repoName}/{commit}/*";
-                var expected = $"{{\"documents\":{{\"{rootDir}*\":\"{expectedUrl}\"}}}}";
+                var expected = $"{{\"documents\":{{\"{GetExpectedRootDirectory()}*\":\"{expectedUrl}\"}}}}";
+
+                var resultText = File.ReadAllText(destination);
+
+                Assert.Equal(expected, resultText);
+            }
+            finally
+            {
+                File.Delete(destination);
+            }
+        }
+
+        [Fact]
+        public void DealsWithBackslash()
+        {
+            var destination = "sourcelink.json";
+
+            var repoName = "aspnet/BuildTools";
+
+            var originUrl = $"git@github.com:{repoName}.git";
+            var commit = "5153bbdfa98dcc27a61d591ce09a0d632875e66f";
+            var rootDir = GetRootDirectory(useBackslash: true);
+
+            var task = new CreateSourceLink
+            {
+                OriginUrl = originUrl,
+                Commit = commit,
+                DestinationFile = destination,
+                RootDirectory = rootDir
+            };
+
+            try
+            {
+                Assert.True(task.Execute(), "The task failed but should have passed.");
+                Assert.True(File.Exists(destination), "SourceLink file doesn't exist.");
+
+                var expectedUrl = $"https://raw.githubusercontent.com/{repoName}/{commit}/*";
+                var expected = $"{{\"documents\":{{\"{GetExpectedRootDirectory()}*\":\"{expectedUrl}\"}}}}";
 
                 var resultText = File.ReadAllText(destination);
 
@@ -73,7 +110,7 @@ namespace BuildTools.Tasks.Tests
                 Assert.True(File.Exists(destination), "SourceLink file doesn't exist.");
 
                 var expectedUrl = $"https://raw.githubusercontent.com/{repoName}/{commit}/*";
-                var expected = $"{{\"documents\":{{\"{rootDir}*\":\"{expectedUrl}\"}}}}";
+                var expected = $"{{\"documents\":{{\"{GetExpectedRootDirectory()}*\":\"{expectedUrl}\"}}}}";
 
                 Assert.Equal(expected, File.ReadAllText(destination));
             }
@@ -83,12 +120,26 @@ namespace BuildTools.Tasks.Tests
             }
         }
 
-        private static string GetRootDirectory()
+        private static string GetExpectedRootDirectory()
         {
-            switch(RuntimeEnvironment.OperatingSystemPlatform)
+            switch (RuntimeEnvironment.OperatingSystemPlatform)
             {
                 case Platform.Windows:
-                    return "C:/";
+                    return "C:\\\\";
+                case Platform.Linux:
+                case Platform.Darwin:
+                    return "/home/";
+                default:
+                    throw new NotImplementedException($"SourceLink tests don't yet support {RuntimeEnvironment.OperatingSystemPlatform}.");
+            }
+        }
+
+        private static string GetRootDirectory(bool useBackslash = false)
+        {
+            switch (RuntimeEnvironment.OperatingSystemPlatform)
+            {
+                case Platform.Windows:
+                    return "C:" + (useBackslash ? "/" : "\\");
                 case Platform.Linux:
                 case Platform.Darwin:
                     return "/home/";


### PR DESCRIPTION
Thanks to @tmat for the help.

Follow up to #506 