### PR TITLE
Support TestGroupNamePrefix 

### DIFF
--- a/files/KoreBuild/modules/vstest/Project.Inspection.targets
+++ b/files/KoreBuild/modules/vstest/Project.Inspection.targets
@@ -2,11 +2,12 @@
 
   <PropertyGroup>
     <GetTestAssemblyDependsOn Condition="'$(TargetFramework)' != ''">GetTargetPath</GetTestAssemblyDependsOn>
-    <TestGroupName Condition="'$(TestGroupName)' == ''">UnitTests</TestGroupName>
+    <!-- TestGroupNamePrefix can be set externally when building multiple repos together -->
+    <TestGroupName Condition="'$(TestGroupName)' == ''">$(TestGroupNamePrefix)UnitTests</TestGroupName>
   </PropertyGroup>
 
   <Target Name="GetTestAssembly" DependsOnTargets="$(GetTestAssemblyDependsOn)" Returns="@(TestAssembly)">
-    <ItemGroup Condition=" '$(IsTestProject)' == 'true' ">
+    <ItemGroup Condition=" '$(IsTestProject)' == 'true' OR ('$(IsTestProject)' == '' AND @(PackageReference->WithMetadataValue('Identity', 'Microsoft.NET.Test.Sdk')->Count()) != 0)">
       <TestAssembly Include="@(TargetPathWithTargetPlatformMoniker)">
         <TargetFramework>$(TargetFramework)</TargetFramework>
         <TestGroupName>$(TestGroupName)</TestGroupName>


### PR DESCRIPTION
Make it possible to group tests from Universe.

Example when gathering all TestAssembly items from aspnet/Universe: https://github.com/aspnet/Universe/commit/7e36d1fef01a1530be5a15d6e21a784af7ff5897