### PR TITLE
Include portable .pdb files in regular nupkgs when Internal.AspNetCore.Sdk is used

### DIFF
--- a/src/Internal.AspNetCore.Sdk/build/Common.targets
+++ b/src/Internal.AspNetCore.Sdk/build/Common.targets
@@ -21,8 +21,9 @@ For single-tfm projects, this will be imported from build/Internal.AspNetCore.Sd
   </PropertyGroup>
 
   <Target Name="_EnsurePdbsInNupkgArePortable" BeforeTargets="GenerateNuspec" Condition=" '$(IsPackable)' != 'false' ">
-    <Error Text="Symbols included in a nupkg package should be portable. Set DebugType=portable or IncludeSymbols=false."
-      Condition=" '$(DebugType)' != 'portable' AND '$(IncludeSymbols)' == 'true' " />
+    <Error Condition=" '$(DebugType)' != 'portable' AND '$(IncludeSymbols)' == 'true' "
+      Text="Symbols were set to be included but the project was built using DebugType = $(DebugType).
+            Set DebugType = portable to include portable pdbs required for symbol publishing or stop including symbols by setting IncludeSymbols=false." />
   </Target>
 
   <Target Name="_ShowBuildVersion" BeforeTargets="PrepareForBuild">

--- a/src/Internal.AspNetCore.Sdk/build/Common.targets
+++ b/src/Internal.AspNetCore.Sdk/build/Common.targets
@@ -15,6 +15,16 @@ For single-tfm projects, this will be imported from build/Internal.AspNetCore.Sd
     <IncludeSymbols Condition="'$(NuspecFile)'!=''">false</IncludeSymbols>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" '$(IncludeSymbols)' != 'false' ">
+    <!-- Include .pdb files in regular .nupkg files. -->
+    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+  </PropertyGroup>
+
+  <Target Name="_EnsurePdbsInNupkgArePortable" BeforeTargets="GenerateNuspec" Condition=" '$(IsPackable)' != 'false' ">
+    <Error Text="Symbols included in a nupkg package should be portable. Set DebugType=portable or IncludeSymbols=false."
+      Condition=" '$(DebugType)' != 'portable' AND '$(IncludeSymbols)' == 'true' " />
+  </Target>
+
   <Target Name="_ShowBuildVersion" BeforeTargets="PrepareForBuild">
     <Message Text="Build version: $(AssemblyName)/$(TargetFramework)/$(Version)" Importance="normal" />
 

--- a/test/KoreBuild.FunctionalTests/KoreBuild.FunctionalTests.csproj
+++ b/test/KoreBuild.FunctionalTests/KoreBuild.FunctionalTests.csproj
@@ -5,11 +5,23 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
+      <_Parameter1>NuGetPackageRoot</_Parameter1>
+      <_Parameter2>$(NuGetPackageRoot)</_Parameter2>
+    </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
+      <_Parameter1>PackageVersion</_Parameter1>
+      <_Parameter2>$(PackageVersion)</_Parameter2>
+    </AssemblyAttribute>
+  </ItemGroup>
+
+  <ItemGroup>
     <Compile Include="..\..\shared\Microsoft.Extensions.CommandLineUtils.Sources\**\*.cs" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPackageVersion)" />
+    <PackageReference Include="NuGet.Packaging" Version="$(NuGetPackagingPackageVersion)" />
     <PackageReference Include="xunit" Version="$(XunitPackageVersion)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitRunnerVisualStudioPackageVersion)" />
   </ItemGroup>

--- a/test/KoreBuild.FunctionalTests/SimpleRepoTests.cs
+++ b/test/KoreBuild.FunctionalTests/SimpleRepoTests.cs
@@ -52,7 +52,7 @@ namespace KoreBuild.FunctionalTests
             using (var reader = new PackageArchiveReader(libPackage))
             {
                 Assert.Contains("lib/netstandard2.0/Simple.Lib.pdb", reader.GetFiles());
-                Assert.Contains("lib/net46/Simple.Lib.pdb", reader.GetFiles());
+                Assert.Contains("lib/net461/Simple.Lib.pdb", reader.GetFiles());
             }
 
             // /t:TestNuGetPush

--- a/test/KoreBuild.FunctionalTests/SimpleRepoTests.cs
+++ b/test/KoreBuild.FunctionalTests/SimpleRepoTests.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using System.Runtime.InteropServices;
 using System.Linq;
 using System.Xml.Linq;
+using NuGet.Packaging;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -41,9 +42,18 @@ namespace KoreBuild.FunctionalTests
             Assert.True(File.Exists(Path.Combine(app.WorkingDirectory, "korebuild-lock.txt")), "Should have created the korebuild lock file");
 
             // /t:Package
+            var libPackage = Path.Combine(app.WorkingDirectory, "artifacts", "build", "Simple.Lib.1.0.0-beta-0001.nupkg");
+            var libSymbolsPackage = Path.Combine(app.WorkingDirectory, "artifacts", "build", "Simple.Lib.1.0.0-beta-0001.symbols.nupkg");
             Assert.True(File.Exists(Path.Combine(app.WorkingDirectory, "artifacts", "build", "Simple.CliTool.1.0.0-beta-0001.nupkg")), "Build should have produced a lib nupkg");
-            Assert.True(File.Exists(Path.Combine(app.WorkingDirectory, "artifacts", "build", "Simple.Lib.1.0.0-beta-0001.nupkg")), "Build should have produced a lib nupkg");
+            Assert.True(File.Exists(libPackage), "Build should have produced a lib nupkg");
+            Assert.True(File.Exists(libSymbolsPackage), "Build should have produced a symbols lib nupkg");
             Assert.True(File.Exists(Path.Combine(app.WorkingDirectory, "artifacts", "build", "Simple.Sources.1.0.0-beta-0001.nupkg")), "Build should have produced a sources nupkg");
+
+            using (var reader = new PackageArchiveReader(libPackage))
+            {
+                Assert.Contains("lib/netstandard2.0/Simple.Lib.pdb", reader.GetFiles());
+                Assert.Contains("lib/net46/Simple.Lib.pdb", reader.GetFiles());
+            }
 
             // /t:TestNuGetPush
             Assert.True(File.Exists(Path.Combine(app.WorkingDirectory, "obj", "tmp-nuget", "Simple.CliTool.1.0.0-beta-0001.nupkg")), "Build done a test push of all the packages");
@@ -119,8 +129,7 @@ namespace KoreBuild.FunctionalTests
                             Assert.Equal("lib/netstandard2.0/Simple.Lib.dll", a.Attribute("Path")?.Value);
                             Assert.Equal("TestCert", a.Attribute("Certificate")?.Value);
                         });
-                }
-                );
+                });
         }
 
         [Fact]


### PR DESCRIPTION
Allows adding .pdb files in the .nupkg for aspnetcore packages that end up on NuGet.org.

cref https://github.com/aspnet/Universe/issues/131

cc @Eilon @JunTaoLuo @ctaggart