### PR TITLE
Fail faster when the artifacts directory isn't clean

### DIFF
--- a/files/KoreBuild/KoreBuild.Verify.targets
+++ b/files/KoreBuild/KoreBuild.Verify.targets
@@ -11,18 +11,20 @@
     <SkipArtifactVerification>true</SkipArtifactVerification>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(SkipArtifactVerification)' != 'true'">
+    <PrepareDependsOn>CheckForUnknownArtifacts</PrepareDependsOn>
+  </PropertyGroup>
+
 <!--
 ###################################################################
-Target: VerifyArtifacts
+Target: CheckForUnknownArtifacts
 
-Verifies everything in artifacts/* is accounted for.
+Verifies everything in artifacts/* is accounted for before build.
 ###################################################################
 -->
 
-  <Target Name="VerifyArtifacts" Condition="'$(SkipArtifactVerification)' != 'true'" DependsOnTargets="GetArtifactInfo" AfterTargets="Package">
+  <Target Name="CheckForUnknownArtifacts" DependsOnTargets="GetArtifactInfo">
     <ItemGroup>
-      <_ExpectedArtifact Remove="@(_ExpectedArtifact)" />
-      <_ExpectedArtifact Include="%(ArtifactInfo.Identity)" Condition=" ! Exists(%(ArtifactInfo.Identity))" />
       <_UnexpectedArtifact Remove="@(_UnexpectedArtifact)" />
       <_UnexpectedArtifact Include="$(ArtifactsDir)**\*" Exclude="@(ArtifactInfo->'%(FullPath)');$(IgnoredArtifactItems)" />
     </ItemGroup>
@@ -30,10 +32,32 @@ Verifies everything in artifacts/* is accounted for.
     <PropertyGroup>
       <ArtifactErrorMessage Condition=" @(_UnexpectedArtifact->Count()) != 0 ">
 Undeclared artifacts exist in $(ArtifactsDir).
-Run /t:Clean or update repo.props to list known artifacts as an ArtifactInfo item.
+Run /t:Clean or update repo.props to list known build output as an ArtifactInfo item.
 Unexpected files:
   - @(_UnexpectedArtifact, '%0A  - ')
       </ArtifactErrorMessage>
+    </PropertyGroup>
+
+    <Error Text="$(ArtifactErrorMessage.Trim())"
+           Code="KRB5002"
+           Condition=" '$(ArtifactErrorMessage.Trim())' != '' " />
+  </Target>
+
+<!--
+###################################################################
+Target: VerifyArtifacts
+
+Verifies everything in artifacts/* is accounted for after build.
+###################################################################
+-->
+
+  <Target Name="VerifyArtifacts" Condition="'$(SkipArtifactVerification)' != 'true'" DependsOnTargets="GetArtifactInfo" AfterTargets="Package">
+    <ItemGroup>
+      <_ExpectedArtifact Remove="@(_ExpectedArtifact)" />
+      <_ExpectedArtifact Include="%(ArtifactInfo.Identity)" Condition=" ! Exists(%(ArtifactInfo.Identity))" />
+    </ItemGroup>
+
+    <PropertyGroup>
       <ArtifactErrorMessage Condition=" @(_ExpectedArtifact->Count()) != 0 ">
 $(ArtifactErrorMessage.Trim())
 Expected items that do not exist:

--- a/files/KoreBuild/KoreBuild.Verify.targets
+++ b/files/KoreBuild/KoreBuild.Verify.targets
@@ -30,6 +30,7 @@ Verifies everything in artifacts/* is accounted for before build.
     </ItemGroup>
 
     <PropertyGroup>
+      <ArtifactErrorMessage />
       <ArtifactErrorMessage Condition=" @(_UnexpectedArtifact->Count()) != 0 ">
 Undeclared artifacts exist in $(ArtifactsDir).
 Run /t:Clean or update repo.props to list known build output as an ArtifactInfo item.
@@ -58,6 +59,7 @@ Verifies everything in artifacts/* is accounted for after build.
     </ItemGroup>
 
     <PropertyGroup>
+      <ArtifactErrorMessage />
       <ArtifactErrorMessage Condition=" @(_ExpectedArtifact->Count()) != 0 ">
 $(ArtifactErrorMessage.Trim())
 Expected items that do not exist:

--- a/files/KoreBuild/KoreBuild.Verify.targets
+++ b/files/KoreBuild/KoreBuild.Verify.targets
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(SkipArtifactVerification)' != 'true'">
-    <PrepareDependsOn>CheckForUnknownArtifacts</PrepareDependsOn>
+    <RestoreDependsOn>$(RestoreDependsOn);CheckForUnknownArtifacts</RestoreDependsOn>
   </PropertyGroup>
 
 <!--
@@ -52,7 +52,7 @@ Verifies everything in artifacts/* is accounted for after build.
 ###################################################################
 -->
 
-  <Target Name="VerifyArtifacts" Condition="'$(SkipArtifactVerification)' != 'true'" DependsOnTargets="GetArtifactInfo" AfterTargets="Package">
+  <Target Name="VerifyArtifacts" Condition="'$(SkipArtifactVerification)' != 'true'" DependsOnTargets="GetArtifactInfo;CheckForUnknownArtifacts" AfterTargets="Package">
     <ItemGroup>
       <_ExpectedArtifact Remove="@(_ExpectedArtifact)" />
       <_ExpectedArtifact Include="%(ArtifactInfo.Identity)" Condition=" ! Exists(%(ArtifactInfo.Identity))" />

--- a/files/KoreBuild/modules/sharedsources/module.targets
+++ b/files/KoreBuild/modules/sharedsources/module.targets
@@ -23,7 +23,7 @@ that matches "$(RepositoryRoot)/shared/*.Sources".
   <Target Name="ResolveSharedSourcesPackageInfo" DependsOnTargets="_SetSharedSourcesProperties" Returns="@(ArtifactInfo)">
     <MSBuild Targets="GetArtifactInfo"
       Projects="$(MSBuildThisFileDirectory)sharedsources.csproj"
-      Properties="$(_SharedSourcesPackageProperties);NuspecBasePath=$([MSBuild]::NormalizeDirectory('%(SharedSourceDirectories.Identity)'));PackageId=%(FileName)%(Extension);DesignTimeBuild=true"
+      Properties="$(_SharedSourcesPackageProperties);NuspecBasePath=$([MSBuild]::NormalizeDirectory('%(SharedSourceDirectories.Identity)'));PackageId=%(FileName)%(Extension)"
       Condition="@(SharedSourceDirectories->Count()) != 0"
       BuildInParallel="true">
       <Output TaskParameter="TargetOutputs" ItemName="ArtifactInfo" />

--- a/files/KoreBuild/modules/sharedsources/module.targets
+++ b/files/KoreBuild/modules/sharedsources/module.targets
@@ -23,7 +23,7 @@ that matches "$(RepositoryRoot)/shared/*.Sources".
   <Target Name="ResolveSharedSourcesPackageInfo" DependsOnTargets="_SetSharedSourcesProperties" Returns="@(ArtifactInfo)">
     <MSBuild Targets="GetArtifactInfo"
       Projects="$(MSBuildThisFileDirectory)sharedsources.csproj"
-      Properties="$(_SharedSourcesPackageProperties);NuspecBasePath=$([MSBuild]::NormalizeDirectory('%(SharedSourceDirectories.Identity)'));PackageId=%(FileName)%(Extension);"
+      Properties="$(_SharedSourcesPackageProperties);NuspecBasePath=$([MSBuild]::NormalizeDirectory('%(SharedSourceDirectories.Identity)'));PackageId=%(FileName)%(Extension);DesignTimeBuild=true"
       Condition="@(SharedSourceDirectories->Count()) != 0"
       BuildInParallel="true">
       <Output TaskParameter="TargetOutputs" ItemName="ArtifactInfo" />

--- a/files/KoreBuild/modules/sharedsources/sharedsources.csproj
+++ b/files/KoreBuild/modules/sharedsources/sharedsources.csproj
@@ -42,11 +42,11 @@
   <ItemGroup Condition="'$(NuspecBasePath)'!=''">
     <Compile Include="$(NuspecBasePath)**\*.cs" Exclude="$(DefaultExcludeItems)">
       <Pack>true</Pack>
-      <PackagePath>$(ContentTargetFolders)\cs\netstandard1.0\</PackagePath>
+      <PackagePath>$(ContentTargetFolders)\cs\netstandard1.0\$(PackageId)\%(RecursiveDir)\</PackagePath>
     </Compile>
     <EmbeddedResource Include="$(NuspecBasePath)**\*.resx" Exclude="$(DefaultExcludeItems)">
       <Pack>true</Pack>
-      <PackagePath>$(ContentTargetFolders)\any\any\</PackagePath>
+      <PackagePath>$(ContentTargetFolders)\any\any\$(PackageId)\%(RecursiveDir)\</PackagePath>
     </EmbeddedResource>
   </ItemGroup>
 

--- a/files/KoreBuild/modules/solutionbuild/module.targets
+++ b/files/KoreBuild/modules/solutionbuild/module.targets
@@ -148,7 +148,7 @@ Executes /t:Pack on all projects matching src/*/*.csproj.
     <MSBuild Targets="GetArtifactInfo"
       Projects="@(ProjectsToPack)"
       Condition="@(ProjectsToPack->Count()) != 0"
