### PR TITLE
Ensure Run.ExitCode is non-zero when it fails to launch a process

### DIFF
--- a/modules/BuildTools.Tasks/RunBase.cs
+++ b/modules/BuildTools.Tasks/RunBase.cs
@@ -70,6 +70,9 @@ namespace Microsoft.AspNetCore.BuildTools
 
         public override bool Execute()
         {
+            // Initialize to non-zero in case of early return
+            ExitCode = -1;
+
             var exe = GetExecutable();
 
             if (string.IsNullOrEmpty(exe))
@@ -124,7 +127,8 @@ namespace Microsoft.AspNetCore.BuildTools
                     FileName = exe,
                     Arguments = arguments,
                     WorkingDirectory = WorkingDirectory ?? Directory.GetCurrentDirectory(),
-                    UseShellExecute = UseShellExecute
+                    UseShellExecute = UseShellExecute,
+                    CreateNoWindow = true,
                 },
             };
 

--- a/test/BuildTools.Tasks.Tests/RunTaskTests.cs
+++ b/test/BuildTools.Tasks.Tests/RunTaskTests.cs
@@ -1,0 +1,26 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using Microsoft.AspNetCore.BuildTools;
+using Xunit;
+
+namespace BuildTools.Tasks.Tests
+{
+    public class RunTaskTests
+    {
+        [Fact]
+        public void ExitCodeIsNonZeroIfFailedToStart()
+        {
+            var engine = new MockEngine { ContinueOnError = true };
+            var task = new Run
+            {
+                FileName = "sdfkjskldfsjdflkajsdas",
+                BuildEngine = engine,
+            };
+            Assert.False(task.Execute());
+            Assert.NotEqual(0, task.ExitCode);
+        }
+    }
+}


### PR DESCRIPTION
Found this while working on updating publishing in aspnet/Universe. NPM failed to launch, but the ExitCode was still 0, so the MSBuild targets didn't thing there was an error.