### PR TITLE
Verify sign requests

### DIFF
--- a/BuildTools.sln
+++ b/BuildTools.sln
@@ -92,6 +92,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ApiCheckForwardDestination"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Internal.AspNetCore.SiteExtension.Sdk", "src\Internal.AspNetCore.SiteExtension.Sdk\Internal.AspNetCore.SiteExtension.Sdk.csproj", "{418F99A5-5EC4-4895-B8EB-7F8BBA241DB2}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NuGetPackageVerifier.Tests", "test\NuGetPackageVerifier.Tests\NuGetPackageVerifier.Tests.csproj", "{439CC7A3-F6E6-46B8-B6A0-05E22E558FC2}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -166,6 +168,10 @@ Global
 		{418F99A5-5EC4-4895-B8EB-7F8BBA241DB2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{418F99A5-5EC4-4895-B8EB-7F8BBA241DB2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{418F99A5-5EC4-4895-B8EB-7F8BBA241DB2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{439CC7A3-F6E6-46B8-B6A0-05E22E558FC2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{439CC7A3-F6E6-46B8-B6A0-05E22E558FC2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{439CC7A3-F6E6-46B8-B6A0-05E22E558FC2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{439CC7A3-F6E6-46B8-B6A0-05E22E558FC2}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -189,6 +195,7 @@ Global
 		{85C30B96-BCEA-4C9C-99AA-6DAEB448EEF3} = {BD3545FB-5520-43DF-B4F9-83BEA3A38ECA}
 		{605F0478-A9D2-4A8A-BB38-9D5DC132FBB5} = {60A938B2-D95A-403C-AA7A-3683AD64DFA0}
 		{418F99A5-5EC4-4895-B8EB-7F8BBA241DB2} = {A4F4353B-C3D2-40B0-909A-5B48A748EA76}
+		{439CC7A3-F6E6-46B8-B6A0-05E22E558FC2} = {60A938B2-D95A-403C-AA7A-3683AD64DFA0}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {1B8809C8-A6C3-4761-BC91-B12841F49AE1}

--- a/files/KoreBuild/KoreBuild.Common.targets
+++ b/files/KoreBuild/KoreBuild.Common.targets
@@ -54,5 +54,4 @@ extending the *DependsOn property
 
   <!-- For external analysis of inputs/outputs. -->
   <Target Name="GetArtifactInfo" DependsOnTargets="$(GetArtifactInfoDependsOn)" Returns="@(ArtifactInfo)" />
-
 </Project>

--- a/files/KoreBuild/modules/sharedsources/module.targets
+++ b/files/KoreBuild/modules/sharedsources/module.targets
@@ -27,7 +27,8 @@ that matches "$(RepositoryRoot)/shared/*.Sources".
       Condition="@(SharedSourceDirectories->Count()) != 0"
       BuildInParallel="true">
       <Output TaskParameter="TargetOutputs" ItemName="ArtifactInfo" />
-      <Output TaskParameter="TargetOutputs" ItemName="ExcludeFromSigning" Condition="'$(SignSourcesPackages)' != 'true'" />
+      <Output TaskParameter="TargetOutputs" ItemName="FilesToExcludeFromSigning" Condition="'$(SignSourcesPackages)' != 'true'" />
+      <Output TaskParameter="TargetOutputs" ItemName="FilesToSign" Condition="'$(SignSourcesPackages)' == 'true'" />
     </MSBuild>
   </Target>
 

--- a/files/KoreBuild/modules/sharedsources/sharedsources.csproj
+++ b/files/KoreBuild/modules/sharedsources/sharedsources.csproj
@@ -69,6 +69,11 @@
         <Version>$(NormalizedPackageVersion)</Version>
         <TargetFramework>$(TargetFramework)</TargetFramework>
         <RepositoryRoot>$(RepositoryRoot)</RepositoryRoot>
+        <RepositoryUrl>$(RepositoryUrl)</RepositoryUrl>
+        <Category>$(PackageArtifactCategory)</Category>
+        <IsContainer>true</IsContainer>
+        <Certificate>$(PackageSigningCertName)</Certificate>
+        <ShouldBeSigned Condition=" '$(PackageSigningCertName)' != '' ">true</ShouldBeSigned>
       </ArtifactInfo>
     </ItemGroup>
   </Target>

--- a/files/KoreBuild/modules/solutionbuild/Project.Inspection.targets
+++ b/files/KoreBuild/modules/solutionbuild/Project.Inspection.targets
@@ -21,6 +21,7 @@
         <TargetFrameworks>$([MSBuild]::Escape($(TargetFrameworks)))</TargetFrameworks>
         <PackageType>$(PackageType)</PackageType>
         <RepositoryRoot>$(RepositoryRoot)</RepositoryRoot>
+        <RepositoryUrl>$(RepositoryUrl)</RepositoryUrl>
         <Category>$(PackageArtifactCategory)</Category>
         <Certificate>$(PackageSigningCertName)</Certificate>
         <ShouldBeSigned Condition="'$(PackageSigningCertName)' != '' OR @(SignedPackageFile->Count()) != 0 ">true</ShouldBeSigned>
@@ -36,6 +37,7 @@
         <SourceIncluded>$(IncludeSource)</SourceIncluded>
         <PackageType>$(PackageType)</PackageType>
         <RepositoryRoot>$(RepositoryRoot)</RepositoryRoot>
+        <RepositoryUrl>$(RepositoryUrl)</RepositoryUrl>
         <Category>$(PackageArtifactCategory)</Category>
         <Certificate>$(PackageSigningCertName)</Certificate>
         <ShouldBeSigned Condition="'$(PackageSigningCertName)' != '' OR @(SignedPackageFile->Count()) != 0 ">true</ShouldBeSigned>
@@ -47,19 +49,30 @@
         <Container>$(FullPackageOutputPath)</Container>
       </ArtifactInfo>
 
+      <ArtifactInfo Include="@(ExcludePackageFileFromSigning)">
+        <ShouldBeSigned>false</ShouldBeSigned>
+        <Container>$(FullPackageOutputPath)</Container>
+      </ArtifactInfo>
+
       <ArtifactInfo Include="@(SignedPackageFile)" Condition="'$(IncludeSymbols)' == 'true' AND '$(NuspecFile)' == ''">
         <ShouldBeSigned>true</ShouldBeSigned>
         <Container>$(SymbolsPackageOutputPath)</Container>
       </ArtifactInfo>
+
+      <ArtifactInfo Include="@(ExcludePackageFileFromSigning)" Condition="'$(IncludeSymbols)' == 'true' AND '$(NuspecFile)' == ''">
+        <ShouldBeSigned>false</ShouldBeSigned>
+        <Container>$(SymbolsPackageOutputPath)</Container>
+      </ArtifactInfo>
     </ItemGroup>
+
   </Target>
 
 <!--
 ####################################################################################
 Target: GetSignedPackageFiles
 
-Gets itesm for built assemblies that will be in the package.
-Also supports projects that explicitly set SignedPackageFile.
+Gets items for built assemblies that will be in the NuGet package.
+Also supports projects that explicitly set items in the SignedPackageFile group.
 
 Items:
 [out] SignedPackageFile

--- a/files/KoreBuild/modules/solutionbuild/module.targets
+++ b/files/KoreBuild/modules/solutionbuild/module.targets
@@ -159,10 +159,10 @@ Executes /t:Pack on all projects matching src/*/*.csproj.
       <ArtifactInfo Include="@(_Temp)" Condition="'%(_Temp.Container)' == ''" />
 
       <!-- Nupkgs or assemblies in the nupkg that should be signed -->
-      <FilesToSign Include="@(_Temp)" Condition=" '%(ArtifactInfo.ShouldBeSigned)' == 'true' " />
+      <FilesToSign Include="@(_Temp)" Condition=" '%(_Temp.ShouldBeSigned)' == 'true' " />
 
       <!-- Assemblies inside a nupkg that should not be signed -->
-      <FilesToExcludeFromSigning Include="@(_Temp)" Condition=" '%(ArtifactInfo.ShouldBeSigned)' == 'false' AND '%(_Temp.Container)' != ''" />
+      <FilesToExcludeFromSigning Include="@(_Temp)" Condition=" '%(_Temp.ShouldBeSigned)' == 'false' AND '%(_Temp.Container)' != ''" />
     </ItemGroup>
   </Target>
 

--- a/files/KoreBuild/modules/solutionbuild/module.targets
+++ b/files/KoreBuild/modules/solutionbuild/module.targets
@@ -155,8 +155,14 @@ Executes /t:Pack on all projects matching src/*/*.csproj.
     </MSBuild>
 
     <ItemGroup>
+      <!-- Output from this target may include items representing assemblies inside the nupkg. -->
       <ArtifactInfo Include="@(_Temp)" Condition="'%(_Temp.Container)' == ''" />
-      <Sign Include="@(_Temp)" Condition="'%(_Temp.Container)' != ''" />
+
+      <!-- Nupkgs or assemblies in the nupkg that should be signed -->
+      <FilesToSign Include="@(_Temp)" Condition=" '%(ArtifactInfo.ShouldBeSigned)' == 'true' " />
+
+      <!-- Assemblies inside a nupkg that should not be signed -->
+      <FilesToExcludeFromSigning Include="@(_Temp)" Condition=" '%(ArtifactInfo.ShouldBeSigned)' == 'false' AND '%(_Temp.Container)' != ''" />
     </ItemGroup>
   </Target>
 

--- a/modules/KoreBuild.Tasks/GenerateSignRequests.cs
+++ b/modules/KoreBuild.Tasks/GenerateSignRequests.cs
@@ -125,28 +125,31 @@ namespace KoreBuild.Tasks
                 }
             }
 
-            foreach (var item in Exclusions)
+            if (Exclusions != null)
             {
-                var normalizedPath = NormalizePath(BasePath, item.ItemSpec);
-
-                var containerPath = item.GetMetadata("Container");
-                if (!string.IsNullOrEmpty(containerPath))
+                foreach (var item in Exclusions)
                 {
-                    if (!containers.TryGetValue(containerPath, out var container))
+                    var normalizedPath = NormalizePath(BasePath, item.ItemSpec);
+
+                    var containerPath = item.GetMetadata("Container");
+                    if (!string.IsNullOrEmpty(containerPath))
                     {
-                        Log.LogError($"Exclusion item '{item.ItemSpec}' specifies an unknown container '{containerPath}'.");
-                        continue;
-                    }
+                        if (!containers.TryGetValue(containerPath, out var container))
+                        {
+                            Log.LogError($"Exclusion item '{item.ItemSpec}' specifies an unknown container '{containerPath}'.");
+                            continue;
+                        }
 
-                    var packagePath = item.GetMetadata("PackagePath");
-                    normalizedPath = string.IsNullOrEmpty(packagePath) ? normalizedPath : packagePath.Replace('\\', '/');
-                    var file = new SignRequestItem.Exclusion(normalizedPath);
-                    container.AddItem(file);
-                }
-                else
-                {
-                    var file = new SignRequestItem.Exclusion(normalizedPath);
-                    signRequestCollection.Add(file);
+                        var packagePath = item.GetMetadata("PackagePath");
+                        normalizedPath = string.IsNullOrEmpty(packagePath) ? normalizedPath : packagePath.Replace('\\', '/');
+                        var file = new SignRequestItem.Exclusion(normalizedPath);
+                        container.AddItem(file);
+                    }
+                    else
+                    {
+                        var file = new SignRequestItem.Exclusion(normalizedPath);
+                        signRequestCollection.Add(file);
+                    }
                 }
             }
 

--- a/modules/KoreBuild.Tasks/Internal/KoreBuildErrors.cs
+++ b/modules/KoreBuild.Tasks/Internal/KoreBuildErrors.cs
@@ -31,5 +31,6 @@ namespace KoreBuild.Tasks
         // not used in code, but reserved for MSBuild targets
         public const int ArtifactInfoMismatch = 5002;
         public const int FilesToSignMismatchedWithArtifactInfo = 5003;
+        public const int FilesToSignMissingCertInfo = 5004;
     }
 }

--- a/modules/KoreBuild.Tasks/Internal/KoreBuildErrors.cs
+++ b/modules/KoreBuild.Tasks/Internal/KoreBuildErrors.cs
@@ -30,5 +30,6 @@ namespace KoreBuild.Tasks
 
         // not used in code, but reserved for MSBuild targets
         public const int ArtifactInfoMismatch = 5002;
+        public const int FilesToSignMismatchedWithArtifactInfo = 5003;
     }
 }

