### PR TITLE
Backport some important fixes to 2.0.0 build tools

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -3,7 +3,6 @@ init:
 branches:
   only:
     - master
-    - release
     - dev
     - /^release\/.*/
     - /^(.*\/)?ci-.*$/

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ addons:
 branches:
   only:
     - master
-    - release
     - dev
     - /^release\/.*/
     - /^(.*\/)?ci-.*$/

--- a/files/KoreBuild/KoreBuild.sh
+++ b/files/KoreBuild/KoreBuild.sh
@@ -63,3 +63,9 @@ if [ "$(uname)" = "Darwin" ]; then
     # increase file descriptor limit
     ulimit -n 5000
 fi
+
+# Set required environment variables
+
+# This disables automatic rollforward to /usr/local/dotnet and other global locations.
+# We want to ensure are tests are running against the exact runtime specified by the project.
+export DOTNET_MULTILEVEL_LOOKUP=0

--- a/files/KoreBuild/modules/sharedsources/sharedsources.csproj
+++ b/files/KoreBuild/modules/sharedsources/sharedsources.csproj
@@ -56,7 +56,7 @@
 
   <Target Name="GetArtifactInfo" Returns="@(ArtifactInfo)">
     <ItemGroup>
-      <ArtifactInfo Include="$(PackageOutputPath)$(PackageId.ToLowerInvariant()).$(PackageVersion).nupkg">
+      <ArtifactInfo Include="$(PackageOutputPath)$(PackageId).$(PackageVersion).nupkg">
         <ArtifactType>NuGetPackage</ArtifactType>
         <PackageId>$(PackageId)</PackageId>
         <Version>$(PackageVersion)</Version>

--- a/files/KoreBuild/modules/solutionbuild/Project.Inspection.targets
+++ b/files/KoreBuild/modules/solutionbuild/Project.Inspection.targets
@@ -2,7 +2,7 @@
 
   <Target Name="GetArtifactInfo" Returns="@(ArtifactInfo)">
     <ItemGroup Condition="'$(IsPackable)' == 'true' ">
-      <ArtifactInfo Include="$(PackageOutputPath)$(PackageId.ToLowerInvariant()).$(PackageVersion).nupkg">
+      <ArtifactInfo Include="$(PackageOutputPath)$(PackageId).$(PackageVersion).nupkg">
         <ArtifactType>NuGetPackage</ArtifactType>
         <PackageId>$(PackageId)</PackageId>
         <Version>$(PackageVersion)</Version>
@@ -12,7 +12,7 @@
         <RepositoryRoot>$(RepositoryRoot)</RepositoryRoot>
       </ArtifactInfo>
 
-      <ArtifactInfo Include="$(PackageOutputPath)$(PackageId.ToLowerInvariant()).$(PackageVersion).symbols.nupkg" Condition="'$(IncludeSymbols)' == 'true' AND '$(NuspecFile)' == ''">
+      <ArtifactInfo Include="$(PackageOutputPath)$(PackageId).$(PackageVersion).symbols.nupkg" Condition="'$(IncludeSymbols)' == 'true' AND '$(NuspecFile)' == ''">
         <ArtifactType>NuGetSymbolsPackage</ArtifactType>
         <PackageId>$(PackageId)</PackageId>
         <Version>$(PackageVersion)</Version>

--- a/files/KoreBuild/scripts/KoreBuild.psm1
+++ b/files/KoreBuild/scripts/KoreBuild.psm1
@@ -33,6 +33,12 @@ if ($env:KOREBUILD_DOTNET_FEED_CREDENTIAL) {
     $script:config.'dotnet.feed.credential' = $env:KOREBUILD_DOTNET_FEED_CREDENTIAL
 }
 
+# Set required environment variables
+
+# This disables automatic rollforward to C:\Program Files\ and other global locations.
+# We want to ensure are tests are running against the exact runtime specified by the project.
+$env:DOTNET_MULTILEVEL_LOOKUP=0
+
 <#
 .SYNOPSIS
 Builds a repository

