### PR TITLE
Install tools as part of dockerfile

### DIFF
--- a/tools/KoreBuild.Console/Commands/DockerFiles/jessie.dockerfile
+++ b/tools/KoreBuild.Console/Commands/DockerFiles/jessie.dockerfile
@@ -2,16 +2,18 @@ FROM microsoft/dotnet:2.0-runtime-deps-jessie
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-        git \
-# KoreBuild dependencies
-        jq \
-        curl \
-        unzip \
-        apt-transport-https \
+    git \
+    # KoreBuild dependencies
+    jq \
+    curl \
+    unzip \
+    apt-transport-https \
     && rm -rf /var/lib/apt/lists/*
 
 ADD . .
 
 ENV DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true
+
+RUN ./run.sh install-tools
 
 ENTRYPOINT ["./build.sh"]

--- a/tools/KoreBuild.Console/Commands/DockerFiles/winservercore.dockerfile
+++ b/tools/KoreBuild.Console/Commands/DockerFiles/winservercore.dockerfile
@@ -15,4 +15,6 @@ ADD . .
 
 ENV DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true
 
+RUN ./run.ps1 install-tools
+
 ENTRYPOINT ["build.cmd"]


### PR DESCRIPTION
If we run install-tools as part of a docker builds then it should be faster to run a docker image the second time. I put the `run.sh install-tools` after `ADD . .` so that it will re-run in the case that files like `korebuild-lock.txt` were changed.