--- a/modules/KoreBuild.Tasks/module.targets
+++ b/modules/KoreBuild.Tasks/module.targets
@@ -158,10 +158,13 @@ Verifies all artifact items have a corresponding sign item.
   <Target Name="VerifySignRequestItems"
           DependsOnTargets="GetArtifactInfo"
           Condition="'$(GenerateSignRequest)' == 'true' AND '$(SkipArtifactVerification)' != 'true'">
+
     <ItemGroup>
       <_ExpectedFileToSign Remove="@(_ExpectedFileToSign)" />
       <_ExpectedFileToSign Include="@(ArtifactInfo)" />
       <_ExpectedFileToSign Remove="@(FilesToSign);@(FilesToExcludeFromSigning);$(SignRequestOutputPath)" />
+      <_FilesToSignMissingConfig Remove="@(_FilesToSignMissingConfig)" />
+      <_FilesToSignMissingConfig Include="@(FilesToSign)" Condition=" '%(FilesToSign.Certificate)' == '' AND '%(FilesToSign.StrongName)' == '' AND '%(FilesToSign.IsContainer)' != 'true' " />
     </ItemGroup>
 
     <PropertyGroup>
@@ -175,6 +178,17 @@ Fix this error by adding these items to FilesToSign or FilesToExcludeFromSigning
     <Error Text="$(_SigningErrorMessage.Trim())"
            Code="KRB5003"
            Condition=" @(_ExpectedFileToSign->Count()) != 0 " />
