### PR TITLE
Trim whitespace from restore sources in DownloadNuGetPackages

### DIFF
--- a/modules/KoreBuild.Tasks/DownloadNuGetPackages.cs
+++ b/modules/KoreBuild.Tasks/DownloadNuGetPackages.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using KoreBuild.Tasks.Utilities;

--- a/modules/KoreBuild.Tasks/Utilities/PackageDownloader.cs
+++ b/modules/KoreBuild.Tasks/Utilities/PackageDownloader.cs
@@ -40,7 +40,11 @@ namespace KoreBuild.Tasks.Utilities
 
                 foreach (var request in requests)
                 {
-                    var feeds = request.Sources.Select(sourceProvider.CreateRepository);
+                    var feeds = request.Sources
+                        .Select(s => s?.Trim())
+                        .Where(s => !string.IsNullOrEmpty(s))
+                        .Distinct()
+                        .Select(sourceProvider.CreateRepository);
                     tasks.Add(DownloadPackageAsync(request, feeds, cacheContext, throttle, logger, cts.Token));
                 }
 

--- a/test/KoreBuild.Tasks.Tests/DownloadNuGetPackagesTests.cs
+++ b/test/KoreBuild.Tasks.Tests/DownloadNuGetPackagesTests.cs
@@ -26,7 +26,11 @@ namespace KoreBuild.Tasks.Tests
         {
             var packages = new[]
             {
-                new TaskItem("Newtonsoft.Json", new Hashtable { ["Version"] = "9.0.1", ["Source"] = "https://api.nuget.org/v3/index.json"} ),
+                new TaskItem("Newtonsoft.Json", new Hashtable
+                {
+                    ["Version"] = "9.0.1",
+                    ["Source"] = "  https://api.nuget.org/v3/index.json  ; ;https://api.nuget.org/v3/index.json; https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json "
+                }),
             };
 
             var task = new DownloadNuGetPackages


### PR DESCRIPTION
Fixes a bug in DownloadNuGetPackages that happens when the metadata is a list of feeds with some whitespace in it.