### PR TITLE
Better logging and more skips for StrongName

### DIFF
--- a/modules/KoreBuild.Tasks/SkipStrongNames.xml
+++ b/modules/KoreBuild.Tasks/SkipStrongNames.xml
@@ -1,4 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <assemblies defaultPublicKeyToken="31bf3856ad364e35">
+  <assembly name="Microsoft.Win32.Registry" />
+  <assembly name="System.Buffers" />
+  <assembly name="System.Diagnostics.DiagnosticSource" />
+  <assembly name="System.Memory" />
   <assembly name="System.Runtime.CompilerServices.Unsafe" />
+  <assembly name="System.Text.Encodings.Web" />
 </assemblies>


### PR DESCRIPTION
Bump the importance of messages from these tasks so we actually see them, and include more assemblies to the list of things we'll actually skip.