+
+    <PropertyGroup>
+      <_SigningErrorMessage Condition=" @(_FilesToSignMissingConfig->Count()) != 0 ">
+The following FilesToSign did not specify a Certificate or StrongName to use.
+  - @(_FilesToSignMissingConfig, '%0A  - ')
+      </_SigningErrorMessage>
+    </PropertyGroup>
+
+    <Error Text="$(_SigningErrorMessage.Trim())"
+           Code="KRB5004"
+           Condition=" @(_FilesToSignMissingConfig->Count()) != 0 " />
   </Target>
 
 <!--

--- a/modules/KoreBuild.Tasks/module.targets
+++ b/modules/KoreBuild.Tasks/module.targets
@@ -150,33 +150,59 @@ and NodeJS.
 
 <!--
 ####################################################################################
+Target: VerifySignRequestItems
+
+Verifies all artifact items have a corresponding sign item.
+####################################################################################
+-->
+  <Target Name="VerifySignRequestItems"
+          DependsOnTargets="GetArtifactInfo"
+          Condition="'$(GenerateSignRequest)' == 'true' AND '$(SkipArtifactVerification)' != 'true'">
+    <ItemGroup>
+      <_ExpectedFileToSign Remove="@(_ExpectedFileToSign)" />
+      <_ExpectedFileToSign Include="@(ArtifactInfo)" />
+      <_ExpectedFileToSign Remove="@(FilesToSign);@(FilesToExcludeFromSigning);$(SignRequestOutputPath)" />
+    </ItemGroup>
+
+    <PropertyGroup>
+      <_SigningErrorMessage Condition=" @(_ExpectedFileToSign->Count()) != 0 ">
+Could not determine signing information for all ArtifactInfo items.
+Fix this error by adding these items to FilesToSign or FilesToExcludeFromSigning:
+  - @(_ExpectedFileToSign, '%0A  - ')
+      </_SigningErrorMessage>
+    </PropertyGroup>
+
+    <Error Text="$(_SigningErrorMessage.Trim())"
+           Code="KRB5003"
+           Condition=" @(_ExpectedFileToSign->Count()) != 0 " />
+  </Target>
+
+<!--
+####################################################################################
 Target: GenerateSignRequest
 
 Generates a manifest that contains signin requests for files.
 
