### PR TITLE
Fix the already-installed check in dotnet-install when only shared runtime is being installed

### DIFF
--- a/files/KoreBuild/scripts/dotnet-install.ps1
+++ b/files/KoreBuild/scripts/dotnet-install.ps1
@@ -474,10 +474,15 @@ if ($DryRun) {
 $InstallRoot = Resolve-Installation-Path $InstallDir
 Say-Verbose "InstallRoot: $InstallRoot"
 
-$IsSdkInstalled = Is-Dotnet-Package-Installed -InstallRoot $InstallRoot -RelativePathToPackage "sdk" -SpecificVersion $SpecificVersion
-Say-Verbose ".NET SDK installed? $IsSdkInstalled"
-if ($IsSdkInstalled) {
-    Say ".NET SDK version $SpecificVersion is already installed."
+$dotnetPackageRelativePath = if ($SharedRuntime) { "shared\Microsoft.NETCore.App" } else { "sdk" }
+
+$isAssetInstalled = Is-Dotnet-Package-Installed -InstallRoot $InstallRoot -RelativePathToPackage $dotnetPackageRelativePath -SpecificVersion $SpecificVersion
+if ($isAssetInstalled) {
+    if ($SharedRuntime) {
+        Say ".NET Core Runtime version $SpecificVersion is already installed."
+    } else {
+        Say ".NET Core SDK version $SpecificVersion is already installed."
+    }
     Prepend-Sdk-InstallRoot-To-Path -InstallRoot $InstallRoot -BinFolderRelativePath $BinFolderRelativePath
     exit 0
 }

--- a/files/KoreBuild/scripts/dotnet-install.sh
+++ b/files/KoreBuild/scripts/dotnet-install.sh
@@ -692,9 +692,16 @@ install_dotnet() {
     eval $invocation
     local download_failed=false
 
-    if is_dotnet_package_installed "$install_root" "sdk" "$specific_version"; then
-        say ".NET SDK version $specific_version is already installed."
-        return 0
+    if [ "$shared_runtime" = true ]; then
+        if is_dotnet_package_installed "$install_root" "shared/Microsoft.NETCore.App" "$specific_version"; then
+            say ".NET Core Runtime version $specific_version is already installed."
+            return 0
+        fi
+    else
+        if is_dotnet_package_installed "$install_root" "sdk" "$specific_version"; then
+            say ".NET Core SDK version $specific_version is already installed."
+            return 0
+        fi
     fi
 
     mkdir -p "$install_root"


### PR DESCRIPTION
When `--shared-runtime` is specified, the scripts were checking the wrong folder in the "is installed?" check.