### PR TITLE
Use SHA256 in PDBs

### DIFF
--- a/src/Internal.AspNetCore.Sdk/build/Common.props
+++ b/src/Internal.AspNetCore.Sdk/build/Common.props
@@ -23,6 +23,8 @@ Usage: this should be imported once via NuGet at the top of the file.
     <Serviceable Condition="'$(Configuration)' == 'Release'">true</Serviceable>
     <LangVersion Condition="'$(LangVersion)' == ''">7.2</LangVersion>
     <RepositoryCommit Condition="'$(RepositoryCommit)' == ''">$(CommitHash)</RepositoryCommit>
+    <!-- Instructs the compiler to use SHA256 instead of SHA1 when adding file hashes to PDBs. -->
+    <ChecksumAlgorithm>SHA256</ChecksumAlgorithm> 
   </PropertyGroup>
 
   <!-- common build options -->


### PR DESCRIPTION
Use a new feature of the compiler. Cref https://github.com/dotnet/roslyn/pull/24820

cc @tmat