-[in] (items) ArtifactInfo
-[in] (items) Sign
-[in] (prop) Artifacts
+[in] (items) FilesToSign
+[in] (items) FilesToExcludeFromSigning
 
 [out] SignRequestOutputPath - the bom file
 ####################################################################################
 -->
+  <ItemGroup Condition=" '$(GenerateSignRequest)' == 'true' ">
+    <ArtifactInfo Include="$(SignRequestOutputPath)">
+      <ArtifactType>XmlFile</ArtifactType>
+      <Category>noship</Category>
+    </ArtifactInfo>
+  </ItemGroup>
+
   <Target Name="GenerateSignRequest"
-          DependsOnTargets="GetArtifactInfo"
+          DependsOnTargets="GetArtifactInfo;VerifySignRequestItems"
           Condition=" '$(GenerateSignRequest)' == 'true' ">
 
-    <ItemGroup>
-      <ArtifactInfo Include="$(SignRequestOutputPath)">
-        <ArtifactType>XmlFile</ArtifactType>
-        <Category>noship</Category>
-      </ArtifactInfo>
-
-      <Sign Include="@(ArtifactInfo)" Condition=" '%(ArtifactInfo.ShouldBeSigned)' == 'true' " />
-    </ItemGroup>
-
     <GenerateSignRequest
-      Requests="@(Sign)"
-      Exclusions="@(ExcludeFromSigning)"
+      Requests="@(FilesToSign)"
+      Exclusions="@(FilesToExcludeFromSigning)"
       BasePath="$(ArtifactsDir)"
       OutputPath="$(SignRequestOutputPath)" />
   </Target>

--- a/modules/NuGetPackageVerifier/console/CompositeRules/DefaultCompositeRule.cs
+++ b/modules/NuGetPackageVerifier/console/CompositeRules/DefaultCompositeRule.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
@@ -28,6 +28,7 @@ namespace NuGetPackageVerifier.Rules
             new PackageTypesRule(),
             new PackageVersionMatchesAssemblyVersionRule(),
             new BuildItemsRule(),
+            new SignRequestListsAllSignableFiles(),
         };
     }
 }

--- a/modules/NuGetPackageVerifier/console/Manifests/PackageSignRequest.cs
+++ b/modules/NuGetPackageVerifier/console/Manifests/PackageSignRequest.cs
@@ -1,0 +1,13 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace NuGetPackageVerifier.Manifests
+{
+    public class PackageSignRequest
+    {
+        public ISet<string> FilesExcludedFromSigning { get; set; }
+        public ISet<string> FilesToSign { get; set; }
+    }
+}

--- a/modules/NuGetPackageVerifier/console/Manifests/SignRequestManifest.cs
+++ b/modules/NuGetPackageVerifier/console/Manifests/SignRequestManifest.cs
@@ -1,0 +1,49 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace NuGetPackageVerifier.Manifests
+{
+    public class SignRequestManifest
+    {
+        /// <summary>
+        /// Represents all signing requests in the sign request manifest that are for nupkg files.
+        /// </summary>
+        public IReadOnlyDictionary<string, PackageSignRequest> PackageSignRequests { get; private set; }
+
+        public static SignRequestManifest Parse(string filePath)
+        {
+            var doc = XDocument.Load(filePath);
+            var requests = new Dictionary<string, PackageSignRequest>(StringComparer.OrdinalIgnoreCase);
+            var manifest = new SignRequestManifest { PackageSignRequests = requests };
+
+            var nupkgContainers = doc.Root
+                .Elements("Container")
+                .Where(c => "nupkg".Equals(c.Attribute("Type")?.Value, StringComparison.Ordinal));
+
+            var manifestDir = Path.GetDirectoryName(filePath);
+
+            foreach (var container in nupkgContainers)
+            {
+                var request = new PackageSignRequest
+                {
+                    FilesToSign = container.Elements("File").Select(GetPath).ToHashSet(StringComparer.Ordinal),
+                    FilesExcludedFromSigning = container.Elements("ExcludedFile").Select(GetPath).ToHashSet(StringComparer.Ordinal),
+                };
+
+                var path = new FileInfo(Path.Combine(manifestDir, GetPath(container))).FullName;
+
+                requests.Add(path, request);
+            }
+
+            return manifest;
+        }
+
+        private static string GetPath(XElement element) => element.Attribute("Path")?.Value;
+    }
+}

