### PR TITLE
Enhance nuspec to support adding files and setting include/exclude flags

### DIFF
--- a/modules/KoreBuild.Tasks/Internal/KoreBuildErrors.cs
+++ b/modules/KoreBuild.Tasks/Internal/KoreBuildErrors.cs
@@ -10,6 +10,8 @@ namespace KoreBuild.Tasks
 
         // NuGet errors
         public const int InvalidNuspecFile = 4001;
+        public const int NuspecMissingFilesNode = 4011;
+        public const int InvalidPackagePathMetadata = 4012;
 
         // Other errors
         public const int MissingArtifactType = 5001;

--- a/modules/KoreBuild.Tasks/PackNuSpec.cs
+++ b/modules/KoreBuild.Tasks/PackNuSpec.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Microsoft.AspNetCore.BuildTools;
@@ -65,7 +64,7 @@ namespace KoreBuild.Tasks
         public bool Overwrite { get; set; } = false;
 
         /// <summary>
-        /// The nuspec files created
+        /// The nupkg files created
         /// </summary>
         [Output]
         public ITaskItem[] Packages { get; set; }
@@ -180,7 +179,14 @@ namespace KoreBuild.Tasks
                     Log.LogError($"Dependency {d.ItemSpec} is missing expected metdata: Version");
                 }
 
-                return new { tfm, dependency = new PackageDependency(d.ItemSpec, VersionRange.Parse(d.GetMetadata("Version"))) };
+                return new
+                {
+                    tfm,
+                    dependency = new PackageDependency(d.ItemSpec,
+                        VersionRange.Parse(d.GetMetadata("Version")),
+                        d.GetMetadata("IncludeAssets").Split(';').Select(s => s.Trim()).ToArray(),
+                        d.GetMetadata("ExcludeAssets").Split(';').Select(s => s.Trim()).ToArray())
+                };
             });
 
             foreach (var group in packageRequest.GroupBy(g => g.tfm))

--- a/test.ps1
+++ b/test.ps1
@@ -2,8 +2,8 @@
 #requires -version 4
 [CmdletBinding(PositionalBinding = $true)]
 param(
-    [Parameter(Mandatory = $true)]
-    [string]$Command,
+    [Parameter]
+    [string]$Command = 'default-build',
     [Parameter(Mandatory = $true)]
     [string]$RepoPath,
     [switch]$NoBuild = $false,

--- a/test/KoreBuild.Tasks.Tests/PackNuSpecTests.cs
+++ b/test/KoreBuild.Tasks.Tests/PackNuSpecTests.cs
@@ -3,9 +3,11 @@
 
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using BuildTools.Tasks.Tests;
+using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using NuGet.Frameworks;
 using NuGet.Packaging;
@@ -85,7 +87,11 @@ namespace KoreBuild.Tasks.Tests
                     <authors>Microsoft</authors>
                     <description>$description$</description>
                     <copyright>$copyright$</copyright>
+                    <dependencies>
+                      <dependency id=`somepackage` version=`1.0.0` />
+                    </dependencies>
                   </metadata>
+                  <files />
                 </package>
                 ");
 
@@ -128,6 +134,7 @@ namespace KoreBuild.Tasks.Tests
                         <dependency id=`AlreadyInNuspec` version=`[2.0.0]` />
                     </dependencies>
                   </metadata>
+                  <files />
                 </package>
                 ");
 
@@ -164,6 +171,120 @@ namespace KoreBuild.Tasks.Tests
         }
 
         [Fact]
+        public void WarnIfMissingFilesNodes()
+        {
+            var nuspec = CreateNuspec(@"
+                <?xml version=`1.0` encoding=`utf-8`?>
+                <package xmlns=`http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd`>
+                  <metadata>
+                    <id>HasNoFiles</id>
+                    <version>1.0.0</version>
+                    <authors>Test</authors>
+                    <description>Test</description>
+                  </metadata>
+                </package>
+                ");
+
+            var engine = new MockEngine();
+            var task = new PackNuSpec
+            {
+                NuspecPath = nuspec,
+                BasePath = _tempDir,
+                BuildEngine = engine,
+                DestinationFolder = _tempDir,
+            };
+            Assert.True(task.Execute());
+            var warning = Assert.Single(engine.Warnings);
+            Assert.Equal("KRB" + KoreBuildErrors.NuspecMissingFilesNode, warning.Code);
+        }
+
+        [Fact]
+        public void PacksFiles()
+        {
+            var files = new[]
+            {
+                Path.Combine("lib", "netstandard1.0", "_._"),
+                "top.txt",
+            };
+
+            var items = new List<ITaskItem>();
+
+            foreach (var file in files)
+            {
+                var path = Path.Combine(_tempDir, file);
+                Directory.CreateDirectory(Path.GetDirectoryName(path));
+                File.WriteAllText(path, "");
+                items.Add(new TaskItem(path, new Hashtable { ["PackagePath"] = file }));
+            }
+
+            var nuspec = CreateNuspec(@"
+                <?xml version=`1.0` encoding=`utf-8`?>
+                <package xmlns=`http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd`>
+                  <metadata>
+                    <id>HasFiles</id>
+                    <version>1.0.0</version>
+                    <authors>Test</authors>
+                    <description>Test</description>
+                  </metadata>
+                  <files />
+                </package>
+                ");
+
+            var engine = new MockEngine();
+            var task = new PackNuSpec
+            {
+                NuspecPath = nuspec,
+                BasePath = _tempDir,
+                BuildEngine = engine,
+                PackageFiles = items.ToArray(),
+                DestinationFolder = _tempDir,
+            };
+
+            Assert.True(task.Execute());
+            var result = Assert.Single(task.Packages);
+
+            using (var reader = new PackageArchiveReader(result.ItemSpec))
+            {
+                Assert.Contains("lib/netstandard1.0/_._", reader.GetFiles());
+                Assert.Contains("top.txt", reader.GetFiles());
+            }
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("/")]
+        [InlineData("somedir/")]
+        public void FailsForBadPackagePath(string path)
+        {
+            var nuspec = CreateNuspec(@"
+                <?xml version=`1.0` encoding=`utf-8`?>
+                <package xmlns=`http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd`>
+                  <metadata>
+                    <id>HasFiles</id>
+                    <version>1.0.0</version>
+                    <authors>Test</authors>
+                    <description>Test</description>
+                  </metadata>
+                  <files />
+                </package>
+                ");
+
+            var engine = new MockEngine { ContinueOnError = true };
+            var task = new PackNuSpec
+            {
+                NuspecPath = nuspec,
+                BasePath = _tempDir,
+                BuildEngine = engine,
+                PackageFiles = new[] { new TaskItem("file.txt", new Hashtable { ["PackagePath"] = path }) },
+                DestinationFolder = _tempDir,
+            };
+
+            Assert.False(task.Execute(), "Task should fail");
+            var error = Assert.Single(engine.Errors);
+            Assert.Equal("KRB" + KoreBuildErrors.InvalidPackagePathMetadata, error.Code);
+        }
+
+        [Fact]
         public void SetsLibraryIncludeFlagsOnDependency()
         {
             var nuspec = CreateNuspec(@"
@@ -175,6 +296,7 @@ namespace KoreBuild.Tasks.Tests
                     <authors>Test</authors>
                     <description>Test</description>
                   </metadata>
+                  <files />
                 </package>
                 ");
 


### PR DESCRIPTION
 - Add support for include/exclude flags on PackNuspec
 - Add support for passing files directly to the PackNuspec task

One more PackNuspec update to allow generating dependencies with include/exclude flags set (will be required for some upcoming infrastructure work).