### PR TITLE
Use TeamCity x-plat logger (take 2)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,14 +6,14 @@
 root = true
 
 [*]
-indent_style = space
-charset = utf-8
+indent_style             = space
+charset                  = utf-8
 trim_trailing_whitespace = true
-insert_final_newline = true
+insert_final_newline     = true
 
-[*.{cs}]
-indent_size = 4
-dotnet_sort_system_directives_first = true:warning
+[*.cs]
+indent_size                         = 4
+dotnet_sort_system_directives_first = true : warning
 
 [*.{xml,config,*proj,nuspec,props,resx,targets,yml,tasks}]
 indent_size = 2

--- a/build/repo.targets
+++ b/build/repo.targets
@@ -8,6 +8,7 @@
     <KoreBuildArchiveFile>$(_KoreBuildOutDir)korebuild.$(Version).zip</KoreBuildArchiveFile>
     <KoreBuildBadgeFile>$(_ChannelOutDir)badge.svg</KoreBuildBadgeFile>
     <KoreBuildLatestTxtFile>$(_ChannelOutDir)latest.txt</KoreBuildLatestTxtFile>
+    <PrepareDependsOn>$(PrepareDependsOn);SetTeamCityBuildNumberToVersion</PrepareDependsOn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/build/tasks/RepoTasks.csproj
+++ b/build/tasks/RepoTasks.csproj
@@ -11,6 +11,7 @@
     <Compile Include="..\..\shared\Microsoft.Extensions.CommandLineUtils.Sources\Utilities\*.cs" />
     <Compile Include="..\..\shared\Utilities\MSBuildListSplitter.cs" />
     <Compile Include="..\..\modules\BuildTools.Tasks\Utilities\**" />
+    <Compile Include="..\..\modules\BuildTools.Tasks\ConsoleMessage.cs" />
     <Compile Include="..\..\modules\BuildTools.Tasks\GetGitCommitInfo.cs" />
     <Compile Include="..\..\modules\BuildTools.Tasks\GenerateFileFromTemplate.cs" />
     <Compile Include="..\..\modules\BuildTools.Tasks\GenerateSvgBadge.cs" />

--- a/build/tasks/RepoTasks.tasks
+++ b/build/tasks/RepoTasks.tasks
@@ -3,6 +3,7 @@
     <_RepoTaskAssembly>$(MSBuildThisFileDirectory)bin\publish\RepoTasks.dll</_RepoTaskAssembly>
   </PropertyGroup>
 
+  <UsingTask TaskName="Microsoft.AspNetCore.BuildTools.ConsoleMessage" AssemblyFile="$(_RepoTaskAssembly)" />
   <UsingTask TaskName="Microsoft.AspNetCore.BuildTools.GetGitCommitInfo" AssemblyFile="$(_RepoTaskAssembly)" />
   <UsingTask TaskName="Microsoft.AspNetCore.BuildTools.GenerateFileFromTemplate" AssemblyFile="$(_RepoTaskAssembly)" />
   <UsingTask TaskName="Microsoft.AspNetCore.BuildTools.GenerateSvgBadge" AssemblyFile="$(_RepoTaskAssembly)" />

--- a/docs/Logging.md
+++ b/docs/Logging.md
@@ -1,0 +1,20 @@
+Logging
+-------
+
+KoreBuild produces log files to $(RepositoryRoot)/artifacts/logs. The following log formats can be used:
+
+## Binary Logger
+
+Using `build.cmd -Verbose` will produce a binary log file to artifacts/logs/msbuild.binlog.
+
+See <http://msbuildlog.com> for details.
+
+## TeamCity Logger
+
+KoreBuild can produce log messages for TeamCity by using <https://github.com/JetBrains/TeamCity.MSBuild.Logger>.
+
+To configure this,
+
+1. Download the logger from JetBrains. https://github.com/JetBrains/TeamCity.MSBuild.Logger#download
+2. Install this on CI agents.
+3. Set the environment variable `KOREBUILD_TEAMCITY_LOGGER` to the file path of TeamCity.MSBuild.Logger.dll on CI agents.

--- a/files/KoreBuild/modules/teamcity/module.targets
+++ b/files/KoreBuild/modules/teamcity/module.targets
@@ -1,7 +1,7 @@
 <Project>
 
   <Target Name="SetTeamCityBuildNumberToVersion">
-    <Message Text="##teamcity[buildNumber '$(Version)']" Importance="High" />
+    <ConsoleMessage Text="##teamcity[buildNumber '$(Version)']" Condition=" '$(TEAMCITY_VERSION)' != '' "/>
   </Target>
 
 </Project>

--- a/files/KoreBuild/modules/vstest/module.targets
+++ b/files/KoreBuild/modules/vstest/module.targets
@@ -102,7 +102,7 @@ Runs the VSTest on all projects in the ProjectsToTest itemgroup.
       <Output TaskParameter="ExitCode" PropertyName="VsTestExitCode" />
     </RunDotNet>
 
-    <Message Text="##teamcity[importData type='vstest' path='$(TrxFile)']" Condition="'$(TEAMCITY_VERSION)' != '' AND Exists($(TrxFile))" Importance="High" />
+    <ConsoleMessage Text="##teamcity[importData type='vstest' path='$(TrxFile)']" Condition="'$(TEAMCITY_VERSION)' != '' AND Exists($(TrxFile))" />
     <Error Text="Test group $(TestGroupName)/$(TargetFramework) failed with exit code '$(VsTestExitCode)'." Condition=" $(VsTestExitCode) != 0 " />
   </Target>
 