--- a/modules/NuGetPackageVerifier/console/PackageAnalysisContext.cs
+++ b/modules/NuGetPackageVerifier/console/PackageAnalysisContext.cs
@@ -23,7 +23,7 @@ namespace NuGetPackageVerifier
 
         public IDictionary<string, AssemblyAttributesData> AssemblyData { get; } = new Dictionary<string, AssemblyAttributesData>();
 
-        public void Dispose()
+        public virtual void Dispose()
         {
             _reader?.Dispose();
         }

--- a/modules/NuGetPackageVerifier/console/PackageAnalysisContext.cs
+++ b/modules/NuGetPackageVerifier/console/PackageAnalysisContext.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using NuGet.Packaging;
 using NuGetPackageVerifier.Logging;
+using NuGetPackageVerifier.Manifests;
 
 namespace NuGetPackageVerifier
 {
@@ -14,6 +15,7 @@ namespace NuGetPackageVerifier
         private PackageArchiveReader _reader;
 
         public FileInfo PackageFileInfo { get; set; }
+        public PackageSignRequest SignRequest { get; set; }
         public IPackageMetadata Metadata { get; set; }
         public PackageVerifierOptions Options { get; set; }
         public IPackageVerifierLogger Logger { get; set; }

--- a/modules/NuGetPackageVerifier/console/PackageIssueFactory.cs
+++ b/modules/NuGetPackageVerifier/console/PackageIssueFactory.cs
@@ -37,6 +37,15 @@ namespace NuGetPackageVerifier
             );
         }
 
+        public static PackageVerifierIssue SignRequestMissingPackageFile(string id, string filePath)
+        {
+            return new PackageVerifierIssue(
+                "FILE_MISSING_FROM_SIGN_REQUEST",
+                filePath,
+                string.Format("The sign request for package {0} does not specify what to do with signable file {1}", id, filePath),
+                PackageIssueLevel.Error);
+        }
+
         public static PackageVerifierIssue PackageTypeMissing(string packageType)
         {
             return new PackageVerifierIssue(

--- a/modules/NuGetPackageVerifier/console/Rules/SignRequestListsAllSignableFiles.cs
+++ b/modules/NuGetPackageVerifier/console/Rules/SignRequestListsAllSignableFiles.cs
@@ -1,0 +1,47 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using NuGetPackageVerifier.Logging;
+
+namespace NuGetPackageVerifier.Rules
+{
+    public class SignRequestListsAllSignableFiles : IPackageVerifierRule
+    {
+        private static readonly HashSet<string> SignableExtensions = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ".dll",
+            ".exe",
+            ".ps1",
+            ".psd1",
+            ".psm1",
+            ".psc1",
+            ".ps1xml",
+        };
+
+        public IEnumerable<PackageVerifierIssue> Validate(PackageAnalysisContext context)
+        {
+            if (context.SignRequest == null)
+            {
+                context.Logger.Log(LogLevel.Info, "Skipping signing rule request verification for " + context.PackageFileInfo.FullName);
+                yield break;
+            }
+
+            foreach (var file in context.PackageReader.GetFiles())
+            {
+                var ext = Path.GetExtension(file);
+                if (!SignableExtensions.Contains(ext))
+                {
+                    continue;
+                }
+
+                if (!context.SignRequest.FilesToSign.Contains(file) && !context.SignRequest.FilesExcludedFromSigning.Contains(file))
+                {
+                    yield return PackageIssueFactory.SignRequestMissingPackageFile(context.Metadata.Id, file);
+                }
+            }
+        }
+    }
+}

--- a/modules/NuGetPackageVerifier/module.targets
+++ b/modules/NuGetPackageVerifier/module.targets
@@ -31,6 +31,7 @@ repository root.
 
     <VerifyPackages ArtifactDirectory="$(BuildDir)"
       RuleFile="$(NuGetVerifierRuleFile)"
+      SignRequestManifest="$(SignRequestOutputPath)"
       Condition="Exists('$(BuildDir)')" />
   </Target>
 

--- a/modules/NuGetPackageVerifier/module.targets
+++ b/modules/NuGetPackageVerifier/module.targets
@@ -25,13 +25,18 @@ repository root.
       <Packages Include="$(BuildDir)*.nupkg" />
     </ItemGroup>
 
+    <PropertyGroup>
+      <_VerifierSignRequestPath />
+      <_VerifierSignRequestPath Condition=" '$(GenerateSignRequest)' == 'true' ">$(SignRequestOutputPath)</_VerifierSignRequestPath>
+    </PropertyGroup>
+
     <Warning Text="No nupkg found in '$(BuildDir)'." Condition="$(Packages -> Count()) == 0" />
     <Warning Text="Skipping nuget package verification because artifacts directory could not be found"
       Condition="!Exists('$(BuildDir)')" />
 
     <VerifyPackages ArtifactDirectory="$(BuildDir)"
       RuleFile="$(NuGetVerifierRuleFile)"
-      SignRequestManifest="$(SignRequestOutputPath)"
+      SignRequestManifest="$(_VerifierSignRequestPath)"
       Condition="Exists('$(BuildDir)')" />
   </Target>
 

--- a/modules/NuGetPackageVerifier/msbuild/VerifyPackages.cs
+++ b/modules/NuGetPackageVerifier/msbuild/VerifyPackages.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
@@ -26,6 +26,8 @@ namespace NuGetPackagerVerifier
         public string ArtifactDirectory { get; set; }
 
         public string[] ExcludedRules { get; set; }
+
+        public string SignRequestManifest { get; set; }
 
         public override bool Execute()
         {
@@ -57,6 +59,12 @@ namespace NuGetPackagerVerifier
                 ArtifactDirectory,
             };
 
+            if (!string.IsNullOrEmpty(SignRequestManifest) && File.Exists(SignRequestManifest))
+            {
+                arguments.Add("--sign-request");
+                arguments.Add(SignRequestManifest);
+            }
+
             foreach (var rule in ExcludedRules ?? Enumerable.Empty<string>())
             {
                 arguments.Add("--excluded-rule");
@@ -69,7 +77,8 @@ namespace NuGetPackagerVerifier
                 Arguments = ArgumentEscaper.EscapeAndConcatenate(arguments),
             };
 
-            Log.LogMessage($"Executing '{psi.FileName} {psi.Arguments}'");
+            Log.LogCommandLine($"Executing '{psi.FileName} {psi.Arguments}'");
+
             var process = Process.Start(psi);
             process.WaitForExit();
             return process.ExitCode == 0;

--- a/modules/NuGetPackageVerifier/msbuild/VerifyPackages.cs
+++ b/modules/NuGetPackageVerifier/msbuild/VerifyPackages.cs
@@ -59,8 +59,14 @@ namespace NuGetPackagerVerifier
                 ArtifactDirectory,
             };
 
