### PR TITLE
Generate API Check 2.0

### DIFF
--- a/build/repo.targets
+++ b/build/repo.targets
@@ -47,7 +47,7 @@
 
     <!-- passing /warnaserror:BUILD1001 on CI to prevent channel/branch mismatch -->
     <Warning Text="Current branch '$(GitBranch)' does not match the value of KoreBuildChannel: '$(KoreBuildChannel)'"
-      Condition="'$(GitBranch)' != '$(KoreBuildChannel)'"
+      Condition="'$(GitBranch)' != '$(KoreBuildChannel)' AND '$(CI)' == 'true'"
       Code="BUILD1001" />
 
     <ItemGroup>

--- a/src/ApiCheck.Console/Program.cs
+++ b/src/ApiCheck.Console/Program.cs
@@ -287,8 +287,16 @@ namespace ApiCheck
 
             foreach (var exclusion in incorrectBreakingChanges)
             {
-                Console.WriteLine(
-                    "ERROR: The following exclusion is in the exclusion file, but is no longer necessary:");
+                if (breakingChangesPathOption.HasValue())
+                {
+                    Console.Error.WriteLine(
+                        $"ERROR: The following exclusion is in the exclusion file '{breakingChangesPathOption.Value()}', but is no longer necessary:");
+                }
+                else
+                {
+                    Console.Error.WriteLine(
+                        "ERROR: The following exclusion is in the exclusion file, but is no longer necessary:");
+                }
                 Console.WriteLine(JsonConvert.SerializeObject(exclusion, Formatting.Indented));
                 Console.WriteLine();
             }

--- a/src/Internal.AspNetCore.Sdk/build/ApiCheck.props
+++ b/src/Internal.AspNetCore.Sdk/build/ApiCheck.props
@@ -20,7 +20,8 @@
     <ExcludePublicInternalTypes_InApiCheck Condition=" '$(ExcludePublicInternalTypes_InApiCheck)' == '' ">true</ExcludePublicInternalTypes_InApiCheck>
 
     <!-- Hook API checks into Pack run, prior to creating the .nupkg but after build (if any). -->
-    <GenerateNuspecDependsOn Condition=" '$(GenerateBaselines)' == 'true'">$(GenerateNuspecDependsOn);Generate-ApiCheck-Baselines</GenerateNuspecDependsOn>
+    <GenerateNuspecDependsOn Condition=" '$(GenerateBaselines)' != 'false'">$(GenerateNuspecDependsOn);Generate-ApiCheck-Baselines</GenerateNuspecDependsOn>
+    <GenerateNuspecDependsOn Condition=" '$(ReplaceBaselines)' == 'true' ">$(GenerateNuspecDependsOn);Replace-ApiCheck-Baselines</GenerateNuspecDependsOn>
     <GenerateNuspecDependsOn>$(GenerateNuspecDependsOn);ApiCheck</GenerateNuspecDependsOn>
     </PropertyGroup>
 </Project>

--- a/src/Internal.AspNetCore.Sdk/build/ApiCheck.targets
+++ b/src/Internal.AspNetCore.Sdk/build/ApiCheck.targets
@@ -8,7 +8,8 @@
       <_ApiListingFileSuffix Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' ">netframework.json</_ApiListingFileSuffix>
       <_ApiListingFileSuffix Condition=" '$(_ApiListingFileSuffix)' == '' ">netcore.json</_ApiListingFileSuffix>
       <_ApiListingFilePath>$(MSBuildProjectDirectory)\baseline.$(_ApiListingFileSuffix)</_ApiListingFilePath>
-      <_ApiListingFile Condition=" Exists('$(_ApiListingFilePath)') ">$(_ApiListingFilePath)</_ApiListingFile>
+      <_ApiListingOutputFile>$(OutputPath)\baseline.$(_ApiListingFileSuffix)</_ApiListingOutputFile>
+      <_ApiExclusionsFilePath>$(MSBuildProjectDirectory)\breakingchanges.$(_ApiListingFileSuffix)</_ApiExclusionsFilePath>
     </PropertyGroup>
   </Target>
 
