### PR TITLE
Add DotNetToolPackageRule to NGPV

### DIFF
--- a/modules/NuGetPackageVerifier/console/CompositeRules/DefaultCompositeRule.cs
+++ b/modules/NuGetPackageVerifier/console/CompositeRules/DefaultCompositeRule.cs
@@ -24,6 +24,8 @@ namespace NuGetPackageVerifier.Rules
             new StrictSemanticVersionValidationRule(),
             new DependenciesVersionRangeBoundsRule(),
             new DotNetCliToolPackageRule(),
+            new DotNetToolPackageRule(),
+            new PackageTypesRule(),
             new PackageVersionMatchesAssemblyVersionRule(),
             new BuildItemsRule(),
         };

--- a/modules/NuGetPackageVerifier/console/Extensions/PackageArchiveReaderExtensions.cs
+++ b/modules/NuGetPackageVerifier/console/Extensions/PackageArchiveReaderExtensions.cs
@@ -4,7 +4,6 @@
 using System;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
-using NuGet.Versioning;
 
 namespace NuGetPackageVerifier
 {

--- a/modules/NuGetPackageVerifier/console/PackageIssueFactory.cs
+++ b/modules/NuGetPackageVerifier/console/PackageIssueFactory.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -10,6 +10,33 @@ namespace NuGetPackageVerifier
 {
     public static class PackageIssueFactory
     {
+        public static PackageVerifierIssue DotNetToolMustHaveManifest(string packageType, string path)
+        {
+            return new PackageVerifierIssue(
+                "DOTNET_TOOL_MANIFEST_MISSING",
+                string.Format("Packages with type '{0}' must have a tools manifest in {1}.", packageType, path),
+                PackageIssueLevel.Error
+            );
+        }
+
+        public static PackageVerifierIssue DotNetToolMissingEntryPoint(string filePath)
+        {
+            return new PackageVerifierIssue(
+                "DOTNET_TOOL_MISSING_ENTRY_POINT",
+                string.Format("The tools manifest in tools/DotNetSettings.xml specifies an entry point to {0}, but this file could not be found in the package.", filePath),
+                PackageIssueLevel.Error
+            );
+        }
+
+        public static PackageVerifierIssue DotNetToolMalformedManifest(string error)
+        {
+            return new PackageVerifierIssue(
+                "DOTNET_TOOL_MANIFEST_MALFORMED",
+                string.Format("The tool manifest in tools/DotNetSettings.xml is malformed: {0}", error),
+                PackageIssueLevel.Error
+            );
+        }
+
         public static PackageVerifierIssue PackageTypeMissing(string packageType)
         {
             return new PackageVerifierIssue(
@@ -39,7 +66,7 @@ namespace NuGetPackageVerifier
                 PackageIssueLevel.Error);
         }
 
-        public static PackageVerifierIssue AssemblyInformationalVersionDoesNotMatchPackageVersion(string assemblyPath, NuGetVersion assemblyInformationalVersion, NuGetVersion packageVersion, string packageId)
+        public static PackageVerifierIssue AssemblyInformationalVersionDoesNotMatchPackageVersion(string assemblyPath, string assemblyInformationalVersion, NuGetVersion packageVersion, string packageId)
         {
             return new PackageVerifierIssue(
                 "ASSEMBLY_INFORMATIONAL_VERSION_MISMATCH",

--- a/modules/NuGetPackageVerifier/console/Program.cs
+++ b/modules/NuGetPackageVerifier/console/Program.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using Microsoft.Extensions.CommandLineUtils;
 using Newtonsoft.Json;
 using NuGet.Packaging;

--- a/modules/NuGetPackageVerifier/console/Rules/DotNetToolPackageRule.cs
+++ b/modules/NuGetPackageVerifier/console/Rules/DotNetToolPackageRule.cs
@@ -1,0 +1,66 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using NuGet.Packaging.Core;
+
+namespace NuGetPackageVerifier.Rules
+{
+    public class DotNetToolPackageRule : IPackageVerifierRule
+    {
+        private const string ToolManifestPath = "tools/DotnetToolSettings.xml";
+
+        private static PackageType DotNetTool = new PackageType("DotnetTool", PackageType.EmptyVersion);
+
+        public IEnumerable<PackageVerifierIssue> Validate(PackageAnalysisContext context)
+        {
+            if (!context.Metadata.PackageTypes.Any(p => p == DotNetTool))
+            {
+                yield break;
+            }
+
+            var packageFiles = context.PackageReader.GetFiles();
+
+            if (packageFiles == null || packageFiles.SingleOrDefault(f => f.Equals(ToolManifestPath, StringComparison.Ordinal)) == null)
+            {
+                yield return PackageIssueFactory.DotNetToolMustHaveManifest(DotNetTool.Name, ToolManifestPath);
+                yield break;
+            }
+
+            var manifestStream = context.PackageReader.GetStream(ToolManifestPath);
+            var manifest = XDocument.Load(manifestStream);
+
+            AssemblyAttributesDataHelper.SetAssemblyAttributesData(context);
+
+            var commands = manifest.Descendants("Command");
+            foreach (var command in commands)
+            {
+                var name = command.Attribute("Name");
+                if (string.IsNullOrEmpty(name?.Value))
+                {
+                    yield return PackageIssueFactory.DotNetToolMalformedManifest("Missing Name");
+                    continue;
+                }
+
+                var entryPoint = command.Attribute("EntryPoint");
+                if (entryPoint?.Value == null)
+                {
+                    yield return PackageIssueFactory.DotNetToolMalformedManifest("Missing EntryPoint");
+                    continue;
+                }
+
+
+                if (!packageFiles.Any(a => a.Equals(entryPoint.Value, StringComparison.Ordinal))
+                    && !packageFiles.Any(a => a.StartsWith("tools/netcoreapp", StringComparison.Ordinal) && Path.GetFileName(a).Equals(entryPoint.Value, StringComparison.Ordinal)))
+                {
+                    // In the initial implementation of global tools, EntryPoint is just a filename, not a full path inside the package.
+                    yield return PackageIssueFactory.DotNetToolMissingEntryPoint(entryPoint.Value);
+                }
+            }
+        }
+    }
+}

--- a/modules/NuGetPackageVerifier/console/Rules/PackageVersionMatchesAssemblyVersionRule.cs
+++ b/modules/NuGetPackageVerifier/console/Rules/PackageVersionMatchesAssemblyVersionRule.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -21,12 +21,23 @@ namespace NuGetPackageVerifier.Rules
                     typeof(AssemblyInformationalVersionAttribute).FullName,
                     StringComparison.Ordinal));
 
-                var assemblyInformationalNuGetVersion = new NuGetVersion(assemblyInformationalVersionAttribute.ConstructorArguments[0].Value.ToString());
+                var infoVersion = assemblyInformationalVersionAttribute?.ConstructorArguments[0].Value?.ToString();
+
+                if (!NuGetVersion.TryParse(infoVersion, out var assemblyInformationalNuGetVersion))
+                {
+                    yield return PackageIssueFactory.AssemblyInformationalVersionDoesNotMatchPackageVersion(
+                       assemblyData.Key,
+                       infoVersion,
+                       context.Metadata.Version,
+                       context.Metadata.Id);
+                    yield break;
+                }
+
                 if (!VersionEquals(context.Metadata.Version, assemblyInformationalNuGetVersion))
                 {
                     yield return PackageIssueFactory.AssemblyInformationalVersionDoesNotMatchPackageVersion(
                         assemblyData.Key,
-                        assemblyInformationalNuGetVersion,
+                        infoVersion,
                         context.Metadata.Version,
                         context.Metadata.Id);
                 }


### PR DESCRIPTION
Add support for a new package type - global CLI tools.

Also, fixed NullReferenceException's when running NGPV on the CLI tool packages