### PR TITLE
Add target for setting the teamcity build number to match the product version

### DIFF
--- a/files/KoreBuild/modules/teamcity/module.targets
+++ b/files/KoreBuild/modules/teamcity/module.targets
@@ -1,0 +1,7 @@
+<Project>
+
+  <Target Name="SetTeamCityBuildNumberToVersion">
+    <Message Text="##teamcity[buildNumber '$(Version)']" Importance="High" />
+  </Target>
+
+</Project>


### PR DESCRIPTION
For now, I'm not automatically chaining this to anything. There are enough complications in how we use build number and chain build numbers together that this would be a breaking change. To opt-in to this, our CI configs can run `build.cmd /t:SetTeamCityBuildNumberToVersion /t:Build` or chain it into their build via repo.pros/targets