### PR TITLE
Don't include symbols in the regular .nupkg file but still ensure symbols are portable

### DIFF
--- a/src/Internal.AspNetCore.Sdk/build/Common.targets
+++ b/src/Internal.AspNetCore.Sdk/build/Common.targets
@@ -16,18 +16,14 @@ For single-tfm projects, this will be imported from build/Internal.AspNetCore.Sd
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(IncludeSymbols)' != 'false' ">
-    <!-- Include .pdb files in regular .nupkg files. -->
-    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+    <GenerateNuspecDependsOn>$(GenerateNuspecDependsOn);_EnsureDebugTypeIsPortable</GenerateNuspecDependsOn>
+    <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);_EnsureDebugTypeIsPortable</TargetsForTfmSpecificBuildOutput>
   </PropertyGroup>
 
-  <Target Name="_EnsurePdbsInNupkgArePortable"
-          BeforeTargets="GenerateNuspec"
-          AfterTargets="CoreCompile"
-          Condition=" '$(IsPackable)' != 'false' ">
-
-    <Error Condition=" '$(DebugType)' != 'portable' AND '$(IncludeSymbols)' == 'true' "
+  <Target Name="_EnsureDebugTypeIsPortable">
+    <Error Condition=" '$(DebugType)' != 'portable' "
       Code="KRB5005"
-      Text="Symbols were set to be included but the project was built using DebugType = $(DebugType). Set DebugType = portable to include portable pdbs required for symbol publishing or stop including symbols by setting IncludeSymbols=false." />
+      Text="The project was set to produce a symbols package but the project was built using DebugType = $(DebugType). Set DebugType = portable to include portable pdbs required for symbol publishing or stop producing symbols by setting IncludeSymbols=false." />
   </Target>
 
   <Target Name="_ShowBuildVersion" BeforeTargets="PrepareForBuild">

--- a/test/KoreBuild.FunctionalTests/SimpleRepoTests.cs
+++ b/test/KoreBuild.FunctionalTests/SimpleRepoTests.cs
@@ -51,8 +51,7 @@ namespace KoreBuild.FunctionalTests
 
             using (var reader = new PackageArchiveReader(libPackage))
             {
-                Assert.Contains("lib/netstandard2.0/Simple.Lib.pdb", reader.GetFiles());
-                Assert.Contains("lib/net461/Simple.Lib.pdb", reader.GetFiles());
+                Assert.Empty(reader.GetFiles().Where(p => Path.GetExtension(p).Equals(".pdb", StringComparison.OrdinalIgnoreCase)));
             }
 
             // /t:TestNuGetPush


### PR DESCRIPTION
Undo part of #568. Don't include .pdb files in the regular .nupkg, but still ensure DebugType == portable.

cref https://github.com/aspnet/Universe/issues/131

cc @Eilon 