-            if (!string.IsNullOrEmpty(SignRequestManifest) && File.Exists(SignRequestManifest))
+            if (!string.IsNullOrEmpty(SignRequestManifest))
             {
+                if (!File.Exists(SignRequestManifest))
+                {
+                    Log.LogError($"SignRequestManifest file {SignRequestManifest} does not exist.");
+                    return false;
+                }
+
                 arguments.Add("--sign-request");
                 arguments.Add(SignRequestManifest);
             }

--- a/test/NuGetPackageVerifier.Tests/NuGetPackageVerifier.Tests.csproj
+++ b/test/NuGetPackageVerifier.Tests/NuGetPackageVerifier.Tests.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Moq" Version="$(MoqPackageVersion)" />
+    <PackageReference Include="xunit" Version="$(XunitPackageVersion)" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitRunnerVisualStudioPackageVersion)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\modules\NuGetPackageVerifier\console\NuGetPackageVerifier.Console.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/NuGetPackageVerifier.Tests/SignRequestListsAllSignableFilesRuleTests.cs
+++ b/test/NuGetPackageVerifier.Tests/SignRequestListsAllSignableFilesRuleTests.cs
@@ -1,0 +1,93 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using NuGetPackageVerifier.Rules;
+using NuGetPackageVerifier.Tests.Utilities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace NuGetPackageVerifier.Tests
+{
+    public class SignRequestListsAllSignableFilesRuleTests
+    {
+        private readonly ITestOutputHelper _output;
+
+        public SignRequestListsAllSignableFilesRuleTests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [Fact]
+        public void ItFailsWhenPackageContainsUnlistedFiles()
+        {
+            var signRequest = @"
+<SignRequest>
+    <Container Path=""TestPackage.1.0.0.nupkg"" Type=""nupkg"">
+    </Container>
+</SignRequest>";
+
+            var context = TestHelper.CreateAnalysisContext(_output,
+            new[] { "lib/netstandard2.0/Test.dll", "tools/MyScript.psd1" },
+            signRequest: signRequest);
+
+            var rule = new SignRequestListsAllSignableFiles();
+
+            var errors = rule.Validate(context);
+
+            Assert.NotEmpty(errors);
+
+            Assert.Contains(errors, e =>
+                e.Instance.Equals("lib/netstandard2.0/Test.dll", StringComparison.Ordinal)
+                && e.IssueId.Equals("FILE_MISSING_FROM_SIGN_REQUEST", StringComparison.Ordinal));
+
+            Assert.Contains(errors, e =>
+                e.Instance.Equals("tools/MyScript.psd1", StringComparison.Ordinal)
+                && e.IssueId.Equals("FILE_MISSING_FROM_SIGN_REQUEST", StringComparison.Ordinal));
+        }
+
+        [Fact]
+        public void DoesNotFailWhenSignRequestIncludesAllFiles()
+        {
+            var signRequest = @"
+<SignRequest>
+    <Container Path=""TestPackage.1.0.0.nupkg"" Type=""nupkg"">
+        <File Path=""lib/netstandard2.0/Test.dll"" />
+        <File Path=""tools/MyScript.psd1"" />
+    </Container>
+</SignRequest>";
+
+            var context = TestHelper.CreateAnalysisContext(_output,
+                new[] { "lib/netstandard2.0/Test.dll", "tools/MyScript.psd1" },
+                signRequest: signRequest);
+
+            var rule = new SignRequestListsAllSignableFiles();
+
+            var errors = rule.Validate(context);
+
+            Assert.Empty(errors);
+        }
+
+        [Fact]
+        public void DoesNotFailWhenSignRequestListsAllFiles()
+        {
+            var signRequest = @"
+<SignRequest>
+    <Container Path=""TestPackage.1.0.0.nupkg"" Type=""nupkg"">
+        <ExcludedFile Path=""lib/netstandard2.0/Test.dll"" />
+        <ExcludedFile Path=""tools/MyScript.psd1"" />
+    </Container>
+</SignRequest>";
+
+            var context = TestHelper.CreateAnalysisContext(_output,
+                 new[] { "lib/netstandard2.0/Test.dll", "tools/MyScript.psd1" },
+                signRequest: signRequest);
+
+            var rule = new SignRequestListsAllSignableFiles();
+
+            var errors = rule.Validate(context);
+
+            Assert.Empty(errors);
+        }
+    }
+}

