### PR TITLE
ApiCheck generation 2.0.0

### DIFF
--- a/src/ApiCheck.Task/ApiCheckTasksBase.cs
+++ b/src/ApiCheck.Task/ApiCheckTasksBase.cs
@@ -141,16 +141,18 @@ namespace Microsoft.AspNetCore.BuildTools.ApiCheck.Task
             }
 
             arguments += $@" --assembly ""{AssemblyPath}"" --framework {Framework}";
-            arguments += $@" --project ""{ProjectAssetsPath}"" --api-listing ""{ApiListingPath}""";
+            arguments += $@" --project ""{ProjectAssetsPath}""";
+            if (command == "compare")
+            {
+                arguments += $@" --api-listing ""{ApiListingPath}""";
+            }
+
+            if (command == "generate")
+            {
+                arguments += $@" --out {ApiListingPath}";
+            }
 
             return arguments;
-        }
-
-        /// <inheritdoc />
-        protected override string GetWorkingDirectory()
-        {
-            // Working directory should not matter. Use project folder because it is a well-known location.
-            return Path.GetDirectoryName(ApiListingPath);
         }
     }
 }

--- a/src/Internal.AspNetCore.Sdk/build/ApiCheck.props
+++ b/src/Internal.AspNetCore.Sdk/build/ApiCheck.props
@@ -20,6 +20,7 @@
     <ExcludePublicInternalTypes_InApiCheck Condition=" '$(ExcludePublicInternalTypes_InApiCheck)' == '' ">true</ExcludePublicInternalTypes_InApiCheck>
 
     <!-- Hook API checks into Pack run, prior to creating the .nupkg but after build (if any). -->
+    <GenerateNuspecDependsOn Condition=" '$(GenerateBaselines)' == 'true'">$(GenerateNuspecDependsOn);Generate-ApiCheck-Baselines</GenerateNuspecDependsOn>
     <GenerateNuspecDependsOn>$(GenerateNuspecDependsOn);ApiCheck</GenerateNuspecDependsOn>
-  </PropertyGroup>
+    </PropertyGroup>
 </Project>

--- a/src/Internal.AspNetCore.Sdk/build/ApiCheck.targets
+++ b/src/Internal.AspNetCore.Sdk/build/ApiCheck.targets
@@ -17,7 +17,7 @@
       DependsOnTargets="_GetApiListingFile"
       Condition=" '$(EnableApiCheck)' == 'true' " >
     <ApiCheckGenerateTask
-      ApiListingPath="$(_ApiListingFile)"
+      ApiListingPath="$(_ApiListingFilePath)"
       AssemblyPath="$(TargetPath)"
       Framework="$(TargetFramework)"
       ExcludePublicInternalTypes="$(ExcludePublicInternalTypes_InApiCheck)"

--- a/src/Internal.AspNetCore.Sdk/buildMultiTargeting/ApiCheck.targets
+++ b/src/Internal.AspNetCore.Sdk/buildMultiTargeting/ApiCheck.targets
@@ -3,6 +3,16 @@
   for use outside of Microsoft.
 -->
 <Project>
+
+  <Target
+      Name="Generate-ApiCheck-Baselines" >
+
+    <MSBuild Projects="$(MSBuildProjectFullPath)"
+      Targets="Generate-ApiCheck-Baselines"
+      Properties="TargetFramework=%(_TargetFrameworks.Identity)"
+      RemoveProperties="TargetFrameworks" />
+  </Target>
+
   <Target Name="ApiCheck" Condition=" '$(EnableApiCheck)' == 'true' ">
     <ItemGroup>
       <_TargetFrameworks Remove="@(_TargetFrameworks)" />

--- a/test.ps1
+++ b/test.ps1
@@ -2,8 +2,6 @@
 #requires -version 4
 [CmdletBinding(PositionalBinding = $true)]
 param(
-    [Parameter]
-    [string]$Command = 'default-build',
     [Parameter(Mandatory = $true)]
     [string]$RepoPath,
     [switch]$NoBuild = $false,
@@ -27,7 +25,7 @@ foreach ($line in Get-Content $latestFile) {
 
 $packageDir = Join-Path $toolsSource "build\"
 
-$Arguments += ,"/p:InternalAspNetCoreSdkPackageVersion=$toolsVersion"
-$Arguments += ,"/p:DotNetRestoreSources=$packageDir"
+$Arguments += , "/p:InternalAspNetCoreSdkPackageVersion=$toolsVersion"
+$Arguments += , "/p:DotNetRestoreSources=$packageDir"
 
 & .\scripts\bootstrapper\build.ps1 -Update -Reinstall -Path $RepoPath -ToolsSource $toolsSource @Arguments


### PR DESCRIPTION
Fix baseline generation for 2.0.0 and fix the `test.ps1` to work when passing parameters.