--- a/files/KoreBuild/scripts/dotnet-install.ps1
+++ b/files/KoreBuild/scripts/dotnet-install.ps1
@@ -469,10 +469,15 @@ if ($DryRun) {
 $InstallRoot = Resolve-Installation-Path $InstallDir
 Say-Verbose "InstallRoot: $InstallRoot"
 
-$IsSdkInstalled = Is-Dotnet-Package-Installed -InstallRoot $InstallRoot -RelativePathToPackage "sdk" -SpecificVersion $SpecificVersion
-Say-Verbose ".NET SDK installed? $IsSdkInstalled"
-if ($IsSdkInstalled) {
-    Say ".NET SDK version $SpecificVersion is already installed."
+$dotnetPackageRelativePath = if ($SharedRuntime) { "shared\Microsoft.NETCore.App" } else { "sdk" }
+
+$isAssetInstalled = Is-Dotnet-Package-Installed -InstallRoot $InstallRoot -RelativePathToPackage $dotnetPackageRelativePath -SpecificVersion $SpecificVersion
+if ($isAssetInstalled) {
+    if ($SharedRuntime) {
+        Say ".NET Core Runtime version $SpecificVersion is already installed."
+    } else {
+        Say ".NET Core SDK version $SpecificVersion is already installed."
+    }
     Prepend-Sdk-InstallRoot-To-Path -InstallRoot $InstallRoot -BinFolderRelativePath $BinFolderRelativePath
     exit 0
 }

--- a/files/KoreBuild/scripts/dotnet-install.sh
+++ b/files/KoreBuild/scripts/dotnet-install.sh
@@ -654,9 +654,16 @@ install_dotnet() {
     eval $invocation
     local download_failed=false
 
-    if is_dotnet_package_installed $install_root "sdk" $specific_version; then
-        say ".NET SDK version $specific_version is already installed."
-        return 0
+    if [ "$shared_runtime" = true ]; then
+        if is_dotnet_package_installed "$install_root" "shared/Microsoft.NETCore.App" "$specific_version"; then
+            say ".NET Core Runtime version $specific_version is already installed."
+            return 0
+        fi
+    else
+        if is_dotnet_package_installed "$install_root" "sdk" "$specific_version"; then
+            say ".NET Core SDK version $specific_version is already installed."
+            return 0
+        fi
     fi
 
     mkdir -p $install_root
@@ -749,7 +756,6 @@ do
             runtime_id="$1"
             ;;
         --skip-non-versioned-files|-[Ss]kip[Nn]on[Vv]ersioned[Ff]iles)
-            shift
             override_non_versioned_files=false
             ;;
         -?|--?|-h|--help|-[Hh]elp)

--- a/files/KoreBuild/scripts/dotnet-install.sh
+++ b/files/KoreBuild/scripts/dotnet-install.sh
@@ -55,7 +55,10 @@ say_verbose() {
     fi
 }
 
-get_os_download_name_from_platform() {
+# This platform list is finite - if the SDK/Runtime has supported Linux distribution-specific assets,
+#   then and only then should the Linux distribution appear in this list.
+# Adding a Linux distribution to this list does not imply distribution-specific support.
+get_legacy_os_name_from_platform() {
     eval $invocation
 
     platform="$1"
@@ -108,6 +111,30 @@ get_os_download_name_from_platform() {
     return 1
 }
 
+get_linux_platform_name() {
+    eval $invocation
+
+    if [ -n "$runtime_id" ]; then
+        echo "${runtime_id%-*}"
+        return 0
+    else
+        if [ -e /etc/os-release ]; then
+            . /etc/os-release
+            echo "$ID.$VERSION_ID"
+            return 0
+        elif [ -e /etc/redhat-release ]; then
+            local redhatRelease=$(</etc/redhat-release)
+            if [[ $redhatRelease == "CentOS release 6."* || $redhatRelease == "Red Hat Enterprise Linux Server release 6."* ]]; then
+                echo "rhel.6"
+                return 0
+            fi
+        fi
+    fi
+
+    say_verbose "Linux specific platform name and version could not be detected: $ID.$VERSION_ID"
+    return 1
+}
+
 get_current_os_name() {
     eval $invocation
 
@@ -115,8 +142,14 @@ get_current_os_name() {
     if [ "$uname" = "Darwin" ]; then
         echo "osx"
         return 0
-    else
-        if [ "$uname" = "Linux" ]; then
+    elif [ "$uname" = "Linux" ]; then
+        local linux_platform_name
+        linux_platform_name="$(get_linux_platform_name)" || { echo "linux" && return 0 ; }
+
+        if [[ $linux_platform_name == "rhel.6"* ]]; then
+            echo "rhel.6"
+            return 0
+        else
             echo "linux"
             return 0
         fi
@@ -126,7 +159,7 @@ get_current_os_name() {
     return 1
 }
 
-get_distro_specific_os_name() {
+get_legacy_os_name() {
     eval $invocation
 
     local uname=$(uname)
@@ -134,12 +167,12 @@ get_distro_specific_os_name() {
         echo "osx"
         return 0
     elif [ -n "$runtime_id" ]; then
-        echo $(get_os_download_name_from_platform "${runtime_id%-*}" || echo "${runtime_id%-*}")
+        echo $(get_legacy_os_name_from_platform "${runtime_id%-*}" || echo "${runtime_id%-*}")
         return 0
     else
         if [ -e /etc/os-release ]; then
             . /etc/os-release
-            os=$(get_os_download_name_from_platform "$ID.$VERSION_ID" || echo "")
+            os=$(get_legacy_os_name_from_platform "$ID.$VERSION_ID" || echo "")
             if [ -n "$os" ]; then
                 echo "$os"
                 return 0
@@ -184,16 +217,20 @@ check_pre_reqs() {
     fi
 
     if [ "$(uname)" = "Linux" ]; then
-        if ! [ -x "$(command -v ldconfig)" ]; then
+        if [ ! -x "$(command -v ldconfig)" ]; then
             echo "ldconfig is not in PATH, trying /sbin/ldconfig."
             LDCONFIG_COMMAND="/sbin/ldconfig"
         else
             LDCONFIG_COMMAND="ldconfig"
         fi
 
-        [ -z "$($LDCONFIG_COMMAND -p | grep libunwind)" ] && say_err "Unable to locate libunwind. Install libunwind to continue" && failing=true
-        [ -z "$($LDCONFIG_COMMAND -p | grep libssl)" ] && say_err "Unable to locate libssl. Install libssl to continue" && failing=true
-        [ -z "$($LDCONFIG_COMMAND -p | grep libicu)" ] && say_err "Unable to locate libicu. Install libicu to continue" && failing=true
+        local librarypath=${LD_LIBRARY_PATH:-}
+        LDCONFIG_COMMAND="$LDCONFIG_COMMAND -NXv ${librarypath//:/ }"
+
+        [ -z "$($LDCONFIG_COMMAND 2>/dev/null | grep libunwind)" ] && say_err "Unable to locate libunwind. Install libunwind to continue" && failing=true
+        [ -z "$($LDCONFIG_COMMAND 2>/dev/null | grep libssl)" ] && say_err "Unable to locate libssl. Install libssl to continue" && failing=true
+        [ -z "$($LDCONFIG_COMMAND 2>/dev/null | grep libicu)" ] && say_err "Unable to locate libicu. Install libicu to continue" && failing=true
+        [ -z "$($LDCONFIG_COMMAND 2>/dev/null | grep -F libcurl.so)" ] && say_err "Unable to locate libcurl. Install libcurl to continue" && failing=true
     fi
 
     if [ "$failing" = true ]; then
@@ -217,7 +254,7 @@ to_lowercase() {
 remove_trailing_slash() {
     #eval $invocation
 
-    local input=${1:-}
+    local input="${1:-}"
     echo "${input%/}"
     return 0
 }
@@ -227,7 +264,7 @@ remove_trailing_slash() {
 remove_beginning_slash() {
     #eval $invocation
 
-    local input=${1:-}
+    local input="${1:-}"
     echo "${input#/}"
     return 0
 }
@@ -244,8 +281,8 @@ combine_paths() {
         return 1
     fi
 
-    local root_path=$(remove_trailing_slash $1)
-    local child_path=$(remove_beginning_slash ${2:-})
+    local root_path="$(remove_trailing_slash "$1")"
+    local child_path="$(remove_beginning_slash "${2:-}")"
     say_verbose "combine_paths: root_path=$root_path"
     say_verbose "combine_paths: child_path=$child_path"
     echo "$root_path/$child_path"
@@ -265,10 +302,10 @@ get_machine_architecture() {
 get_normalized_architecture_from_architecture() {
     eval $invocation
 
-    local architecture=$(to_lowercase $1)
-    case $architecture in
+    local architecture="$(to_lowercase "$1")"
+    case "$architecture" in
         \<auto\>)
-            echo "$(get_normalized_architecture_from_architecture $(get_machine_architecture))"
+            echo "$(get_normalized_architecture_from_architecture "$(get_machine_architecture)")"
             return 0
             ;;
         amd64|x64)
@@ -295,7 +332,7 @@ get_normalized_architecture_from_architecture() {
 get_version_from_version_info() {
     eval $invocation
 
-    cat | tail -n 1
+    cat | tail -n 1 | sed 's/\r$//'
     return 0
 }
 
@@ -304,7 +341,7 @@ get_version_from_version_info() {
 get_commit_hash_from_version_info() {
     eval $invocation
 
-    cat | head -n 1
+    cat | head -n 1 | sed 's/\r$//'
     return 0
 }
 
@@ -315,11 +352,11 @@ get_commit_hash_from_version_info() {
 is_dotnet_package_installed() {
     eval $invocation
 
-    local install_root=$1
-    local relative_path_to_package=$2
-    local specific_version=${3//[$'\t\r\n']}
+    local install_root="$1"
+    local relative_path_to_package="$2"
+    local specific_version="${3//[$'\t\r\n']}"
 
-    local dotnet_package_path=$(combine_paths $(combine_paths $install_root $relative_path_to_package) $specific_version)
+    local dotnet_package_path="$(combine_paths "$(combine_paths "$install_root" "$relative_path_to_package")" "$specific_version")"
     say_verbose "is_dotnet_package_installed: dotnet_package_path=$dotnet_package_path"
 
     if [ -d "$dotnet_package_path" ]; then
@@ -333,13 +370,14 @@ is_dotnet_package_installed() {
 # azure_feed - $1
 # channel - $2
 # normalized_architecture - $3
+# coherent - $4
 get_latest_version_info() {
     eval $invocation
 
-    local azure_feed=$1
-    local channel=$2
-    local normalized_architecture=$3
-    local coherent=$4
+    local azure_feed="$1"
+    local channel="$2"
+    local normalized_architecture="$3"
+    local coherent="$4"
 
     local version_file_url=null
     if [ "$shared_runtime" = true ]; then
@@ -353,7 +391,7 @@ get_latest_version_info() {
     fi
     say_verbose "get_latest_version_info: latest url: $version_file_url"
 
-    download $version_file_url
+    download "$version_file_url"
     return $?
 }
 
@@ -365,28 +403,28 @@ get_latest_version_info() {
 get_specific_version_from_version() {
     eval $invocation
 
-    local azure_feed=$1
-    local channel=$2
-    local normalized_architecture=$3
-    local version=$(to_lowercase $4)
+    local azure_feed="$1"
+    local channel="$2"
+    local normalized_architecture="$3"
+    local version="$(to_lowercase "$4")"
 
-    case $version in
+    case "$version" in
         latest)
             local version_info
-            version_info="$(get_latest_version_info $azure_feed $channel $normalized_architecture false)" || return 1
+            version_info="$(get_latest_version_info "$azure_feed" "$channel" "$normalized_architecture" false)" || return 1
             say_verbose "get_specific_version_from_version: version_info=$version_info"
             echo "$version_info" | get_version_from_version_info
             return 0
             ;;
         coherent)
             local version_info
-            version_info="$(get_latest_version_info $azure_feed $channel $normalized_architecture true)" || return 1
+            version_info="$(get_latest_version_info "$azure_feed" "$channel" "$normalized_architecture" true)" || return 1
             say_verbose "get_specific_version_from_version: version_info=$version_info"
             echo "$version_info" | get_version_from_version_info
             return 0
             ;;
         *)
-            echo $version
+            echo "$version"
             return 0
             ;;
     esac
@@ -400,13 +438,13 @@ get_specific_version_from_version() {
 construct_download_link() {
     eval $invocation
 
-    local azure_feed=$1
-    local channel=$2
-    local normalized_architecture=$3
-    local specific_version=${4//[$'\t\r\n']}
+    local azure_feed="$1"
+    local channel="$2"
+    local normalized_architecture="$3"
+    local specific_version="${4//[$'\t\r\n']}"
 
     local osname
-    osname=$(get_current_os_name) || return 1
+    osname="$(get_current_os_name)" || return 1
 
     local download_link=null
     if [ "$shared_runtime" = true ]; then
@@ -427,13 +465,13 @@ construct_download_link() {
 construct_legacy_download_link() {
     eval $invocation
 
-    local azure_feed=$1
-    local channel=$2
-    local normalized_architecture=$3
-    local specific_version=${4//[$'\t\r\n']}
+    local azure_feed="$1"
+    local channel="$2"
+    local normalized_architecture="$3"
+    local specific_version="${4//[$'\t\r\n']}"
 
     local distro_specific_osname
-    distro_specific_osname=$(get_distro_specific_os_name) || return 1
+    distro_specific_osname="$(get_legacy_os_name)" || return 1
 
     local legacy_download_link=null
     if [ "$shared_runtime" = true ]; then
@@ -450,7 +488,7 @@ get_user_install_path() {
     eval $invocation
 
     if [ ! -z "${DOTNET_INSTALL_DIR:-}" ]; then
-        echo $DOTNET_INSTALL_DIR
+        echo "$DOTNET_INSTALL_DIR"
     else
         echo "$HOME/.dotnet"
     fi
@@ -464,7 +502,7 @@ resolve_installation_path() {
 
     local install_dir=$1
     if [ "$install_dir" = "<auto>" ]; then
-        local user_install_path=$(get_user_install_path)
+        local user_install_path="$(get_user_install_path)"
         say_verbose "resolve_installation_path: user_install_path=$user_install_path"
         echo "$user_install_path"
         return 0
@@ -479,11 +517,11 @@ resolve_installation_path() {
 get_installed_version_info() {
     eval $invocation
 
-    local install_root=$1
-    local version_file=$(combine_paths "$install_root" "$local_version_file_relative_path")
+    local install_root="$1"
+    local version_file="$(combine_paths "$install_root" "$local_version_file_relative_path")"
     say_verbose "Local version file: $version_file"
     if [ ! -z "$version_file" ] | [ -r "$version_file" ]; then
-        local version_info="$(cat $version_file)"
+        local version_info="$(cat "$version_file")"
         echo "$version_info"
         return 0
     fi
@@ -498,7 +536,7 @@ get_absolute_path() {
     eval $invocation
 
     local relative_or_absolute_path=$1
-    echo $(cd $(dirname "$1") && pwd -P)/$(basename "$1")
+    echo "$(cd "$(dirname "$1")" && pwd -P)/$(basename "$1")"
     return 0
 }
 
@@ -510,17 +548,17 @@ get_absolute_path() {
 copy_files_or_dirs_from_list() {
     eval $invocation
 
-    local root_path=$(remove_trailing_slash $1)
-    local out_path=$(remove_trailing_slash $2)
-    local override=$3
+    local root_path="$(remove_trailing_slash "$1")"
+    local out_path="$(remove_trailing_slash "$2")"
+    local override="$3"
     local override_switch=$(if [ "$override" = false ]; then printf -- "-n"; fi)
 
     cat | uniq | while read -r file_path; do
-        local path=$(remove_beginning_slash ${file_path#$root_path})
-        local target=$out_path/$path
+        local path="$(remove_beginning_slash "${file_path#$root_path}")"
+        local target="$out_path/$path"
         if [ "$override" = true ] || (! ([ -d "$target" ] || [ -e "$target" ])); then
-            mkdir -p $out_path/$(dirname $path)
-            cp -R $override_switch $root_path/$path $target
+            mkdir -p "$out_path/$(dirname "$path")"
+            cp -R $override_switch "$root_path/$path" "$target"
         fi
     done
 }
@@ -531,19 +569,19 @@ copy_files_or_dirs_from_list() {
 extract_dotnet_package() {
     eval $invocation
 
-    local zip_path=$1
-    local out_path=$2
+    local zip_path="$1"
+    local out_path="$2"
 
-    local temp_out_path=$(mktemp -d $temporary_file_template)
+    local temp_out_path="$(mktemp -d "$temporary_file_template")"
 
     local failed=false
     tar -xzf "$zip_path" -C "$temp_out_path" > /dev/null || failed=true
 
     local folders_with_version_regex='^.*/[0-9]+\.[0-9]+[^/]+/'
-    find $temp_out_path -type f | grep -Eo $folders_with_version_regex | copy_files_or_dirs_from_list $temp_out_path $out_path false
-    find $temp_out_path -type f | grep -Ev $folders_with_version_regex | copy_files_or_dirs_from_list $temp_out_path $out_path $override_non_versioned_files
+    find "$temp_out_path" -type f | grep -Eo "$folders_with_version_regex" | copy_files_or_dirs_from_list "$temp_out_path" "$out_path" false
+    find "$temp_out_path" -type f | grep -Ev "$folders_with_version_regex" | copy_files_or_dirs_from_list "$temp_out_path" "$out_path" "$override_non_versioned_files"
 
-    rm -rf $temp_out_path
+    rm -rf "$temp_out_path"
 
     if [ "$failed" = true ]; then
         say_err "Extraction failed"
@@ -557,14 +595,14 @@ extract_dotnet_package() {
 download() {
     eval $invocation
 
-    local remote_path=$1
-    local out_path=${2:-}
+    local remote_path="$1"
+    local out_path="${2:-}"
 
     local failed=false
     if machine_has "curl"; then
-        downloadcurl $remote_path $out_path || failed=true
+        downloadcurl "$remote_path" "$out_path" || failed=true
     elif machine_has "wget"; then
-        downloadwget $remote_path $out_path || failed=true
+        downloadwget "$remote_path" "$out_path" || failed=true
     else
         failed=true
     fi
@@ -577,8 +615,8 @@ download() {
 
 downloadcurl() {
     eval $invocation
-    local remote_path=$1
-    local out_path=${2:-}
+    local remote_path="$1"
+    local out_path="${2:-}"
 
     # Append feed_credential as late as possible before calling curl to avoid logging feed_credential
     if [[ "$remote_path" == "$azure_feed"* ]] || [[ "$remote_path" == "$uncached_feed"* ]]; then
@@ -587,9 +625,9 @@ downloadcurl() {
 
     local failed=false
     if [ -z "$out_path" ]; then
-        curl --retry 10 -sSL -f --create-dirs $remote_path || failed=true
+        curl --retry 10 -sSL -f --create-dirs "$remote_path" || failed=true
     else
-        curl --retry 10 -sSL -f --create-dirs -o $out_path $remote_path || failed=true
+        curl --retry 10 -sSL -f --create-dirs -o "$out_path" "$remote_path" || failed=true
     fi
     if [ "$failed" = true ]; then
         say_verbose "Curl download failed"
@@ -600,8 +638,8 @@ downloadcurl() {
 
 downloadwget() {
     eval $invocation
-    local remote_path=$1
-    local out_path=${2:-}
+    local remote_path="$1"
+    local out_path="${2:-}"
 
     # Append feed_credential as late as possible before calling wget to avoid logging feed_credential
     if [[ "$remote_path" == "$azure_feed"* ]] || [[ "$remote_path" == "$uncached_feed"* ]]; then
@@ -610,9 +648,9 @@ downloadwget() {
 
     local failed=false
     if [ -z "$out_path" ]; then
-        wget -q --tries 10 $remote_path || failed=true
+        wget -q --tries 10 -O - "$remote_path" || failed=true
     else
-        wget -v --tries 10 -O $out_path $remote_path || failed=true
+        wget -v --tries 10 -O "$out_path" "$remote_path" || failed=true
     fi
     if [ "$failed" = true ]; then
         say_verbose "Wget download failed"
@@ -625,20 +663,20 @@ calculate_vars() {
     eval $invocation
     valid_legacy_download_link=true
 
-    normalized_architecture=$(get_normalized_architecture_from_architecture "$architecture")
+    normalized_architecture="$(get_normalized_architecture_from_architecture "$architecture")"
     say_verbose "normalized_architecture=$normalized_architecture"
 
-    specific_version=$(get_specific_version_from_version $azure_feed $channel $normalized_architecture $version)
+    specific_version="$(get_specific_version_from_version "$azure_feed" "$channel" "$normalized_architecture" "$version")"
     say_verbose "specific_version=$specific_version"
     if [ -z "$specific_version" ]; then
         say_err "Could not get version information."
         return 1
     fi
 
-    download_link=$(construct_download_link $azure_feed $channel $normalized_architecture $specific_version)
+    download_link="$(construct_download_link "$azure_feed" "$channel" "$normalized_architecture" "$specific_version")"
     say_verbose "download_link=$download_link"
 
-    legacy_download_link=$(construct_legacy_download_link $azure_feed $channel $normalized_architecture $specific_version) || valid_legacy_download_link=false
+    legacy_download_link="$(construct_legacy_download_link "$azure_feed" "$channel" "$normalized_architecture" "$specific_version")" || valid_legacy_download_link=false
 
     if [ "$valid_legacy_download_link" = true ]; then
         say_verbose "legacy_download_link=$legacy_download_link"
@@ -646,7 +684,7 @@ calculate_vars() {
         say_verbose "Cound not construct a legacy_download_link; omitting..."
     fi
 
-    install_root=$(resolve_installation_path $install_dir)
+    install_root="$(resolve_installation_path "$install_dir")"
     say_verbose "install_root=$install_root"
 }
 
@@ -666,25 +704,28 @@ install_dotnet() {
         fi
     fi
 
-    mkdir -p $install_root
-    zip_path=$(mktemp $temporary_file_template)
+    mkdir -p "$install_root"
+    zip_path="$(mktemp "$temporary_file_template")"
     say_verbose "Zip path: $zip_path"
 
     say "Downloading link: $download_link"
-    download "$download_link" $zip_path || download_failed=true
+
+    # Failures are normal in the non-legacy case for ultimately legacy downloads.
+    # Do not output to stderr, since output to stderr is considered an error.
+    download "$download_link" "$zip_path" 2>&1 || download_failed=true
 
     #  if the download fails, download the legacy_download_link
     if [ "$download_failed" = true ] && [ "$valid_legacy_download_link" = true ]; then
         say "Cannot download: $download_link"
-        download_link=$legacy_download_link
-        zip_path=$(mktemp $temporary_file_template)
+        download_link="$legacy_download_link"
+        zip_path="$(mktemp "$temporary_file_template")"
         say_verbose "Legacy zip path: $zip_path"
         say "Downloading legacy link: $download_link"
-        download "$download_link" $zip_path
+        download "$download_link" "$zip_path"
     fi
 
     say "Extracting zip from $download_link"
-    extract_dotnet_package $zip_path $install_root
+    extract_dotnet_package "$zip_path" "$install_root"
 
     return 0
 }
@@ -709,11 +750,11 @@ override_non_versioned_files=true
 
 while [ $# -ne 0 ]
 do
-    name=$1
-    case $name in
+    name="$1"
+    case "$name" in
         -c|--channel|-[Cc]hannel)
             shift
-            channel=$1
+            channel="$1"
             ;;
         -v|--version|-[Vv]ersion)
             shift
@@ -759,7 +800,7 @@ do
             override_non_versioned_files=false
             ;;
         -?|--?|-h|--help|-[Hh]elp)
-            script_name="$(basename $0)"
+            script_name="$(basename "$0")"
             echo ".NET Tools Installer"
             echo "Usage: $script_name [-c|--channel <CHANNEL>] [-v|--version <VERSION>] [-p|--prefix <DESTINATION>]"
             echo "       $script_name -h|-?|--help"
@@ -826,17 +867,17 @@ if [ "$dry_run" = true ]; then
     if [ "$valid_legacy_download_link" = true ]; then
         say "Legacy payload URL: $legacy_download_link"
     fi
-    say "Repeatable invocation: ./$(basename $0) --version $specific_version --channel $channel --install-dir $install_dir"
+    say "Repeatable invocation: ./$(basename "$0") --version $specific_version --channel $channel --install-dir $install_dir"
     exit 0
 fi
 
 check_pre_reqs
 install_dotnet
 
-bin_path=$(get_absolute_path $(combine_paths $install_root $bin_folder_relative_path))
+bin_path="$(get_absolute_path "$(combine_paths "$install_root" "$bin_folder_relative_path")")"
 if [ "$no_path" = false ]; then
     say "Adding to current process PATH: \`$bin_path\`. Note: This change will be visible only when sourcing script."
-    export PATH=$bin_path:$PATH
+    export PATH="$bin_path":"$PATH"
 else
     say "Binaries of dotnet can be found in $bin_path"
 fi

--- a/modules/BuildTools.Tasks/CreateSourceLink.cs
+++ b/modules/BuildTools.Tasks/CreateSourceLink.cs
@@ -34,20 +34,26 @@ namespace Microsoft.AspNetCore.BuildTools
         public override bool Execute()
         {
             var rootDirectory = Path.Combine(Path.GetFullPath(RootDirectory), "*");
-            rootDirectory = rootDirectory.Replace("\\", "/");
+
+            var escapedPath = JsonEscapePath(rootDirectory);
 
             var codeSource = ConvertUrl();
 
-            File.WriteAllText(DestinationFile, $"{{\"documents\":{{\"{rootDirectory}\":\"{codeSource}\"}}}}");
+            File.WriteAllText(DestinationFile, $"{{\"documents\":{{\"{escapedPath}\":\"{codeSource}\"}}}}");
 
             SourceLinkFile = DestinationFile;
 
             return true;
         }
 
+        private string JsonEscapePath(string path)
+        {
+            return path.Replace("\\", "\\\\");
+        }
+
         private string ConvertUrl()
         {
-            if(!OriginUrl.Contains("github.com"))
+            if (!OriginUrl.Contains("github.com"))
             {
                 throw new ArgumentException("OriginUrl must be for github.com", "OriginUrl");
             }

--- a/modules/KoreBuild.Tasks/InstallDotNet.cs
+++ b/modules/KoreBuild.Tasks/InstallDotNet.cs
@@ -117,6 +117,20 @@ namespace KoreBuild.Tasks
                     assetName += $"/{request.Channel}";
                 }
 
+                if (!string.IsNullOrEmpty(request.Feed))
+                {
+                    arguments.Add("-AzureFeed");
+                    arguments.Add(request.Feed);
+                    arguments.Add("-UncachedFeed");
+                    arguments.Add(request.Feed);
+                }
+
+                if (!string.IsNullOrEmpty(request.FeedCredential))
+                {
+                    arguments.Add("-FeedCredential");
+                    arguments.Add(request.FeedCredential);
+                }
+
                 var expectedPath = request.IsSharedRuntime && !isFloatingVersion
                     ? Path.Combine(installDir, "shared", "Microsoft.NETCore.App", request.Version, ".version")
                     : Path.Combine(installDir, "sdk", request.Version, "dotnet.dll");
@@ -247,7 +261,11 @@ namespace KoreBuild.Tasks
                     Channel = item.GetMetadata("Channel"),
                     InstallDir = item.GetMetadata("InstallDir"),
                     Arch = item.GetMetadata("Arch"),
+                    // trimmed because dotnet-install.ps1/sh expect the feed not to have this
+                    Feed = item.GetMetadata("Feed")?.TrimEnd(new[] { '/', '\\' }),
+                    FeedCredential = item.GetMetadata("FeedCredential"),
                 };
+
                 all.Add(request);
             }
 

--- a/modules/KoreBuild.Tasks/Internal/DotNetAssetRequest.cs
+++ b/modules/KoreBuild.Tasks/Internal/DotNetAssetRequest.cs
@@ -17,5 +17,7 @@ namespace KoreBuild.Tasks
         public string Channel { get; set; }
         public string InstallDir { get; set; }
         public string Arch { get; set; }
+        public string Feed { get; set; }
+        public string FeedCredential { get; set; }
     }
 }

--- a/modules/KoreBuild.Tasks/module.props
+++ b/modules/KoreBuild.Tasks/module.props
@@ -1,11 +1,15 @@
 <Project>
-  <UsingTask TaskName="KoreBuild.Tasks.ComputeChecksum" AssemblyFile="$(MSBuildThisFileDirectory)Internal.AspNetCore.KoreBuild.Tasks.dll" />
-  <UsingTask TaskName="KoreBuild.Tasks.ComputeManyChecksum" AssemblyFile="$(MSBuildThisFileDirectory)Internal.AspNetCore.KoreBuild.Tasks.dll" />
-  <UsingTask TaskName="KoreBuild.Tasks.GenerateBillOfMaterials" AssemblyFile="$(MSBuildThisFileDirectory)Internal.AspNetCore.KoreBuild.Tasks.dll" />
-  <UsingTask TaskName="KoreBuild.Tasks.InstallDotNet" AssemblyFile="$(MSBuildThisFileDirectory)Internal.AspNetCore.KoreBuild.Tasks.dll" />
-  <UsingTask TaskName="KoreBuild.Tasks.PackNuSpec" AssemblyFile="$(MSBuildThisFileDirectory)Internal.AspNetCore.KoreBuild.Tasks.dll" />
-  <UsingTask TaskName="KoreBuild.Tasks.PushNuGetPackages" AssemblyFile="$(MSBuildThisFileDirectory)Internal.AspNetCore.KoreBuild.Tasks.dll" />
-  <UsingTask TaskName="KoreBuild.Tasks.VerifyChecksum" AssemblyFile="$(MSBuildThisFileDirectory)Internal.AspNetCore.KoreBuild.Tasks.dll" />
+  <PropertyGroup>
+    <KoreBuildTasksDll>$(MSBuildThisFileDirectory)Internal.AspNetCore.KoreBuild.Tasks.dll</KoreBuildTasksDll>
+  </PropertyGroup>
+
+  <UsingTask TaskName="KoreBuild.Tasks.ComputeChecksum" AssemblyFile="$(KoreBuildTasksDll)" />
+  <UsingTask TaskName="KoreBuild.Tasks.ComputeManyChecksum" AssemblyFile="$(KoreBuildTasksDll)" />
+  <UsingTask TaskName="KoreBuild.Tasks.GenerateBillOfMaterials" AssemblyFile="$(KoreBuildTasksDll)" />
+  <UsingTask TaskName="KoreBuild.Tasks.InstallDotNet" AssemblyFile="$(KoreBuildTasksDll)" />
+  <UsingTask TaskName="KoreBuild.Tasks.PackNuSpec" AssemblyFile="$(KoreBuildTasksDll)" />
+  <UsingTask TaskName="KoreBuild.Tasks.PushNuGetPackages" AssemblyFile="$(KoreBuildTasksDll)" />
+  <UsingTask TaskName="KoreBuild.Tasks.VerifyChecksum" AssemblyFile="$(KoreBuildTasksDll)" />
 
   <PropertyGroup>
     <DefaultDotNetAssetArch>$(KOREBUILD_DOTNET_ARCH)</DefaultDotNetAssetArch>
@@ -18,6 +22,7 @@
 
       Examples:
         <DotNetCoreRuntime Include="1.0.5" />
+        <DotNetCoreRuntime Include="1.0.5" Feed="https://mydotnetclifeed/assets" />
         <DotNetCoreRuntime Include="latest" Channel="1.0" />
         <DotNetCoreRuntime Include="2.0.0" Arch="x64" InstallDir="C:\custom\" />
     -->
@@ -26,6 +31,8 @@
       <SharedRuntime>true</SharedRuntime>
       <Channel></Channel>
       <InstallDir></InstallDir>
+      <Feed>$(DefaultDotNetAssetFeed)</Feed>
+      <FeedCredential>$(DefaultDotNetAssetFeedCredential)</FeedCredential>
     </DotNetCoreRuntime>
 
     <!--
@@ -39,6 +46,9 @@
       <SharedRuntime>false</SharedRuntime>
       <Channel></Channel>
       <InstallDir></InstallDir>
+      <Feed>$(DefaultDotNetAssetFeed)</Feed>
+      <FeedCredential>$(DefaultDotNetAssetFeedCredential)</FeedCredential>
     </DotNetCoreSdk>
   </ItemDefinitionGroup>
+
 </Project>

--- a/modules/KoreBuild.Tasks/module.targets
+++ b/modules/KoreBuild.Tasks/module.targets
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <RestoreDependsOn>InstallDotNet;$(RestoreDependsOn)</RestoreDependsOn>
+    <RestoreDependsOn Condition=" '$(DisableDefaultTargets)' != 'true' ">InstallDotNet;$(RestoreDependsOn)</RestoreDependsOn>
     <BomPath>$(ArtifactsDir)bom.xml</BomPath>
     <IgnoredArtifactItems>$(IgnoredArtifactItems);$(BomPath)</IgnoredArtifactItems>
   </PropertyGroup>

--- a/src/Internal.AspNetCore.Sdk/build/Git.targets
+++ b/src/Internal.AspNetCore.Sdk/build/Git.targets
@@ -4,8 +4,25 @@
     <GenerateCommitHashAttribute Condition="'$(GenerateCommitHashAttribute)'==''">true</GenerateCommitHashAttribute>
     <GeneratedCommitHashAttributeFile Condition="'$(GeneratedCommitHashAttributeFile)'==''">$(IntermediateOutputPath)$(AssemblyName).CommitHash$(DefaultLanguageSourceExtension)</GeneratedCommitHashAttributeFile>
     <SourceLinkDestination Condition="'$(SourceLinkDestination)' == ''">$(IntermediateOutputPath)sourcelink.json</SourceLinkDestination>
-    <SourceDirectory>$([System.IO.Path]::Combine($(RepositoryRoot.Trim('/')), 'src'))</SourceDirectory>
     <GenerateSourceLinkFile Condition="'$(GenerateSourceLinkFile)' == '' AND '$(IsPackable)' != 'false'">true</GenerateSourceLinkFile>
+    <!--
+      The source root path used for deterministic normalization of source paths.
+
+      If set the value is used in PathMap to instruct the compiler to normalize source paths
+      emitted to the binary and PDB and as a root for Source Link mapping.
+      If set must end with a directory separator.
+
+      The path can't be just a single '/' due to bug in Roslyn compilers:
+      https://github.com/dotnet/roslyn/issues/22815.
+
+      Only set this in CI builds, otherwise it will mess up the debugger.
+    -->
+    <DeterministicSourceRoot Condition=" '$(CI)' == 'true' ">/_/</DeterministicSourceRoot>
+
+    <SourceLinkRoot Condition="'$(DeterministicSourceRoot)' != ''">$(DeterministicSourceRoot)</SourceLinkRoot>
+    <SourceLinkRoot Condition="'$(SourceLinkRoot)' == ''">$([MSBuild]::NormalizeDirectory($(RepositoryRoot)))</SourceLinkRoot>
+
+    <PathMap Condition=" '$(DeterministicSourceRoot)' != '' ">$(RepositoryRoot)=$(DeterministicSourceRoot)</PathMap>
   </PropertyGroup>
 
   <Target Name="ResolveCommitHash" Condition="'$(CommitHash)'==''">
@@ -28,12 +45,12 @@
           Outputs="$(SourceLinkDestination)" >
 
     <Sdk_CreateSourceLink
-          RootDirectory="$(RepositoryRoot)"
+          SourceLinkRoot="$(SourceLinkRoot)"
           OriginUrl="$(RepositoryUrl)"
           Commit="$(CommitHash)"
           DestinationFile="$(SourceLinkDestination)"
           ContinueOnError="WarnAndContinue"
-          Condition="'$(CommitHash)' != '' AND '$(RepositoryUrl)' != '' AND '$(RepositoryRoot)' != ''">
+          Condition="'$(CommitHash)' != '' AND '$(RepositoryUrl)' != '' AND '$(SourceLinkRoot)' != ''">
       <Output TaskParameter="SourceLinkFile" PropertyName="SourceLink" />
     </Sdk_CreateSourceLink>
 
@@ -43,8 +60,8 @@
     <Warning Text="SourceLink not enabled because this is not a git repo."
              Condition="'$(CommitHash)' == ''" />
 
-    <Warning Text="SourceLink not enabled because RepositoryRoot wasn't set."
-             Condition="'$(RepositoryRoot)' == ''" />
+    <Warning Text="SourceLink not enabled because SourceLinkRoot wasn't set."
+             Condition="'$(SourceLinkRoot)' == ''" />
   </Target>
 
 <!--

--- a/test/BuildTools.Tasks.Tests/CreateSourceLinkTest.cs
+++ b/test/BuildTools.Tasks.Tests/CreateSourceLinkTest.cs
@@ -36,7 +36,44 @@ namespace BuildTools.Tasks.Tests
                 Assert.True(File.Exists(destination), "SourceLink file doesn't exist.");
 
                 var expectedUrl = $"https://raw.githubusercontent.com/{repoName}/{commit}/*";
-                var expected = $"{{\"documents\":{{\"{rootDir}*\":\"{expectedUrl}\"}}}}";
+                var expected = $"{{\"documents\":{{\"{GetExpectedRootDirectory()}*\":\"{expectedUrl}\"}}}}";
+
+                var resultText = File.ReadAllText(destination);
+
+                Assert.Equal(expected, resultText);
+            }
+            finally
+            {
+                File.Delete(destination);
+            }
+        }
+
+        [Fact]
+        public void DealsWithBackslash()
+        {
+            var destination = "sourcelink.json";
+
+            var repoName = "aspnet/BuildTools";
+
+            var originUrl = $"git@github.com:{repoName}.git";
+            var commit = "5153bbdfa98dcc27a61d591ce09a0d632875e66f";
+            var rootDir = GetRootDirectory(useBackslash: true);
+
+            var task = new CreateSourceLink
+            {
+                OriginUrl = originUrl,
+                Commit = commit,
+                DestinationFile = destination,
+                RootDirectory = rootDir
+            };
+
+            try
+            {
+                Assert.True(task.Execute(), "The task failed but should have passed.");
+                Assert.True(File.Exists(destination), "SourceLink file doesn't exist.");
+
+                var expectedUrl = $"https://raw.githubusercontent.com/{repoName}/{commit}/*";
+                var expected = $"{{\"documents\":{{\"{GetExpectedRootDirectory()}*\":\"{expectedUrl}\"}}}}";
 
                 var resultText = File.ReadAllText(destination);
 
@@ -73,7 +110,7 @@ namespace BuildTools.Tasks.Tests
                 Assert.True(File.Exists(destination), "SourceLink file doesn't exist.");
 
                 var expectedUrl = $"https://raw.githubusercontent.com/{repoName}/{commit}/*";
-                var expected = $"{{\"documents\":{{\"{rootDir}*\":\"{expectedUrl}\"}}}}";
+                var expected = $"{{\"documents\":{{\"{GetExpectedRootDirectory()}*\":\"{expectedUrl}\"}}}}";
 
                 Assert.Equal(expected, File.ReadAllText(destination));
             }
@@ -83,12 +120,26 @@ namespace BuildTools.Tasks.Tests
             }
         }
 
-        private static string GetRootDirectory()
+        private static string GetExpectedRootDirectory()
         {
-            switch(RuntimeEnvironment.OperatingSystemPlatform)
+            switch (RuntimeEnvironment.OperatingSystemPlatform)
             {
                 case Platform.Windows:
-                    return "C:/";
+                    return "C:\\\\";
+                case Platform.Linux:
+                case Platform.Darwin:
+                    return "/home/";
+                default:
+                    throw new NotImplementedException($"SourceLink tests don't yet support {RuntimeEnvironment.OperatingSystemPlatform}.");
+            }
+        }
+
+        private static string GetRootDirectory(bool useBackslash = false)
+        {
+            switch (RuntimeEnvironment.OperatingSystemPlatform)
+            {
+                case Platform.Windows:
+                    return "C:" + (useBackslash ? "/" : "\\");
                 case Platform.Linux:
                 case Platform.Darwin:
                     return "/home/";


### PR DESCRIPTION
Fixes #507 

Includes 
- #510 - Use PathMap for deterministic source roots
- #509 - disable multi-level lookup
- #512 - ensure dotnet-install actually works when -SharedRuntime is specified