-      Properties="$(SolutionProperties);EnableApiCheck=false;NoBuild=true;DesignTimeBuild=true;RepositoryRoot=$(RepositoryRoot);PackageOutputPath=$(BuildDir);CustomAfterMicrosoftCommonTargets=$(_InspectionTargetsFile);CustomAfterMicrosoftCommonCrossTargetingTargets=$(_InspectionTargetsFile)"
+      Properties="$(SolutionProperties);EnableApiCheck=false;NoBuild=true;RepositoryRoot=$(RepositoryRoot);PackageOutputPath=$(BuildDir);CustomAfterMicrosoftCommonTargets=$(_InspectionTargetsFile);CustomAfterMicrosoftCommonCrossTargetingTargets=$(_InspectionTargetsFile)"
       BuildInParallel="$(BuildInParallel)"
       RemoveProperties="$(_BuildPropertiesToRemove);PackageNoBuild">
       <Output TaskParameter="TargetOutputs" ItemName="_Temp" />

--- a/files/KoreBuild/modules/solutionbuild/module.targets
+++ b/files/KoreBuild/modules/solutionbuild/module.targets
@@ -148,7 +148,7 @@ Executes /t:Pack on all projects matching src/*/*.csproj.
     <MSBuild Targets="GetArtifactInfo"
       Projects="@(ProjectsToPack)"
       Condition="@(ProjectsToPack->Count()) != 0"
-      Properties="$(SolutionProperties);EnableApiCheck=false;NoBuild=true;RepositoryRoot=$(RepositoryRoot);PackageOutputPath=$(BuildDir);CustomAfterMicrosoftCommonTargets=$(_InspectionTargetsFile);CustomAfterMicrosoftCommonCrossTargetingTargets=$(_InspectionTargetsFile)"
+      Properties="$(SolutionProperties);EnableApiCheck=false;NoBuild=true;DesignTimeBuild=true;RepositoryRoot=$(RepositoryRoot);PackageOutputPath=$(BuildDir);CustomAfterMicrosoftCommonTargets=$(_InspectionTargetsFile);CustomAfterMicrosoftCommonCrossTargetingTargets=$(_InspectionTargetsFile)"
       BuildInParallel="$(BuildInParallel)"
       RemoveProperties="$(_BuildPropertiesToRemove);PackageNoBuild">
       <Output TaskParameter="TargetOutputs" ItemName="_Temp" />


### PR DESCRIPTION
It's annoying that this check doesn't happen until after the compilation is done. This moves the check before build so you get a reminder faster that you need to clean when switching branches.