--- a/test/NuGetPackageVerifier.Tests/TestLogger.cs
+++ b/test/NuGetPackageVerifier.Tests/TestLogger.cs
@@ -1,0 +1,23 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using NuGetPackageVerifier.Logging;
+using Xunit.Abstractions;
+
+namespace NuGetPackageVerifier.Tests.Utilities
+{
+    internal class TestLogger : IPackageVerifierLogger
+    {
+        private ITestOutputHelper _output;
+
+        public TestLogger(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        public void Log(LogLevel logLevel, string message)
+        {
+            _output.WriteLine($"{logLevel}: {message}");
+        }
+    }
+}

--- a/test/NuGetPackageVerifier.Tests/Utilities/TestHelper.cs
+++ b/test/NuGetPackageVerifier.Tests/Utilities/TestHelper.cs
@@ -1,0 +1,87 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using NuGet.Packaging;
+using NuGet.Versioning;
+using NuGetPackageVerifier.Manifests;
+using Xunit.Abstractions;
+
+namespace NuGetPackageVerifier.Tests.Utilities
+{
+    public class TestHelper
+    {
+        public static PackageAnalysisContext CreateAnalysisContext(ITestOutputHelper output, string[] emptyFiles, string version = "1.0.0", string signRequest = null)
+        {
+            const string packageId = "TestPackage";
+            var basePath = Path.Combine(AppContext.BaseDirectory, Path.GetRandomFileName());
+            var nupkgFileName = $"{packageId}.{version}.nupkg";
+            var nupkgPath = Path.Combine(basePath, nupkgFileName);
+
+            Directory.CreateDirectory(basePath);
+
+
+            var builder = new PackageBuilder();
+
+            builder.Populate(new ManifestMetadata
+            {
+                Id = packageId,
+                Version = new NuGetVersion(version),
+                Authors = new[] { "Test" },
+                Description = "Test",
+            });
+
+            using (var nupkg = File.Create(nupkgPath))
+            {
+
+                foreach (var dest in emptyFiles)
+                {
+                    var fileName = Path.GetFileName(dest);
+                    File.WriteAllText(Path.Combine(basePath, fileName), "");
+                    builder.AddFiles(basePath, fileName, dest);
+                }
+
+                builder.Save(nupkg);
+            }
+
+            PackageSignRequest packageSignRequest = null;
+
+            if (signRequest != null)
+            {
+                var reader = new StringReader(signRequest);
+                var signManifest = SignRequestManifest.Parse(reader, basePath);
+                packageSignRequest = signManifest.PackageSignRequests[nupkgPath];
+            }
+
+            var context = new TempPackageAnalysisContext(basePath)
+            {
+                Logger = new TestLogger(output),
+                PackageFileInfo = new FileInfo(nupkgPath),
+                SignRequest = packageSignRequest,
+                Metadata = builder,
+            };
+
+            return context;
+        }
+
+        private class TempPackageAnalysisContext : PackageAnalysisContext
+        {
+            private string _tempPath;
+
+            public TempPackageAnalysisContext(string tempPath)
+            {
+                this._tempPath = tempPath;
+            }
+
+            public override void Dispose()
+            {
+                base.Dispose();
+                if (Directory.Exists(_tempPath))
+                {
+                    Directory.Delete(_tempPath, recursive: true);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Ensure every artifact info has a matching FilesToSign or FilesToExcludeFromSigning item
- Add a NuGet package verifier rule to ensure all files in a nupkg are accouned for in the sign request

This was primary added for DotnetTool packages which contain a mix of third-party, partner-team, and our own assemblies.


Verified this rule by running it on https://github.com/aspnet/DotNetTools/pull/370. Before adding https://github.com/aspnet/DotNetTools/pull/370/commits/e7a2f7ede277bd37481494524824d494d68d9ccd, the verifier correctly failed with
```
ERROR: FILE_MISSING_FROM_SIGN_REQUEST @ tools/netcoreapp2.1/any/Microsoft.Extensions.Configuration.Abstractions.dll: The sign request for package dotnet-user-secrets does not specify what to do with signable file tools/netcoreapp2.1/any/Microsoft.Extensions.Configuration.Abstractions.dll
ERROR: FILE_MISSING_FROM_SIGN_REQUEST @ tools/netcoreapp2.1/any/Microsoft.Extensions.Configuration.dll: The sign request for package dotnet-user-secrets does not specify what to do with signable file tools/netcoreapp2.1/any/Microsoft.Extensions.Configuration.dll
ERROR: FILE_MISSING_FROM_SIGN_REQUEST @ tools/netcoreapp2.1/any/Microsoft.Extensions.Configuration.FileExtensions.dll: The sign request for package dotnet-user-secrets does not specify what to do with signable file tools/netcoreapp2.1/any/Microsoft.Extensions.Configuration.FileExtensions.dll
ERROR: FILE_MISSING_FROM_SIGN_REQUEST @ tools/netcoreapp2.1/any/Microsoft.Extensions.Configuration.Json.dll: The sign request for package dotnet-user-secrets does not specify what to do with signable file tools/netcoreapp2.1/any/Microsoft.Extensions.Configuration.Json.dll
ERROR: FILE_MISSING_FROM_SIGN_REQUEST @ tools/netcoreapp2.1/any/Microsoft.Extensions.Configuration.UserSecrets.dll: The sign request for package dotnet-user-secrets does not specify what to do with signable file tools/netcoreapp2.1/any/Microsoft.Extensions.Configuration.UserSecrets.dll
ERROR: FILE_MISSING_FROM_SIGN_REQUEST @ tools/netcoreapp2.1/any/Microsoft.Extensions.FileProviders.Abstractions.dll: The sign request for package dotnet-user-secrets does not specify what to do with signable file tools/netcoreapp2.1/any/Microsoft.Extensions.FileProviders.Abstractions.dll
ERROR: FILE_MISSING_FROM_SIGN_REQUEST @ tools/netcoreapp2.1/any/Microsoft.Extensions.FileProviders.Physical.dll: The sign request for package dotnet-user-secrets does not specify what to do with signable file tools/netcoreapp2.1/any/Microsoft.Extensions.FileProviders.Physical.dll
ERROR: FILE_MISSING_FROM_SIGN_REQUEST @ tools/netcoreapp2.1/any/Microsoft.Extensions.FileSystemGlobbing.dll: The sign request for package dotnet-user-secrets does not specify what to do with signable file tools/netcoreapp2.1/any/Microsoft.Extensions.FileSystemGlobbing.dll
ERROR: FILE_MISSING_FROM_SIGN_REQUEST @ tools/netcoreapp2.1/any/Microsoft.Extensions.Primitives.dll: The sign request for package dotnet-user-secrets does not specify what to do with signable file tools/netcoreapp2.1/any/Microsoft.Extensions.Primitives.dll
```

Adding https://github.com/aspnet/DotNetTools/pull/370/commits/e7a2f7ede277bd37481494524824d494d68d9ccd to the project looks like this:
```xml
    <!-- Files that come from other ASP.NET Core projects -->
    <SignedPackageFile Include="$(PublishDir)Microsoft.Extensions.Configuration.Abstractions.dll" Certificate="$(AssemblySigningCertName)" PackagePath="$(PackageBasePath)Microsoft.Extensions.Configuration.Abstractions.dll" />
    <SignedPackageFile Include="$(PublishDir)Microsoft.Extensions.Configuration.dll" Certificate="$(AssemblySigningCertName)" PackagePath="$(PackageBasePath)Microsoft.Extensions.Configuration.dll" />
    <SignedPackageFile Include="$(PublishDir)Microsoft.Extensions.Configuration.FileExtensions.dll" Certificate="$(AssemblySigningCertName)" PackagePath="$(PackageBasePath)Microsoft.Extensions.Configuration.FileExtensions.dll" />
    <SignedPackageFile Include="$(PublishDir)Microsoft.Extensions.Configuration.Json.dll" Certificate="$(AssemblySigningCertName)" PackagePath="$(PackageBasePath)Microsoft.Extensions.Configuration.Json.dll" />
    <SignedPackageFile Include="$(PublishDir)Microsoft.Extensions.Configuration.UserSecrets.dll" Certificate="$(AssemblySigningCertName)" PackagePath="$(PackageBasePath)Microsoft.Extensions.Configuration.UserSecrets.dll" />
    <SignedPackageFile Include="$(PublishDir)Microsoft.Extensions.FileProviders.Abstractions.dll" Certificate="$(AssemblySigningCertName)" PackagePath="$(PackageBasePath)Microsoft.Extensions.FileProviders.Abstractions.dll" />
    <SignedPackageFile Include="$(PublishDir)Microsoft.Extensions.FileProviders.Physical.dll" Certificate="$(AssemblySigningCertName)" PackagePath="$(PackageBasePath)Microsoft.Extensions.FileProviders.Physical.dll" />
    <SignedPackageFile Include="$(PublishDir)Microsoft.Extensions.FileSystemGlobbing.dll" Certificate="$(AssemblySigningCertName)" PackagePath="$(PackageBasePath)Microsoft.Extensions.FileSystemGlobbing.dll" />
    <SignedPackageFile Include="$(PublishDir)Microsoft.Extensions.Primitives.dll" Certificate="$(AssemblySigningCertName)" PackagePath="$(PackageBasePath)Microsoft.Extensions.Primitives.dll" />

    <!-- Third-party cert -->
    <SignedPackageFile Include="$(PublishDir)Newtonsoft.Json.dll" Certificate="3PartyDual" PackagePath="$(PackageBasePath)Newtonsoft.Json.dll" />

    <!-- This should already be signed by the dotnet-core team -->
    <ExcludePackageFileFromSigning Include="$(PublishDir)System.Runtime.CompilerServices.Unsafe.dll" PackagePath="$(PackageBasePath)System.Runtime.CompilerServices.Unsafe.dll" />
```