--- a/files/KoreBuild/scripts/invoke-repository-build.sh
+++ b/files/KoreBuild/scripts/invoke-repository-build.sh
@@ -68,6 +68,7 @@ fi
 korebuild_proj="$__script_dir/../KoreBuild.proj"
 msbuild_artifacts_dir="$repo_path/artifacts/logs"
 msbuild_response_file="$msbuild_artifacts_dir/msbuild.rsp"
+msbuild_log_rsp_file="$msbuild_artifacts_dir/msbuild.logger.rsp"
 msbuild_log_argument=""
 
 if [ "$__is_verbose" = true ] || [ ! -z "${KOREBUILD_ENABLE_BINARY_LOG:-}" ]; then
@@ -87,10 +88,21 @@ cat > "$msbuild_response_file" <<ENDMSBUILDARGS
 /p:KoreBuildVersion=$korebuild_version
 /p:RepositoryRoot="$repo_path/"
 "$msbuild_log_argument"
-/clp:Summary
 "$korebuild_proj"
 ENDMSBUILDARGS
 echo -e "$msbuild_args" >> "$msbuild_response_file"
+
+if [ ! -z "$KOREBUILD_TEAMCITY_LOGGER" ]; then
+    cat > "$msbuild_log_rsp_file" <<ENDMSBUILDARGS
+/noconsolelogger
+/verbosity:normal
+/logger:TeamCity.MSBuild.Logger.TeamCityMSBuildLogger,$KOREBUILD_TEAMCITY_LOGGER;teamcity
+ENDMSBUILDARGS
+else
+    cat > "$msbuild_log_rsp_file" <<ENDMSBUILDARGS
+/clp:Summary
+ENDMSBUILDARGS
+fi
 
 __verbose "dotnet = $(which dotnet)"
 
@@ -102,8 +114,8 @@ if [ "${noop}" = true ]; then
 elif [ -f "$task_proj" ]; then
     sdk_path="-p:RepoTasksSdkPath=$__script_dir/../msbuild/KoreBuild.RepoTasks.Sdk/Sdk/"
     task_publish_dir="$repo_path/build/tasks/bin/publish/"
-    __exec dotnet publish "$task_proj" --configuration Release --output "$task_publish_dir" -nologo "$sdk_path" $msbuild_props_args
+    __exec dotnet publish "$task_proj" --configuration Release --output "$task_publish_dir" -nologo "$sdk_path" @"$msbuild_log_rsp_file" $msbuild_props_args
 fi
 
 __verbose "Invoking msbuild with '$(< "$msbuild_response_file")'"
-__exec dotnet msbuild @"$msbuild_response_file"
+__exec dotnet msbuild @"$msbuild_response_file" @"$msbuild_log_rsp_file"

--- a/files/KoreBuild/scripts/invoke-repository-build.sh
+++ b/files/KoreBuild/scripts/invoke-repository-build.sh
@@ -92,7 +92,7 @@ cat > "$msbuild_response_file" <<ENDMSBUILDARGS
 ENDMSBUILDARGS
 echo -e "$msbuild_args" >> "$msbuild_response_file"
 
-if [ ! -z "$KOREBUILD_TEAMCITY_LOGGER" ]; then
+if [ ! -z "${KOREBUILD_TEAMCITY_LOGGER:-}" ]; then
     cat > "$msbuild_log_rsp_file" <<ENDMSBUILDARGS
 /noconsolelogger
 /verbosity:normal

--- a/modules/BuildTools.Tasks/BuildTools.Tasks.props
+++ b/modules/BuildTools.Tasks/BuildTools.Tasks.props
@@ -1,5 +1,6 @@
 <Project>
 
+  <UsingTask TaskName="Microsoft.AspNetCore.BuildTools.$(_BuildTasksPrefix)ConsoleMessage" AssemblyFile="$(_BuildToolsAssembly)" />
   <UsingTask TaskName="Microsoft.AspNetCore.BuildTools.$(_BuildTasksPrefix)GenerateResxDesignerFiles" AssemblyFile="$(_BuildToolsAssembly)" />
   <UsingTask TaskName="Microsoft.AspNetCore.BuildTools.$(_BuildTasksPrefix)GenerateFileFromTemplate" AssemblyFile="$(_BuildToolsAssembly)" />
   <UsingTask TaskName="Microsoft.AspNetCore.BuildTools.$(_BuildTasksPrefix)GetAssemblyFileVersion" AssemblyFile="$(_BuildToolsAssembly)" />

--- a/modules/BuildTools.Tasks/ConsoleMessage.cs
+++ b/modules/BuildTools.Tasks/ConsoleMessage.cs
@@ -1,0 +1,28 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Build.Utilities;
+
+namespace Microsoft.AspNetCore.BuildTools
+{
+    /// <summary>
+    /// Writes a message to console output that does not flow through the MSBuild logger.
+    /// </summary>
+#if SDK
+    public class Sdk_ConsoleMessage : Task
+#elif BuildTools
+    public class ConsoleMessage : Task
+#else
+#error This must be built either for an SDK or for BuildTools
+#endif
+    {
+        public string Text { get; set; }
+
+        public override bool Execute()
+        {
+            Console.WriteLine(Text);
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
Same implementation as https://github.com/aspnet/BuildTools/pull/550, but with a workaround for https://github.com/JetBrains/TeamCity.MSBuild.Logger/issues/3 - adding a simple task that calls Console.WriteLine instead of Log.LogMessage.

Resolves https://github.com/aspnet/BuildTools/issues/345