### PR TITLE
Update ApiCheck generation and BuildTools testing script

### DIFF
--- a/src/ApiCheck.Task/ApiCheckTasksBase.cs
+++ b/src/ApiCheck.Task/ApiCheckTasksBase.cs
@@ -141,16 +141,18 @@ namespace Microsoft.AspNetCore.BuildTools.ApiCheck.Task
             }
 
             arguments += $@" --assembly ""{AssemblyPath}"" --framework {Framework}";
-            arguments += $@" --project ""{ProjectAssetsPath}"" --api-listing ""{ApiListingPath}""";
+            arguments += $@" --project ""{ProjectAssetsPath}""";
+            if (command == "compare")
+            {
+                arguments += $@" --api-listing ""{ApiListingPath}""";
+            }
+
+            if (command == "generate")
+            {
+                arguments += $@" --out {ApiListingPath}";
+            }
 
             return arguments;
-        }
-
-        /// <inheritdoc />
-        protected override string GetWorkingDirectory()
-        {
-            // Working directory should not matter. Use project folder because it is a well-known location.
-            return Path.GetDirectoryName(ApiListingPath);
         }
     }
 }

--- a/src/Internal.AspNetCore.Sdk/build/ApiCheck.props
+++ b/src/Internal.AspNetCore.Sdk/build/ApiCheck.props
@@ -20,6 +20,7 @@
     <ExcludePublicInternalTypes_InApiCheck Condition=" '$(ExcludePublicInternalTypes_InApiCheck)' == '' ">true</ExcludePublicInternalTypes_InApiCheck>
 
     <!-- Hook API checks into Pack run, prior to creating the .nupkg but after build (if any). -->
+    <GenerateNuspecDependsOn Condition=" '$(GenerateBaselines)' == 'true'">$(GenerateNuspecDependsOn);Generate-ApiCheck-Baselines</GenerateNuspecDependsOn>
     <GenerateNuspecDependsOn>$(GenerateNuspecDependsOn);ApiCheck</GenerateNuspecDependsOn>
-  </PropertyGroup>
+    </PropertyGroup>
 </Project>

--- a/src/Internal.AspNetCore.Sdk/build/ApiCheck.targets
+++ b/src/Internal.AspNetCore.Sdk/build/ApiCheck.targets
@@ -17,7 +17,7 @@
       DependsOnTargets="_GetApiListingFile"
       Condition=" '$(EnableApiCheck)' == 'true' " >
     <ApiCheckGenerateTask
-      ApiListingPath="$(_ApiListingFile)"
+      ApiListingPath="$(_ApiListingFilePath)"
       AssemblyPath="$(TargetPath)"
       Framework="$(TargetFramework)"
       ExcludePublicInternalTypes="$(ExcludePublicInternalTypes_InApiCheck)"

--- a/src/Internal.AspNetCore.Sdk/buildMultiTargeting/ApiCheck.targets
+++ b/src/Internal.AspNetCore.Sdk/buildMultiTargeting/ApiCheck.targets
@@ -3,6 +3,16 @@
   for use outside of Microsoft.
 -->
 <Project>
+
+  <Target
+      Name="Generate-ApiCheck-Baselines" >
+
+    <MSBuild Projects="$(MSBuildProjectFullPath)"
+      Targets="Generate-ApiCheck-Baselines"
+      Properties="TargetFramework=%(_TargetFrameworks.Identity)"
+      RemoveProperties="TargetFrameworks" />
+  </Target>
+
   <Target Name="ApiCheck" Condition=" '$(EnableApiCheck)' == 'true' ">
     <ItemGroup>
       <_TargetFrameworks Remove="@(_TargetFrameworks)" />

--- a/test.ps1
+++ b/test.ps1
@@ -2,9 +2,9 @@
 #requires -version 4
 [CmdletBinding(PositionalBinding = $true)]
 param(
-    [Parameter(Mandatory=$true)]
+    [Parameter(Mandatory = $true)]
     [string]$Command,
-    [Parameter(Mandatory=$true)]
+    [Parameter(Mandatory = $true)]
     [string]$RepoPath,
     [switch]$NoBuild = $false,
     [Parameter(ValueFromRemainingArguments = $true)]
@@ -12,9 +12,27 @@ param(
 )
 
 if (!$NoBuild) {
-    & .\build.ps1 /t:PackageKoreBuild
+    & .\build.ps1 /p:SkipTests=$true
 }
 
 $toolsSource = "$PSScriptRoot/artifacts/"
+$latestFile = Join-Path $toolsSource "korebuild/channels/dev/latest.txt"
+$toolsVersion = $null
+foreach ($line in Get-Content $latestFile) {
+    $toolsVersion = $line.Split(":")[1]
+    break
+}
+$packageDir = Join-Path $toolsSource "build\"
+$versionPropsPath = Join-Path $toolsSource "dotnetpackageversion.props"
+$sourcePropsPath = Join-Path $toolsSource "source.props"
+
+$versionPropsValue = "<Project><PropertyGroup><InternalAspNetCoreSdkPackageVersion>$toolsVersion</InternalAspNetCoreSdkPackageVersion></PropertyGroup></Project>"
+$sourcePropsValue = "<Project><PropertyGroup><DotNetRestoreSources>$packageDir</DotNetRestoreSources></PropertyGroup></Project>"
+
+Out-File -FilePath $versionPropsPath -InputObject $versionPropsValue
+Out-File -FilePath $sourcePropsPath -InputObject $sourcePropsValue
+
+$Arguments += "/p:DotNetPackageVersionPropsPath=$versionPropsPath"
+$Arguments += "/p:DotNetRestoreSourcePropsPath=$sourcePropsPath"
 
 & .\scripts\bootstrapper\run.ps1 -Update -Reinstall -Command $Command -Path $RepoPath -ToolsSource $toolsSource @Arguments


### PR DESCRIPTION
As written the Generate task didn't work, and there wasn't a simple way to run it on your projects.