### PR TITLE
Support SkipTests and NoBuild properties in the default lifecycle

### DIFF
--- a/files/KoreBuild/KoreBuild.Common.props
+++ b/files/KoreBuild/KoreBuild.Common.props
@@ -10,8 +10,9 @@ Standard lifecycle chain.
     <RestoreDependsOn>Prepare</RestoreDependsOn>
     <CompileDependsOn>Restore</CompileDependsOn>
     <PackageDependsOn>Compile</PackageDependsOn>
-    <TestDependsOn>Package</TestDependsOn>
-    <VerifyDependsOn>Test</VerifyDependsOn>
+    <TestDependsOn Condition=" '$(NoBuild)' != 'true' ">Package</TestDependsOn>
+    <VerifyDependsOn Condition=" '$(SkipTests)' == 'true' ">Package</VerifyDependsOn>
+    <VerifyDependsOn Condition=" '$(SkipTests)' != 'true' ">Test</VerifyDependsOn>
     <BuildDependsOn>Verify</BuildDependsOn>
 
     <CleanDependsOn></CleanDependsOn>


### PR DESCRIPTION
Usage:

Build without tests:
```
build.cmd /p:SkipTests=true
```

Test without building
```
build.cmd /t:Test /p:NoBuild=true
```