@@ -17,7 +18,7 @@
       DependsOnTargets="_GetApiListingFile"
       Condition=" '$(EnableApiCheck)' == 'true' " >
     <ApiCheckGenerateTask
-      ApiListingPath="$(_ApiListingFilePath)"
+      ApiListingPath="$(_ApiListingOutputFile)"
       AssemblyPath="$(TargetPath)"
       Framework="$(TargetFramework)"
       ExcludePublicInternalTypes="$(ExcludePublicInternalTypes_InApiCheck)"
@@ -25,11 +26,24 @@
   </Target>
 
   <Target
+      Name="Replace-ApiCheck-Baselines"
+      DependsOnTargets="Generate-ApiCheck-Baselines"
+      Condition="'$(EnableApiCheck)' == 'true' and Exists('$(_ApiListingOutputFile)')" >
+      <PropertyGroup>
+        <_ApiExclusionsFile Condition=" Exists('$(_ApiExclusionsFilePath)') ">$(_ApiExclusionsFilePath)</_ApiExclusionsFile>
+      </PropertyGroup>
+    <Copy
+      SourceFiles="$(_ApiListingOutputFile)"
+      DestinationFolder="$(MSBuildProjectDirectory)" />
+    <Delete Files="$(_ApiExclusionsFile)" Condition="Exists('$(_ApiExclusionsFile)')" />
+  </Target>
+
+  <Target
       Name="ApiCheck"
       DependsOnTargets="_GetApiListingFile"
       Condition=" '$(EnableApiCheck)' == 'true' ">
     <PropertyGroup>
-      <_ApiExclusionsFilePath>$(MSBuildProjectDirectory)\breakingchanges.$(_ApiListingFileSuffix)</_ApiExclusionsFilePath>
+      <_ApiListingFile Condition=" Exists('$(_ApiListingFilePath)') ">$(_ApiListingFilePath)</_ApiListingFile>
       <_ApiExclusionsFile Condition=" Exists('$(_ApiExclusionsFilePath)') ">$(_ApiExclusionsFilePath)</_ApiExclusionsFile>
     </PropertyGroup>
 
@@ -45,6 +59,6 @@
       ProjectAssetsPath="$(ProjectAssetsFile)" />
 
     <Warning Condition=" '$(_ApiListingFile)' == '' "
-      Text="No baseline file for $(TargetFramework) found in $(MSBuildProjectName)." />
+      Text="No baseline file '$(_ApiListingFilePath)' for $(TargetFramework) found in $(MSBuildProjectName)." />
   </Target>
 </Project>

--- a/src/Internal.AspNetCore.Sdk/buildMultiTargeting/ApiCheck.targets
+++ b/src/Internal.AspNetCore.Sdk/buildMultiTargeting/ApiCheck.targets
@@ -6,9 +6,26 @@
 
   <Target
       Name="Generate-ApiCheck-Baselines" >
+    <ItemGroup>
+      <_TargetFrameworks Remove="@(_TargetFrameworks)" />
+      <_TargetFrameworks Include="$(TargetFrameworks)" />
+    </ItemGroup>
 
     <MSBuild Projects="$(MSBuildProjectFullPath)"
       Targets="Generate-ApiCheck-Baselines"
+      Properties="TargetFramework=%(_TargetFrameworks.Identity)"
+      RemoveProperties="TargetFrameworks" />
+  </Target>
+
+  <Target
+      Name="Replace-ApiCheck-Baselines" >
+    <ItemGroup>
+      <_TargetFrameworks Remove="@(_TargetFrameworks)" />
+      <_TargetFrameworks Include="$(TargetFrameworks)" />
+    </ItemGroup>
+
+    <MSBuild Projects="$(MSBuildProjectFullPath)"
+      Targets="Replace-ApiCheck-Baselines"
       Properties="TargetFramework=%(_TargetFrameworks.Identity)"
       RemoveProperties="TargetFrameworks" />
   </Target>


### PR DESCRIPTION
Porting this to release/2.0.

baselines are generated in output folder by default and replace existing baselines when `/p:ReplaceBaselines` is passed.