### PR TITLE
Add infrastructure to support generating signing requests

### DIFF
--- a/build/repo.targets
+++ b/build/repo.targets
@@ -59,7 +59,8 @@
 
     <MSBuild Targets="Publish"
       Projects="@(_ToolsProjects)"
-      Properties="$(SolutionProperties)" />
+      Properties="$(SolutionProperties)"
+      BuildInParallel="true" />
 
     <ItemGroup>
       <Content Include="$(RepositoryRoot)files\KoreBuild\**\*" />
@@ -80,7 +81,8 @@
 
     <MSBuild Targets="Publish"
       Projects="@(_ModuleProjects)"
-      Properties="$(SolutionProperties)" />
+      Properties="$(SolutionProperties)"
+      BuildInParallel="true" />
 
     <ItemGroup>
       <KoreBuildFiles Include="$(_KoreBuildIntermediateDir)**\*" />

--- a/docs/Signing.md
+++ b/docs/Signing.md
@@ -1,0 +1,126 @@
+Signing
+=======
+
+KoreBuild supports generating a signing request manfiest. This includes a list of all files that should be signed
+and information about the strongname or certificate that should be used.
+
+## Format
+
+The signing request manifest supports three element types. A minimal example looks like this. See [Elements](#Elements) below for details
+
+```xml
+<SigningRequest>
+  <File Path="MyAssembly.dll" Certificate="MyCert" StrongName="MyStrongName" />
+  <File Path="build/Another.dll" Certificate="MyCert" />
+  <Container Path="MyLib.1.0.0.nupkg" Type="nupkg" Certificate="NuGetCert">
+    <File Path="lib/netstandard2.0/MyLib.dll" Certificate="MyCert" />
+  </Container>
+  <Container Path="MyVSTool.vsix" Type="vsix" Certificate="VsixCert">
+    <File Path="MyVSTool.dll" Certificate="MyCert" />
+    <!-- excluded from signing, but useful if you want to assert all files in a container are accounted for. -->
+    <ExcludedFile Path="NotMyLib.dll" />
+  </Container>
+</SigningRequest>
+```
+
+## Config
+
+### Assemblies
+
+To sign assemblies, set the AssemblySigningCertName and AssemblySigningStrongName property in the \*.csproj.
+
+```xml
+<PropertyGroup>
+  <AssemblySigningCertName>MyCert</AssemblySigningCertName>
+  <AssemblySigningStrongName>PrivateStrongName</AssemblySigningStrongName>
+</PropertyGroup>
+```
+
+This will generate a signing request like this:
+
+```xml
+<SigningRequest>
+  <File Path="MyLib.dll" Certificate="MyCert" StrongName="PrivateStrongName" />
+</SigningRequest>
+```
+
+### NuGet packages
+
+To sign NuGet packages, set the PackageSigningCertName property in the \*.csproj that produces the nupkg.
+
+```xml
+<PropertyGroup>
+  <PackageSigningCertName>NuGetCert</PackageSigningCertName>
+</PropertyGroup>
+```
+
+This will generate a signing request like this:
+
+```xml
+<SigningRequest>
+  <Container Path="MyLib.1.0.0.nupkg" Type="nupkg" Certificate="NuGetCert" />
+</SigningRequest>
+```
+
+### NuGet packages with assemblies
+
+For assemblies that ship in a NuGet package, you can specify multiple properties.
+
+```xml
+<PropertyGroup>
+  <AssemblySigningCertName>MyCert</AssemblySigningCertName>
+  <PackageSigningCertName>NuGetCert</PackageSigningCertName>
+</PropertyGroup>
+```
+
+This will generate a signing request like this:
+
+```xml
+<SigningRequest>
+  <Container Path="MyLib.1.0.0.nupkg" Type="nupkg" Certificate="NuGetCert">
+    <File Path="lib/netstandard2.0/MyLib.dll" Certificate="MyCert" />
+  </Container>
+</SigningRequest>
+```
+
+
+## Elements
+
+#### `SigningRequest`
+
+Root element. No options.
+
+#### `File`
+
+A file to be signed.
+
+**Path** - file path, relative to the file path. If nested in a `<Container>`, is relative to the organization within the container
+
+**Certificate** - the name of the certificate to use
+
+**StrongName** - for assemblies only. This is used to strong name assemblies that were delay signed in public.
+
+#### `Container`
+
+A container is an archive file, installer, or some kind of bundle that can be signed, or that has files that can be signed
+inside it. Nested elements can be added for `<File>` and `<ExcludedFile>`.
+
+**Path** - file path to the container
+
+**Certificate** - the name of the certificate to use
+
+**Type** - The type of the container. Instructs the consumer how to extract the container. Example values:
+
+  - zip
+  - tar.gz
+  - vsix
+  - nupkg
+  - msi
+
+#### `ExcludedFile`
+
+This is useful when you want to exclude files within a container from being signed, but want to assert that
+all files in a container are accounted for.
+
+**Path** - file path to a file to be ignored by the signing tool
+

--- a/files/KoreBuild/modules/sharedsources/module.targets
+++ b/files/KoreBuild/modules/sharedsources/module.targets
@@ -27,6 +27,7 @@ that matches "$(RepositoryRoot)/shared/*.Sources".
       Condition="@(SharedSourceDirectories->Count()) != 0"
       BuildInParallel="true">
       <Output TaskParameter="TargetOutputs" ItemName="ArtifactInfo" />
+      <Output TaskParameter="TargetOutputs" ItemName="ExcludeFromSigning" Condition="'$(SignSourcesPackages)' != 'true'" />
     </MSBuild>
   </Target>
 

--- a/files/KoreBuild/modules/solutionbuild/Project.Inspection.targets
+++ b/files/KoreBuild/modules/solutionbuild/Project.Inspection.targets
@@ -22,8 +22,8 @@
         <PackageType>$(PackageType)</PackageType>
         <RepositoryRoot>$(RepositoryRoot)</RepositoryRoot>
         <Category>$(PackageArtifactCategory)</Category>
-        <Certificate>$(PackageSigningCert)</Certificate>
-        <ShouldBeSigned Condition="'$(PackageSigningCert)' != '' OR @(SignedPackageFile->Count()) != 0 ">true</ShouldBeSigned>
+        <Certificate>$(PackageSigningCertName)</Certificate>
+        <ShouldBeSigned Condition="'$(PackageSigningCertName)' != '' OR @(SignedPackageFile->Count()) != 0 ">true</ShouldBeSigned>
         <IsContainer>true</IsContainer>
       </ArtifactInfo>
 
@@ -37,8 +37,8 @@
         <PackageType>$(PackageType)</PackageType>
         <RepositoryRoot>$(RepositoryRoot)</RepositoryRoot>
         <Category>$(PackageArtifactCategory)</Category>
-        <Certificate>$(PackageSigningCert)</Certificate>
-        <ShouldBeSigned Condition="'$(PackageSigningCert)' != '' OR @(SignedPackageFile->Count()) != 0 ">true</ShouldBeSigned>
+        <Certificate>$(PackageSigningCertName)</Certificate>
+        <ShouldBeSigned Condition="'$(PackageSigningCertName)' != '' OR @(SignedPackageFile->Count()) != 0 ">true</ShouldBeSigned>
         <IsContainer>true</IsContainer>
       </ArtifactInfo>
 
@@ -92,16 +92,16 @@ Items:
           Condition=" '$(TargetFramework)' != '' "
           DependsOnTargets="BuiltProjectOutputGroup;SatelliteDllsProjectOutputGroup">
 
-    <ItemGroup Condition=" '$(NuspecFile)' == '' AND '$(IncludeBuildOutput)' != 'false' AND ('$(AssemblySigningCert)' != '' OR '$(AssemblySigningStrongName)' != '') ">
+    <ItemGroup Condition=" '$(NuspecFile)' == '' AND '$(IncludeBuildOutput)' != 'false' AND ('$(AssemblySigningCertName)' != '' OR '$(AssemblySigningStrongName)' != '') ">
       <SignedPackageFile Include="@(BuiltProjectOutputGroupOutput)">
         <PackagePath>$(BuildOutputTargetFolder)/$(TargetFramework)/%(BuiltProjectOutputGroupOutput.FileName)%(BuiltProjectOutputGroupOutput.Extension)</PackagePath>
-        <Certificate>$(AssemblySigningCert)</Certificate>
+        <Certificate>$(AssemblySigningCertName)</Certificate>
         <StrongName>$(AssemblySigningStrongName)</StrongName>
       </SignedPackageFile>
 
       <SignedPackageFile Include="@(SatelliteDllsProjectOutputGroupOutput)">
         <PackagePath>$(BuildOutputTargetFolder)/$(TargetFramework)/%(SatelliteDllsProjectOutputGroupOutput.FileName)%(SatelliteDllsProjectOutputGroupOutput.Extension)</PackagePath>
-        <Certificate>$(AssemblySigningCert)</Certificate>
+        <Certificate>$(AssemblySigningCertName)</Certificate>
         <StrongName>$(AssemblySigningStrongName)</StrongName>
       </SignedPackageFile>
     </ItemGroup>

--- a/files/KoreBuild/modules/solutionbuild/Project.Inspection.targets
+++ b/files/KoreBuild/modules/solutionbuild/Project.Inspection.targets
@@ -1,14 +1,19 @@
 <Project>
 
-  <Target Name="GetArtifactInfo" Returns="@(ArtifactInfo)">
+  <Target Name="GetArtifactInfo"
+          DependsOnTargets="GetSignedPackageFiles"
+          Returns="@(ArtifactInfo)">
+
     <PropertyGroup>
       <NormalizedPackageVersion>$(PackageVersion)</NormalizedPackageVersion>
       <!-- Strip version metadata -->
       <NormalizedPackageVersion Condition="$(NormalizedPackageVersion.Contains('+'))">$(PackageVersion.Substring(0, $(PackageVersion.IndexOf('+'))))</NormalizedPackageVersion>
+      <FullPackageOutputPath>$(PackageOutputPath)$(PackageId).$(NormalizedPackageVersion).nupkg</FullPackageOutputPath>
+      <SymbolsPackageOutputPath>$(PackageOutputPath)$(PackageId).$(NormalizedPackageVersion).symbols.nupkg</SymbolsPackageOutputPath>
     </PropertyGroup>
 
     <ItemGroup Condition="'$(IsPackable)' == 'true' ">
-      <ArtifactInfo Include="$(PackageOutputPath)$(PackageId).$(NormalizedPackageVersion).nupkg">
+      <ArtifactInfo Include="$(FullPackageOutputPath)">
         <ArtifactType>NuGetPackage</ArtifactType>
         <PackageId>$(PackageId)</PackageId>
         <Version>$(NormalizedPackageVersion)</Version>
@@ -17,9 +22,12 @@
         <PackageType>$(PackageType)</PackageType>
         <RepositoryRoot>$(RepositoryRoot)</RepositoryRoot>
         <Category>$(PackageArtifactCategory)</Category>
+        <Certificate>$(PackageSigningCert)</Certificate>
+        <ShouldBeSigned Condition="'$(PackageSigningCert)' != '' OR @(SignedPackageFile->Count()) != 0 ">true</ShouldBeSigned>
+        <IsContainer>true</IsContainer>
       </ArtifactInfo>
 
-      <ArtifactInfo Include="$(PackageOutputPath)$(PackageId).$(NormalizedPackageVersion).symbols.nupkg" Condition="'$(IncludeSymbols)' == 'true' AND '$(NuspecFile)' == ''">
+      <ArtifactInfo Include="$(SymbolsPackageOutputPath)" Condition="'$(IncludeSymbols)' == 'true' AND '$(NuspecFile)' == ''">
         <ArtifactType>NuGetSymbolsPackage</ArtifactType>
         <PackageId>$(PackageId)</PackageId>
         <Version>$(NormalizedPackageVersion)</Version>
@@ -29,7 +37,73 @@
         <PackageType>$(PackageType)</PackageType>
         <RepositoryRoot>$(RepositoryRoot)</RepositoryRoot>
         <Category>$(PackageArtifactCategory)</Category>
+        <Certificate>$(PackageSigningCert)</Certificate>
+        <ShouldBeSigned Condition="'$(PackageSigningCert)' != '' OR @(SignedPackageFile->Count()) != 0 ">true</ShouldBeSigned>
+        <IsContainer>true</IsContainer>
       </ArtifactInfo>
+
+      <ArtifactInfo Include="@(SignedPackageFile)">
+        <ShouldBeSigned>true</ShouldBeSigned>
+        <Container>$(FullPackageOutputPath)</Container>
+      </ArtifactInfo>
+
+      <ArtifactInfo Include="@(SignedPackageFile)" Condition="'$(IncludeSymbols)' == 'true' AND '$(NuspecFile)' == ''">
+        <ShouldBeSigned>true</ShouldBeSigned>
+        <Container>$(SymbolsPackageOutputPath)</Container>
+      </ArtifactInfo>
+    </ItemGroup>
+  </Target>
+
+<!--
+####################################################################################
+Target: GetSignedPackageFiles
+
+Gets itesm for built assemblies that will be in the package.
+Also supports projects that explicitly set SignedPackageFile.
+
+Items:
+[out] SignedPackageFile
+#####################################################################################
+-->
+  <PropertyGroup>
+    <!-- For single-TFM projects -->
+    <GetSignedPackageFilesDependsOn Condition=" '$(TargetFramework)' != '' ">
+      _GetSignedPackageFiles
+    </GetSignedPackageFilesDependsOn>
+  </PropertyGroup>
+
+  <Target Name="GetSignedPackageFiles" DependsOnTargets="$(GetSignedPackageFilesDependsOn)" Returns="@(SignedPackageFile)">
+
+    <ItemGroup Condition=" '$(TargetFramework)' == '' ">
+      <_TargetFrameworks Remove="@(_TargetFrameworks)" />
+      <_TargetFrameworks Include="$(TargetFrameworks)" />
+    </ItemGroup>
+
+    <MSBuild Projects="$(MSBuildProjectFullPath)"
+      Properties="TargetFramework=%(_TargetFrameworks.Identity)"
+      Targets="GetSignedPackageFiles"
+      Condition=" '%(_TargetFrameworks.Identity)' != '' AND '$(TargetFramework)' == '' "
+      BuildInParallel="true">
+      <Output TaskParameter="TargetOutputs" ItemName="SignedPackageFile" />
+    </MSBuild>
+  </Target>
+
+  <Target Name="_GetSignedPackageFiles"
+          Condition=" '$(TargetFramework)' != '' "
+          DependsOnTargets="BuiltProjectOutputGroup;SatelliteDllsProjectOutputGroup">
+
+    <ItemGroup Condition=" '$(NuspecFile)' == '' AND '$(IncludeBuildOutput)' != 'false' AND ('$(AssemblySigningCert)' != '' OR '$(AssemblySigningStrongName)' != '') ">
+      <SignedPackageFile Include="@(BuiltProjectOutputGroupOutput)">
+        <PackagePath>$(BuildOutputTargetFolder)/$(TargetFramework)/%(BuiltProjectOutputGroupOutput.FileName)%(BuiltProjectOutputGroupOutput.Extension)</PackagePath>
+        <Certificate>$(AssemblySigningCert)</Certificate>
+        <StrongName>$(AssemblySigningStrongName)</StrongName>
+      </SignedPackageFile>
+
+      <SignedPackageFile Include="@(SatelliteDllsProjectOutputGroupOutput)">
+        <PackagePath>$(BuildOutputTargetFolder)/$(TargetFramework)/%(SatelliteDllsProjectOutputGroupOutput.FileName)%(SatelliteDllsProjectOutputGroupOutput.Extension)</PackagePath>
+        <Certificate>$(AssemblySigningCert)</Certificate>
+        <StrongName>$(AssemblySigningStrongName)</StrongName>
+      </SignedPackageFile>
     </ItemGroup>
   </Target>
 

--- a/files/KoreBuild/modules/solutionbuild/module.targets
+++ b/files/KoreBuild/modules/solutionbuild/module.targets
@@ -77,7 +77,8 @@ Executes /t:{Target} on all solutions
     <MSBuild Targets="Restore"
       Projects="@(Solutions)"
       Properties="$(SolutionProperties);_SolutionTarget=Restore"
-      RemoveProperties="$(_BuildPropertiesToRemove)" />
+      RemoveProperties="$(_BuildPropertiesToRemove)"
+      BuildInParallel="$(BuildInParallel)" />
   </Target>
 
   <Target Name="CleanSolutions" DependsOnTargets="ResolveSolutions;_EnsureSolutions">
@@ -88,6 +89,7 @@ Executes /t:{Target} on all solutions
     <MSBuild Targets="Clean"
       Projects="@(Solutions)"
       Properties="$(SolutionProperties);_SolutionTarget=Clean"
+      BuildInParallel="$(BuildInParallel)"
       RemoveProperties="$(_BuildPropertiesToRemove)" />
   </Target>
 
@@ -106,7 +108,8 @@ Executes /t:{Target} on all solutions
   <Target Name="RebuildSolutions" DependsOnTargets="ResolveSolutions;_EnsureSolutions">
     <MSBuild Targets="Rebuild"
       Projects="@(Solutions)"
-      RemoveProperties="$(_BuildPropertiesToRemove)" />
+      RemoveProperties="$(_BuildPropertiesToRemove)"
+      BuildInParallel="$(BuildInParallel)" />
 
     <PropertyGroup>
       <_SolutionWasBuilt>true</_SolutionWasBuilt>
@@ -138,14 +141,23 @@ Executes /t:Pack on all projects matching src/*/*.csproj.
       <_InspectionTargetsFile>$(MSBuildThisFileDirectory)Project.Inspection.targets</_InspectionTargetsFile>
     </PropertyGroup>
 
+    <ItemGroup>
+      <_Temp Remove="@(_Temp)" />
+    </ItemGroup>
+
     <MSBuild Targets="GetArtifactInfo"
       Projects="@(ProjectsToPack)"
       Condition="@(ProjectsToPack->Count()) != 0"
-      Properties="$(SolutionProperties);RepositoryRoot=$(RepositoryRoot);PackageOutputPath=$(BuildDir);CustomAfterMicrosoftCommonTargets=$(_InspectionTargetsFile);CustomAfterMicrosoftCommonCrossTargetingTargets=$(_InspectionTargetsFile)"
+      Properties="$(SolutionProperties);EnableApiCheck=false;NoBuild=true;RepositoryRoot=$(RepositoryRoot);PackageOutputPath=$(BuildDir);CustomAfterMicrosoftCommonTargets=$(_InspectionTargetsFile);CustomAfterMicrosoftCommonCrossTargetingTargets=$(_InspectionTargetsFile)"
       BuildInParallel="$(BuildInParallel)"
       RemoveProperties="$(_BuildPropertiesToRemove);PackageNoBuild">
-      <Output TaskParameter="TargetOutputs" ItemName="ArtifactInfo" />
+      <Output TaskParameter="TargetOutputs" ItemName="_Temp" />
     </MSBuild>
+
+    <ItemGroup>
+      <ArtifactInfo Include="@(_Temp)" Condition="'%(_Temp.Container)' == ''" />
+      <Sign Include="@(_Temp)" Condition="'%(_Temp.Container)' != ''" />
+    </ItemGroup>
   </Target>
 
 </Project>

--- a/files/KoreBuild/modules/vstest/module.targets
+++ b/files/KoreBuild/modules/vstest/module.targets
@@ -33,6 +33,7 @@ Runs the VSTest on all projects in the ProjectsToTest itemgroup.
       Targets="GetTestAssembly"
       Properties="$(SolutionProperties);CustomAfterMicrosoftCommonTargets=$(_InspectionTargetsFile);CustomAfterMicrosoftCommonCrossTargetingTargets=$(_InspectionTargetsFile);%(ProjectsToTest.AdditionalProperties)"
       Condition="@(ProjectsToTest->Count()) != 0"
+      BuildInParallel="true"
       RemoveProperties="$(_BuildPropertiesToRemove)">
       <Output TaskParameter="TargetOutputs" ItemName="TestAssembly" />
     </MSBuild>
@@ -57,6 +58,7 @@ Runs the VSTest on all projects in the ProjectsToTest itemgroup.
     <MSBuild Projects="@(TestGroups)"
              Targets="_ExecuteTestAssemblies"
              Condition="@(TestGroups->Count()) != 0"
+             BuildInParallel="false"
              ContinueOnError="$(_TestContinueOnError)" />
   </Target>
 

--- a/modules/BundledPackages/BundledPackages.proj
+++ b/modules/BundledPackages/BundledPackages.proj
@@ -10,6 +10,7 @@
     <MSBuild Projects="@(Projects)"
       Targets="Pack"
       Properties="PackageOutputPath=$(PublishDir);Configuration=$(Configuration);BuildNumber=$(BuildNumber)"
+      BuildInParallel="true"
       RemoveProperties="PublishDir" />
 
     <Copy SourceFiles="module.props" DestinationFolder="$(PublishDir)" />

--- a/modules/KoreBuild.Tasks/GenerateBillOfMaterials.cs
+++ b/modules/KoreBuild.Tasks/GenerateBillOfMaterials.cs
@@ -50,6 +50,12 @@ namespace KoreBuild.Tasks
                 "ArtifactType",
                 "Category",
                 "Dependencies",
+                // metadata used by to create a sign request
+                "ShouldBeSigned",
+                "Certificate",
+                "StrongName",
+                "IsContainer",
+                "Container",
             };
 
             if (AdditionalMetadataFilters != null)

--- a/modules/KoreBuild.Tasks/GenerateSignRequests.cs
+++ b/modules/KoreBuild.Tasks/GenerateSignRequests.cs
@@ -1,0 +1,197 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.Build.Framework;
+
+namespace KoreBuild.Tasks
+{
+    /// <summary>
+    /// Generates an XML document that can be passed to a tool for signing.
+    /// <para>
+    /// The items are expected to be files.
+    /// </para>
+    /// </summary>
+    public class GenerateSignRequests : Microsoft.Build.Utilities.Task
+    {
+        /// <summary>
+        /// Files or containers of files that should be signed.
+        /// Required metadata 'Certificate' or 'StrongName'. Both can be specified.
+        /// Optional metadata: 'IsContainer'. Set this to true for files that can be extract and have inner parts signed. For example, nupkg and vsix files.
+        /// </summary>
+        [Required]
+        public ITaskItem[] Requests { get; set; }
+
+        /// <summary>
+        /// Items that should explicitly be marked as 'excluded' in the sign request.
+        /// Only files in listed as a request item will be signed, but excluded files can be
+        /// added as well so tests can validate that all files in a container are accounted for.
+        /// </summary>
+        public ITaskItem[] Exclusions { get; set; }
+
+        /// <summary>
+        /// The folder that conatins all items. The sign request file paths will be normalized to this path.
+        /// </summary>
+        [Required]
+        public string BasePath { get; set; }
+
+        /// <summary>
+        /// The output path of the sign request file.
+        /// </summary>
+        [Required]
+        [Output]
+        public string OutputPath { get; set; }
+
+        public override bool Execute()
+        {
+            OutputPath = OutputPath.Replace('\\', '/');
+            BasePath = BasePath.Replace('\\', '/');
+
+            return Execute(() =>
+            {
+                Directory.CreateDirectory(Path.GetDirectoryName(OutputPath));
+                return File.CreateText(OutputPath);
+            });
+        }
+
+        internal bool Execute(Func<TextWriter> writerFactory)
+        {
+            var signRequestCollection = new SignRequestCollection();
+
+            var containers = new Dictionary<string, SignRequestItem.Container>(StringComparer.OrdinalIgnoreCase);
+            var isContainer = new bool[Requests.Length];
+            for (var i = 0; i < Requests.Length; i++)
+            {
+                var item = Requests[i];
+                if (bool.TryParse(item.GetMetadata("IsContainer"), out var isc) && isc)
+                {
+                    isContainer[i] = true;
+                    var type = item.GetMetadata("Type");
+                    if (string.IsNullOrEmpty(type))
+                    {
+                        type = GetKnownContainerTypes(item);
+                    }
+
+                    if (string.IsNullOrEmpty(type))
+                    {
+                        Log.LogError("Signing request containers must specify the metadata 'Type'.");
+                        continue;
+                    }
+
+                    var normalizedPath = NormalizePath(BasePath, item.ItemSpec);
+                    var container = new SignRequestItem.Container(
+                        normalizedPath,
+                        type,
+                        item.GetMetadata("Certificate"),
+                        item.GetMetadata("StrongName"));
+
+                    containers[item.ItemSpec] = container;
+                    signRequestCollection.Add(container);
+                }
+            }
+
+            for (var i = 0; i < Requests.Length; i++)
+            {
+                if (isContainer[i])
+                {
+                    continue;
+                }
+
+                var item = Requests[i];
+                var containerPath = item.GetMetadata("Container");
+                if (!string.IsNullOrEmpty(containerPath))
+                {
+                    if (!containers.TryGetValue(containerPath, out var container))
+                    {
+                        Log.LogError($"Signing request item '{item.ItemSpec}' specifies an unknown container '{containerPath}'.");
+                        continue;
+                    }
+
+                    var file = new SignRequestItem.File(item.ItemSpec,
+                        item.GetMetadata("Certificate"),
+                        item.GetMetadata("StrongName"));
+                    container.AddItem(file);
+                }
+                else
+                {
+                    var normalizedPath = NormalizePath(BasePath, item.ItemSpec);
+                    var file = new SignRequestItem.File(normalizedPath,
+                      item.GetMetadata("Certificate"),
+                      item.GetMetadata("StrongName"));
+                    signRequestCollection.Add(file);
+                }
+            }
+
+            foreach (var item in Exclusions)
+            {
+                var containerPath = item.GetMetadata("Container");
+                if (!string.IsNullOrEmpty(containerPath))
+                {
+                    if (!containers.TryGetValue(containerPath, out var container))
+                    {
+                        Log.LogError($"Exclusion item '{item.ItemSpec}' specifies an unknown container '{containerPath}'.");
+                        continue;
+                    }
+
+                    var file = new SignRequestItem.Exclusion(item.ItemSpec);
+                    container.AddItem(file);
+                }
+                else
+                {
+                    var normalizedPath = NormalizePath(BasePath, item.ItemSpec);
+                    var file = new SignRequestItem.Exclusion(normalizedPath);
+                    signRequestCollection.Add(file);
+                }
+            }
+
+            if (Log.HasLoggedErrors)
+            {
+                return false;
+            }
+
+            using (var stream = writerFactory())
+            using (var writer = new SignRequestCollectionXmlWriter(stream))
+            {
+                writer.Write(signRequestCollection);
+            }
+
+            Log.LogMessage($"Generated bill of materials in {OutputPath}");
+
+            return !Log.HasLoggedErrors;
+        }
+
+        private static string GetKnownContainerTypes(ITaskItem item)
+        {
+            string type = null;
+
+            switch (Path.GetExtension(item.ItemSpec).ToLowerInvariant())
+            {
+                case ".nupkg":
+                    type = ".nupkg";
+                    break;
+                case ".zip":
+                    type = "zip";
+                    break;
+                case ".tar.gz":
+                case ".tgz":
+                    type = "tar.gz";
+                    break;
+                case ".vsix":
+                    type = "vsix";
+                    break;
+                case ".msi":
+                    type = "msi";
+                    break;
+            }
+
+            return type;
+        }
+
+        private static string NormalizePath(string basePath, string path)
+        {
+            return Path.GetRelativePath(basePath, path).Replace('\\', '/');
+        }
+    }
+}

--- a/modules/KoreBuild.Tasks/GenerateSignRequests.cs
+++ b/modules/KoreBuild.Tasks/GenerateSignRequests.cs
@@ -14,7 +14,7 @@ namespace KoreBuild.Tasks
     /// The items are expected to be files.
     /// </para>
     /// </summary>
-    public class GenerateSignRequests : Microsoft.Build.Utilities.Task
+    public class GenerateSignRequest : Microsoft.Build.Utilities.Task
     {
         /// <summary>
         /// Files or containers of files that should be signed.

--- a/modules/KoreBuild.Tasks/Internal/SignRequestCollection.cs
+++ b/modules/KoreBuild.Tasks/Internal/SignRequestCollection.cs
@@ -1,0 +1,23 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace KoreBuild.Tasks
+{
+    internal class SignRequestCollection : IEnumerable<SignRequestItem>
+    {
+        private SortedDictionary<string, SignRequestItem> _items = new SortedDictionary<string, SignRequestItem>(StringComparer.Ordinal);
+
+        public IEnumerator<SignRequestItem> GetEnumerator() => _items.Values.GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => _items.Values.GetEnumerator();
+
+        public void Add(SignRequestItem item)
+        {
+            _items.Add(item.Path, item);
+        }
+    }
+}

--- a/modules/KoreBuild.Tasks/Internal/SignRequestCollectionXmlWriter.cs
+++ b/modules/KoreBuild.Tasks/Internal/SignRequestCollectionXmlWriter.cs
@@ -17,7 +17,7 @@ namespace KoreBuild.Tasks
         public SignRequestCollectionXmlWriter(TextWriter output)
         {
             this.output = output;
-            document = new XDocument(new XElement("SignRequests"));
+            document = new XDocument(new XElement("SignRequest"));
         }
 
         public void Save()

--- a/modules/KoreBuild.Tasks/Internal/SignRequestCollectionXmlWriter.cs
+++ b/modules/KoreBuild.Tasks/Internal/SignRequestCollectionXmlWriter.cs
@@ -1,0 +1,104 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Text;
+using System.Xml;
+using System.Xml.Linq;
+
+namespace KoreBuild.Tasks
+{
+    internal class SignRequestCollectionXmlWriter : IDisposable
+    {
+        private readonly TextWriter output;
+        private readonly XDocument document;
+
+        public SignRequestCollectionXmlWriter(TextWriter output)
+        {
+            this.output = output;
+            document = new XDocument(new XElement("SignRequests"));
+        }
+
+        public void Save()
+        {
+            var settings = new XmlWriterSettings
+            {
+                Encoding = Encoding.UTF8,
+                OmitXmlDeclaration = true,
+                Indent = true,
+                NewLineChars = "\r\n",
+                NewLineHandling = NewLineHandling.Replace,
+            };
+
+            using (var writer = XmlWriter.Create(output, settings))
+            {
+                document.Save(writer);
+            }
+        }
+
+        public void Write(SignRequestCollection signRequestCollection)
+        {
+            var node = document.Root;
+            foreach (var request in signRequestCollection)
+            {
+                AddRequest(node, request);
+            }
+        }
+
+        private static void AddRequest(XElement parent, SignRequestItem item)
+        {
+            var path = new XAttribute("Path", item.Path);
+            switch (item)
+            {
+                case SignRequestItem.Container c:
+                    var container = new XElement("Container",
+                        path,
+                        new XAttribute("Type", c.Type));
+
+                    if (!string.IsNullOrEmpty(c.Certificate))
+                    {
+                        container.Add(new XAttribute("Certificate", c.Certificate));
+                    }
+
+                    if (!string.IsNullOrEmpty(c.StrongName))
+                    {
+                        container.Add(new XAttribute("StrongName", c.StrongName));
+                    }
+
+                    parent.Add(container);
+
+                    foreach (var i in c.Items)
+                    {
+                        AddRequest(container, i);
+                    }
+
+                    break;
+                case SignRequestItem.Exclusion e:
+                    parent.Add(new XElement("ExcludedFile", path));
+                    break;
+                case SignRequestItem.File f:
+                    var file = new XElement("File", path);
+
+                    if (!string.IsNullOrEmpty(f.Certificate))
+                    {
+                        file.Add(new XAttribute("Certificate", f.Certificate));
+                    }
+
+                    if (!string.IsNullOrEmpty(f.StrongName))
+                    {
+                        file.Add(new XAttribute("StrongName", f.StrongName));
+                    }
+
+                    parent.Add(file);
+                    break;
+                    throw new InvalidOperationException("Unrecognized sign request item");
+            }
+        }
+
+        public void Dispose()
+        {
+            Save();
+        }
+    }
+}

--- a/modules/KoreBuild.Tasks/Internal/SignRequestItem.cs
+++ b/modules/KoreBuild.Tasks/Internal/SignRequestItem.cs
@@ -1,0 +1,57 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace KoreBuild.Tasks
+{
+    internal abstract class SignRequestItem
+    {
+        public SignRequestItem(string path)
+        {
+            Path = path ?? throw new ArgumentNullException(nameof(path));
+        }
+
+        public string Path { get; }
+
+        public class Exclusion : SignRequestItem
+        {
+            public Exclusion(string path) : base(path)
+            {
+            }
+        }
+
+        public class File : SignRequestItem
+        {
+            public File(string path, string certificate, string strongName) : base(path)
+            {
+                Certificate = certificate;
+                StrongName = strongName;
+            }
+
+            public string Certificate { get; }
+            public string StrongName { get; }
+        }
+
+        public class Container : File
+        {
+            private readonly SignRequestCollection _items = new SignRequestCollection();
+
+            public Container(string path, string type, string certificate, string strongName) : base(path, certificate, strongName)
+            {
+                Type = type ?? throw new ArgumentNullException(nameof(type));
+            }
+
+            public IEnumerable<SignRequestItem> Items => _items;
+
+            public string Type { get; }
+
+            public Container AddItem(SignRequestItem item)
+            {
+                _items.Add(item);
+                return this;
+            }
+        }
+    }
+}

--- a/modules/KoreBuild.Tasks/KoreBuild.Tasks.csproj
+++ b/modules/KoreBuild.Tasks/KoreBuild.Tasks.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <AssemblyName>Internal.AspNetCore.KoreBuild.Tasks</AssemblyName>
   </PropertyGroup>
 

--- a/modules/KoreBuild.Tasks/module.props
+++ b/modules/KoreBuild.Tasks/module.props
@@ -14,7 +14,7 @@
   <UsingTask TaskName="KoreBuild.Tasks.GenerateBillOfMaterials" AssemblyFile="$(KoreBuildTasksDll)" />
   <UsingTask TaskName="KoreBuild.Tasks.GenerateDependenciesPropsFile" AssemblyFile="$(KoreBuildTasksDll)" />
   <UsingTask TaskName="KoreBuild.Tasks.GeneratePackageVersionPropsFile" AssemblyFile="$(KoreBuildTasksDll)" />
-  <UsingTask TaskName="KoreBuild.Tasks.GenerateSignRequests" AssemblyFile="$(KoreBuildTasksDll)" />
+  <UsingTask TaskName="KoreBuild.Tasks.GenerateSignRequest" AssemblyFile="$(KoreBuildTasksDll)" />
   <UsingTask TaskName="KoreBuild.Tasks.GetToolsets" AssemblyFile="$(KoreBuildTasksDll)" />
   <UsingTask TaskName="KoreBuild.Tasks.InstallDotNet" AssemblyFile="$(KoreBuildTasksDll)" />
   <UsingTask TaskName="KoreBuild.Tasks.PackNuSpec" AssemblyFile="$(KoreBuildTasksDll)" />

--- a/modules/KoreBuild.Tasks/module.props
+++ b/modules/KoreBuild.Tasks/module.props
@@ -14,6 +14,7 @@
   <UsingTask TaskName="KoreBuild.Tasks.GenerateBillOfMaterials" AssemblyFile="$(KoreBuildTasksDll)" />
   <UsingTask TaskName="KoreBuild.Tasks.GenerateDependenciesPropsFile" AssemblyFile="$(KoreBuildTasksDll)" />
   <UsingTask TaskName="KoreBuild.Tasks.GeneratePackageVersionPropsFile" AssemblyFile="$(KoreBuildTasksDll)" />
+  <UsingTask TaskName="KoreBuild.Tasks.GenerateSignRequests" AssemblyFile="$(KoreBuildTasksDll)" />
   <UsingTask TaskName="KoreBuild.Tasks.GetToolsets" AssemblyFile="$(KoreBuildTasksDll)" />
   <UsingTask TaskName="KoreBuild.Tasks.InstallDotNet" AssemblyFile="$(KoreBuildTasksDll)" />
   <UsingTask TaskName="KoreBuild.Tasks.PackNuSpec" AssemblyFile="$(KoreBuildTasksDll)" />

--- a/modules/KoreBuild.Tasks/module.targets
+++ b/modules/KoreBuild.Tasks/module.targets
@@ -174,7 +174,7 @@ Generates a manifest that contains signin requests for files.
       <Sign Include="@(ArtifactInfo)" Condition=" '%(ArtifactInfo.ShouldBeSigned)' == 'true' " />
     </ItemGroup>
 
-    <GenerateSignRequests
+    <GenerateSignRequest
       Requests="@(Sign)"
       Exclusions="@(ExcludeFromSigning)"
       BasePath="$(ArtifactsDir)"

--- a/modules/KoreBuild.Tasks/module.targets
+++ b/modules/KoreBuild.Tasks/module.targets
@@ -3,13 +3,17 @@
   <PropertyGroup>
     <PrepareDependsOn Condition=" '$(DisableDefaultTargets)' != 'true' ">GetToolsets;$(PrepareDependsOn)</PrepareDependsOn>
     <RestoreDependsOn Condition=" '$(DisableDefaultTargets)' != 'true' ">InstallDotNet;CheckPackageReferences;$(RestoreDependsOn)</RestoreDependsOn>
+    <PackageDependsOn Condition=" '$(DisableDefaultTargets)' != 'true' ">$(PackageDependsOn);GenerateSignRequest</PackageDependsOn>
+
     <GenerateBillOfMaterials Condition="'$(GenerateBillOfMaterials)' == ''">true</GenerateBillOfMaterials>
+    <GenerateSignRequest Condition="'$(GenerateSignRequest)' == ''">true</GenerateSignRequest>
 
     <DisablePackageReferenceRestrictions Condition=" '$(DisablePackageReferenceRestrictions)' == '' ">false</DisablePackageReferenceRestrictions>
     <KoreBuildConfigFile Condition="'$(KoreBuildConfigFile)' == ''">$(RepositoryRoot)korebuild.json</KoreBuildConfigFile>
     <DependencyVersionsFile Condition="'$(DependencyVersionsFile)' == ''">$(RepositoryRoot)build\dependencies.props</DependencyVersionsFile>
-    <BomPath>$(ArtifactsDir)manifest.xml</BomPath>
-    <IgnoredArtifactItems>$(IgnoredArtifactItems);$(BomPath)</IgnoredArtifactItems>
+    <BuildManifestOutputPath>$(ArtifactsDir)manifest.xml</BuildManifestOutputPath>
+    <SignRequestOutputPath>$(ArtifactsDir)signrequest.xml</SignRequestOutputPath>
+    <IgnoredArtifactItems>$(IgnoredArtifactItems);$(BuildManifestOutputPath)</IgnoredArtifactItems>
   </PropertyGroup>
 
 <!--
@@ -143,6 +147,41 @@ and NodeJS.
     </GetToolsets>
   </Target>
 
+
+<!--
+####################################################################################
+Target: GenerateSignRequest
+
+Generates a manifest that contains signin requests for files.
+
+[in] (items) ArtifactInfo
+[in] (items) Sign
+[in] (prop) Artifacts
+
+[out] SignRequestOutputPath - the bom file
+####################################################################################
+-->
+  <Target Name="GenerateSignRequest"
+          DependsOnTargets="GetArtifactInfo"
+          Condition=" '$(GenerateSignRequest)' == 'true' ">
+
+    <ItemGroup>
+      <ArtifactInfo Include="$(SignRequestOutputPath)">
+        <ArtifactType>XmlFile</ArtifactType>
+        <Category>noship</Category>
+      </ArtifactInfo>
+
+      <Sign Include="@(ArtifactInfo)" Condition=" '%(ArtifactInfo.ShouldBeSigned)' == 'true' " />
+    </ItemGroup>
+
+    <GenerateSignRequests
+      Requests="@(Sign)"
+      Exclusions="@(ExcludeFromSigning)"
+      BasePath="$(ArtifactsDir)"
+      OutputPath="$(SignRequestOutputPath)" />
+  </Target>
+
+
 <!--
 ####################################################################################
 Target: GenerateBillOfMaterials
@@ -152,7 +191,7 @@ Generates a manifest containing metadata about the all artifacts produced in a b
 [in] (items) ArtifactInfo
 [in] (prop) CommitHash
 
-[out] BomPath - the bom file
+[out] BuildManifestOutputPath - the bom file
 
 ####################################################################################
 -->
@@ -171,7 +210,7 @@ Generates a manifest containing metadata about the all artifacts produced in a b
       <Output TaskParameter="Items" ItemName="_ArtifactInfoWithFileHash" />
     </ComputeManyChecksum>
 
-    <GenerateBillOfMaterials Artifacts="@(_ArtifactInfoWithFileHash)" OutputPath="$(BomPath)" />
+    <GenerateBillOfMaterials Artifacts="@(_ArtifactInfoWithFileHash)" OutputPath="$(BuildManifestOutputPath)" />
   </Target>
 
 </Project>

--- a/modules/NuGetPackageVerifier/NuGetPackageVerifier.proj
+++ b/modules/NuGetPackageVerifier/NuGetPackageVerifier.proj
@@ -9,6 +9,7 @@
 
     <MSBuild Projects="@(Projects)"
       Targets="Publish"
+      BuildInParallel="true"
       Properties="PublishDir=$(PublishDir);Configuration=$(Configuration)" />
 
     <Copy SourceFiles="module.targets" DestinationFolder="$(PublishDir)" />

--- a/src/ApiCheck.Console/ApiCheck.Console.csproj
+++ b/src/ApiCheck.Console/ApiCheck.Console.csproj
@@ -31,7 +31,10 @@
     <ItemGroup>
       <_TargetFramework Include="$(TargetFrameworks)" />
     </ItemGroup>
-    <MSBuild Projects="$(MSBuildProjectFullPath)" Targets="Publish" Properties="TargetFramework=%(_TargetFramework.Identity)" />
+    <MSBuild Projects="$(MSBuildProjectFullPath)"
+             Targets="Publish"
+             BuildInParallel="true"
+             Properties="TargetFramework=%(_TargetFramework.Identity)" />
   </Target>
 
   <Target Name="SetPackageDependencies" BeforeTargets="GenerateNuspec" DependsOnTargets="PublishAll">

--- a/test/KoreBuild.Tasks.Tests/BillOfMaterialsXmlWriterTests.cs
+++ b/test/KoreBuild.Tasks.Tests/BillOfMaterialsXmlWriterTests.cs
@@ -23,8 +23,8 @@ namespace KoreBuild.Tasks.Tests
         public void ItSerializesBomToXml()
         {
             var bom = new BillOfMaterials();
-            var test = bom.AddArtifact("Test", "NuGetPackage").SetMetadata("ShouldBeSigned", "false");
-            var ship = bom.AddArtifact("Shipping", "NuGetPackage").SetMetadata("ShouldBeSigned", "true");
+            var test = bom.AddArtifact("Test", "NuGetPackage").SetMetadata("TargetFramework", "netstandard2.0");
+            var ship = bom.AddArtifact("Shipping", "NuGetPackage");
             ship.Category = "Ship";
 
             bom.Dependencies.AddLink(test, ship);
@@ -38,10 +38,10 @@ namespace KoreBuild.Tasks.Tests
 
             var expected = $@"<Build>
   <Artifacts>
-    <Artifact Id=`Test` Type=`NuGetPackage` ShouldBeSigned=`false` />
+    <Artifact Id=`Test` Type=`NuGetPackage` TargetFramework=`netstandard2.0` />
   </Artifacts>
   <Artifacts Category=`Ship`>
-    <Artifact Id=`Shipping` Type=`NuGetPackage` ShouldBeSigned=`true` />
+    <Artifact Id=`Shipping` Type=`NuGetPackage` />
   </Artifacts>
   <Dependencies>
     <Link Source=`Test` Target=`Shipping` />

--- a/test/KoreBuild.Tasks.Tests/GenerateSignRequestsTests.cs
+++ b/test/KoreBuild.Tasks.Tests/GenerateSignRequestsTests.cs
@@ -1,0 +1,90 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections;
+using System.IO;
+using System.Text;
+using BuildTools.Tasks.Tests;
+using Microsoft.Build.Utilities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace KoreBuild.Tasks.Tests
+{
+    public class GenerateSignRequestsTests
+    {
+        private readonly ITestOutputHelper _output;
+
+        public GenerateSignRequestsTests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [Fact]
+        public void ItCreatesSignRequest()
+        {
+            var nupkgPath = Path.Combine(AppContext.BaseDirectory, "build", "MyLib.nupkg");
+            var requests = new[]
+            {
+                new TaskItem(Path.Combine(AppContext.BaseDirectory, "build", "ZZApp.vsix"),
+                    new Hashtable
+                    {
+                        ["IsContainer"] = "true",
+                        ["Certificate"] = "Cert4",
+                    }),
+                new TaskItem(nupkgPath,
+                    new Hashtable
+                    {
+                        ["IsContainer"] = "true",
+                        ["Type"] = "zip",
+                    }),
+                new TaskItem("lib/netstandard2.0/MyLib.dll",
+                    new Hashtable
+                    {
+                        ["Container"] = nupkgPath,
+                        ["Certificate"] = "Cert1",
+                        ["StrongName"] = "Key1",
+                    }),
+                new TaskItem(Path.Combine(AppContext.BaseDirectory, "build", "MyLib.dll"),
+                    new Hashtable
+                    {
+                        ["Certificate"] = "Cert1",
+                    }),
+            };
+
+            var exclusions = new[]
+            {
+                new TaskItem("lib/NotMyLib.dll",
+                    new Hashtable
+                    {
+                        ["Container"] = nupkgPath,
+                    })
+            };
+
+            var task = new GenerateSignRequests
+            {
+                Requests = requests,
+                BasePath = AppContext.BaseDirectory,
+                Exclusions = exclusions,
+                BuildEngine = new MockEngine(_output),
+            };
+
+            var sb = new StringBuilder();
+
+            Assert.True(task.Execute(() => new StringWriter(sb)), "Task should pass");
+
+            var expected = $@"<SignRequests>
+  <File Path=`build/MyLib.dll` Certificate=`Cert1` />
+  <Container Path=`build/MyLib.nupkg` Type=`zip`>
+    <ExcludedFile Path=`lib/NotMyLib.dll` />
+    <File Path=`lib/netstandard2.0/MyLib.dll` Certificate=`Cert1` StrongName=`Key1` />
+  </Container>
+  <Container Path=`build/ZZApp.vsix` Type=`vsix` Certificate=`Cert4` />
+</SignRequests>".Replace('`', '"');
+            _output.WriteLine(sb.ToString());
+
+            Assert.Equal(expected, sb.ToString(), ignoreLineEndingDifferences: true, ignoreWhiteSpaceDifferences: true);
+        }
+    }
+}

--- a/test/KoreBuild.Tasks.Tests/GenerateSignRequestsTests.cs
+++ b/test/KoreBuild.Tasks.Tests/GenerateSignRequestsTests.cs
@@ -39,10 +39,11 @@ namespace KoreBuild.Tasks.Tests
                         ["IsContainer"] = "true",
                         ["Type"] = "zip",
                     }),
-                new TaskItem("lib/netstandard2.0/MyLib.dll",
+                new TaskItem(Path.Combine(AppContext.BaseDirectory, "MyLib.dll"),
                     new Hashtable
                     {
                         ["Container"] = nupkgPath,
+                        ["PackagePath"] = "lib/netstandard2.0/MyLib.dll",
                         ["Certificate"] = "Cert1",
                         ["StrongName"] = "Key1",
                     }),
@@ -55,9 +56,10 @@ namespace KoreBuild.Tasks.Tests
 
             var exclusions = new[]
             {
-                new TaskItem("lib/NotMyLib.dll",
+                new TaskItem(Path.Combine(AppContext.BaseDirectory, "NotMyLib.dll"),
                     new Hashtable
                     {
+                        ["PackagePath"] = "lib/NotMyLib.dll",
                         ["Container"] = nupkgPath,
                     })
             };

--- a/test/KoreBuild.Tasks.Tests/GenerateSignRequestsTests.cs
+++ b/test/KoreBuild.Tasks.Tests/GenerateSignRequestsTests.cs
@@ -12,11 +12,11 @@ using Xunit.Abstractions;
 
 namespace KoreBuild.Tasks.Tests
 {
-    public class GenerateSignRequestsTests
+    public class GenerateSignRequestTests
     {
         private readonly ITestOutputHelper _output;
 
-        public GenerateSignRequestsTests(ITestOutputHelper output)
+        public GenerateSignRequestTests(ITestOutputHelper output)
         {
             _output = output;
         }
@@ -64,7 +64,7 @@ namespace KoreBuild.Tasks.Tests
                     })
             };
 
-            var task = new GenerateSignRequests
+            var task = new GenerateSignRequest
             {
                 Requests = requests,
                 BasePath = AppContext.BaseDirectory,
@@ -76,14 +76,14 @@ namespace KoreBuild.Tasks.Tests
 
             Assert.True(task.Execute(() => new StringWriter(sb)), "Task should pass");
 
-            var expected = $@"<SignRequests>
+            var expected = $@"<SignRequest>
   <File Path=`build/MyLib.dll` Certificate=`Cert1` />
   <Container Path=`build/MyLib.nupkg` Type=`zip`>
     <ExcludedFile Path=`lib/NotMyLib.dll` />
     <File Path=`lib/netstandard2.0/MyLib.dll` Certificate=`Cert1` StrongName=`Key1` />
   </Container>
   <Container Path=`build/ZZApp.vsix` Type=`vsix` Certificate=`Cert4` />
-</SignRequests>".Replace('`', '"');
+</SignRequest>".Replace('`', '"');
             _output.WriteLine(sb.ToString());
 
             Assert.Equal(expected, sb.ToString(), ignoreLineEndingDifferences: true, ignoreWhiteSpaceDifferences: true);

--- a/testassets/SimpleRepo/NuGetPackageVerifier.json
+++ b/testassets/SimpleRepo/NuGetPackageVerifier.json
@@ -1,7 +1,8 @@
 {
  "Default": {
     "rules": [
-      "AssemblyHasVersionAttributesRule"
+      "AssemblyHasVersionAttributesRule",
+      "DotNetToolPackageRule"
     ]
   }
 }

--- a/testassets/SimpleRepo/SimpleRepo.sln
+++ b/testassets/SimpleRepo/SimpleRepo.sln
@@ -18,6 +18,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{62B6BEE6
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RepoTasks", "build\tasks\RepoTasks.csproj", "{D1516754-5270-4CE4-A0AB-78C75597B9D2}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Simple.CliTool", "src\Simple.CliTool\Simple.CliTool.csproj", "{3A9BFE78-61C5-4BBD-91D5-FF2E4E62FD11}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -38,6 +40,10 @@ Global
 		{55E328F5-C2BF-42FF-B70C-8EF6B1502965}.Release|Any CPU.Build.0 = Release|Any CPU
 		{D1516754-5270-4CE4-A0AB-78C75597B9D2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{D1516754-5270-4CE4-A0AB-78C75597B9D2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3A9BFE78-61C5-4BBD-91D5-FF2E4E62FD11}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3A9BFE78-61C5-4BBD-91D5-FF2E4E62FD11}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3A9BFE78-61C5-4BBD-91D5-FF2E4E62FD11}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3A9BFE78-61C5-4BBD-91D5-FF2E4E62FD11}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -47,6 +53,7 @@ Global
 		{D25A24B5-FA41-4135-9531-6A2B70802B4E} = {7EAECC98-54A5-441F-8850-7C822DD23D82}
 		{55E328F5-C2BF-42FF-B70C-8EF6B1502965} = {479F5095-6D24-4C00-9E9E-32A41F71755C}
 		{D1516754-5270-4CE4-A0AB-78C75597B9D2} = {62B6BEE6-38CF-4708-80F4-DB0C100663F3}
+		{3A9BFE78-61C5-4BBD-91D5-FF2E4E62FD11} = {7EAECC98-54A5-441F-8850-7C822DD23D82}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {FEFB375B-9984-43FE-872B-A867AE42FDDA}

--- a/testassets/SimpleRepo/build/dependencies.props
+++ b/testassets/SimpleRepo/build/dependencies.props
@@ -4,7 +4,8 @@
   </PropertyGroup>
   <PropertyGroup Label="Package Versions">
     <InternalAspNetCoreSdkPackageVersion>0.0.1</InternalAspNetCoreSdkPackageVersion>
-    <MicrosoftNETTestSdkPackageVersion>15.3.0</MicrosoftNETTestSdkPackageVersion>
+    <NewtonsoftJsonPackageVersion>10.0.1</NewtonsoftJsonPackageVersion>
+    <MicrosoftNETTestSdkPackageVersion>15.5.0</MicrosoftNETTestSdkPackageVersion>
     <XunitPackageVersion>2.3.1</XunitPackageVersion>
     <XunitRunnerVisualStudioPackageVersion>2.3.1</XunitRunnerVisualStudioPackageVersion>
   </PropertyGroup>

--- a/testassets/SimpleRepo/src/Directory.Build.targets
+++ b/testassets/SimpleRepo/src/Directory.Build.targets
@@ -1,0 +1,12 @@
+<Project>
+  <Import Project="..\Directory.Build.targets" />
+  <Target Name="PackGlobalTool" Condition="'$(PackageType)' == 'DotnetTool'" BeforeTargets="GenerateNuspec" DependsOnTargets="Publish">
+    <PropertyGroup>
+      <NuspecProperties>
+        publishDir=$(PublishDir);
+        version=$(PackageVersion);
+        targetframework=$(TargetFramework);
+      </NuspecProperties>
+    </PropertyGroup>
+  </Target>
+</Project>

--- a/testassets/SimpleRepo/src/Simple.CliTool/DotnetToolSettings.xml
+++ b/testassets/SimpleRepo/src/Simple.CliTool/DotnetToolSettings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<DotNetCliTool>
+  <Commands>
+    <Command Name="cowsay" EntryPoint="cowsay.dll" Runner="dotnet" />
+  </Commands>
+</DotNetCliTool>

--- a/testassets/SimpleRepo/src/Simple.CliTool/Program.cs
+++ b/testassets/SimpleRepo/src/Simple.CliTool/Program.cs
@@ -1,0 +1,15 @@
+using static System.Console;
+
+class Program
+{
+    public static void Main(string[] args)
+        => WriteLine(@"
+ ______
+( Moo! )
+ ------
+        \   ^__^
+         \  (oo)\_______
+            (__)\       )\/\
+                ||----w |
+                ||     ||");
+}

--- a/testassets/SimpleRepo/src/Simple.CliTool/Simple.CliTool.csproj
+++ b/testassets/SimpleRepo/src/Simple.CliTool/Simple.CliTool.csproj
@@ -6,8 +6,8 @@
     <PackageType>DotnetTool</PackageType>
     <AssemblyName>cowsay</AssemblyName>
     <PackageId>Simple.CliTool</PackageId>
-    <AssemblySigningCert>TestCert</AssemblySigningCert>
-    <PackageSigningCert></PackageSigningCert>
+    <AssemblySigningCertName>TestCert</AssemblySigningCertName>
+    <PackageSigningCertName></PackageSigningCertName>
     <NuspecFile>$(MSBuildProjectName).nuspec</NuspecFile>
   </PropertyGroup>
 
@@ -15,7 +15,7 @@
     <PackageReference Include="Newtonsoft.Json" PrivateAssets="All" Version="$(NewtonsoftJsonPackageVersion)" />
 
     <!-- Required to specify manually when using nuspec. -->
-    <SignedPackageFile Include="$(TargetPath)" Certificate="$(AssemblySigningCert)" Visible="false">
+    <SignedPackageFile Include="$(TargetPath)" Certificate="$(AssemblySigningCertName)" Visible="false">
       <PackagePath>tools/$(TargetFramework)/any/$(TargetFileName)</PackagePath>
     </SignedPackageFile>
 

--- a/testassets/SimpleRepo/src/Simple.CliTool/Simple.CliTool.csproj
+++ b/testassets/SimpleRepo/src/Simple.CliTool/Simple.CliTool.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <OutputType>exe</OutputType>
+    <PackageType>DotnetTool</PackageType>
+    <AssemblyName>cowsay</AssemblyName>
+    <PackageId>Simple.CliTool</PackageId>
+    <AssemblySigningCert>TestCert</AssemblySigningCert>
+    <PackageSigningCert></PackageSigningCert>
+    <NuspecFile>$(MSBuildProjectName).nuspec</NuspecFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" PrivateAssets="All" Version="$(NewtonsoftJsonPackageVersion)" />
+
+    <!-- Required to specify manually when using nuspec. -->
+    <SignedPackageFile Include="$(TargetPath)" Certificate="$(AssemblySigningCert)" Visible="false">
+      <PackagePath>tools/$(TargetFramework)/any/$(TargetFileName)</PackagePath>
+    </SignedPackageFile>
+
+    <SignedPackageFile Include="$(PublishDir)Newtonsoft.Json.dll" Certificate="Test3rdPartyCert" Visible="false">
+      <PackagePath>tools/$(TargetFramework)/any/Newtonsoft.Json.dll</PackagePath>
+    </SignedPackageFile>
+  </ItemGroup>
+
+</Project>

--- a/testassets/SimpleRepo/src/Simple.CliTool/Simple.CliTool.nuspec
+++ b/testassets/SimpleRepo/src/Simple.CliTool/Simple.CliTool.nuspec
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
+  <metadata>
+    <id>Simple.CliTool</id>
+    <version>$version$</version>
+    <authors>Microsoft</authors>
+    <description>Test</description>
+    <packageTypes>
+      <packageType name="DotnetTool" />
+    </packageTypes>
+    <dependencies />
+  </metadata>
+  <files>
+    <file src="$publishdir$" target="tools/$targetframework$/any/" />
+    <file src="DotnetToolSettings.xml" target="tools/DotnetToolSettings.xml" />
+  </files>
+</package>

--- a/testassets/SimpleRepo/src/Simple.Lib/Simple.Lib.csproj
+++ b/testassets/SimpleRepo/src/Simple.Lib/Simple.Lib.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <AssemblySigningCert>TestCert</AssemblySigningCert>
   </PropertyGroup>
 
   <ItemGroup>

--- a/testassets/SimpleRepo/src/Simple.Lib/Simple.Lib.csproj
+++ b/testassets/SimpleRepo/src/Simple.Lib/Simple.Lib.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
-    <AssemblySigningCert>TestCert</AssemblySigningCert>
+    <AssemblySigningCertName>TestCert</AssemblySigningCertName>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Add tasks to generate a signing request from MSBuild projects. This will help us decouple to our authenticode signing infrastructure from the layout of artifacts and assemblies on disk.

Read the  docs/Signing.md for details on the file format and how to configure this in csproj files.