### PR TITLE
Ensure copyright in package metadata is "© Microsoft Corporation. All rights reserved."

### DIFF
--- a/modules/NuGetPackageVerifier/console/CompositeRules/DefaultCompositeRule.cs
+++ b/modules/NuGetPackageVerifier/console/CompositeRules/DefaultCompositeRule.cs
@@ -18,6 +18,8 @@ namespace NuGetPackageVerifier.Rules
             new AssemblyHasServicingAttributeRule(),
             new AssemblyHasVersionAttributesRule(),
             new AssemblyStrongNameRule(),
+            new PackageCopyrightRule(),
+            new PackageAuthorRule(),
             new RequiredPackageMetadataRule(),
             new RequiredNuSpecInfoRule(),
             new SatellitePackageRule(),

--- a/modules/NuGetPackageVerifier/console/PackageIssueFactory.cs
+++ b/modules/NuGetPackageVerifier/console/PackageIssueFactory.cs
@@ -198,17 +198,17 @@ namespace NuGetPackageVerifier
                 "The package '{0}' must only have one Author.", assemblyPath), PackageIssueLevel.Error);
         }
 
-        public static PackageVerifierIssue CopyrightIsIncorrect(string assemblyPath, string expectedCopyright, string actualCopyright)
+        public static PackageVerifierIssue CopyrightIsIncorrect(string packageId, string expectedCopyright, string actualCopyright)
         {
-            return new PackageVerifierIssue("PACKAGE_COPYRIGHT_INCORRECT", assemblyPath, string.Format(
-                "The package '{0}'s copyright must be {1} but was {2}", assemblyPath, expectedCopyright, actualCopyright),
+            return new PackageVerifierIssue("PACKAGE_COPYRIGHT_INCORRECT", packageId, string.Format(
+                "The package '{0}'s copyright must be {1} but was {2}", packageId, expectedCopyright, actualCopyright),
                 PackageIssueLevel.Error);
         }
 
-        public static PackageVerifierIssue AuthorIsIncorrect(string assemblyPath, string expectedAuthor, string actualAuthor)
+        public static PackageVerifierIssue AuthorIsIncorrect(string packageId, string expectedAuthor, string actualAuthor)
         {
-            return new PackageVerifierIssue("PACKAGE_AUTHOR_INCORRECT", assemblyPath, string.Format(
-                "The package '{0}'s Author must be {1} but was {2}", assemblyPath, expectedAuthor, actualAuthor),
+            return new PackageVerifierIssue("PACKAGE_AUTHOR_INCORRECT", packageId, string.Format(
+                "The package '{0}'s Author must be {1} but was {2}", packageId, expectedAuthor, actualAuthor),
                 PackageIssueLevel.Error);
         }
 

--- a/modules/NuGetPackageVerifier/console/PackageIssueFactory.cs
+++ b/modules/NuGetPackageVerifier/console/PackageIssueFactory.cs
@@ -198,6 +198,13 @@ namespace NuGetPackageVerifier
                 "The package '{0}' must only have one Author.", assemblyPath), PackageIssueLevel.Error);
         }
 
+        public static PackageVerifierIssue CopyrightIsIncorrect(string assemblyPath, string expectedCopyright, string actualCopyright)
+        {
+            return new PackageVerifierIssue("PACKAGE_COPYRIGHT_INCORRECT", assemblyPath, string.Format(
+                "The package '{0}'s copyright must be {1} but was {2}", assemblyPath, expectedCopyright, actualCopyright),
+                PackageIssueLevel.Error);
+        }
+
         public static PackageVerifierIssue AuthorIsIncorrect(string assemblyPath, string expectedAuthor, string actualAuthor)
         {
             return new PackageVerifierIssue("PACKAGE_AUTHOR_INCORRECT", assemblyPath, string.Format(

--- a/modules/NuGetPackageVerifier/console/Rules/PackageCopyrightRule.cs
+++ b/modules/NuGetPackageVerifier/console/Rules/PackageCopyrightRule.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace NuGetPackageVerifier.Rules
+{
+    public class PackageCopyrightRule : IPackageVerifierRule
+    {
+        private const string ExpectedCopyright = "© Microsoft Corporation. All rights reserved.";
+
+        public IEnumerable<PackageVerifierIssue> Validate(PackageAnalysisContext context)
+        {
+            if (!string.Equals(context.Metadata.Copyright, ExpectedCopyright, StringComparison.Ordinal))
+            {
+                yield return PackageIssueFactory.CopyrightIsIncorrect(context.Metadata.Id, ExpectedCopyright, context.Metadata.Copyright);
+            }
+        }
+    }
+}

--- a/src/Internal.AspNetCore.Sdk/build/Common.props
+++ b/src/Internal.AspNetCore.Sdk/build/Common.props
@@ -12,7 +12,7 @@ Usage: this should be imported once via NuGet at the top of the file.
   <PropertyGroup>
     <Authors>Microsoft</Authors>
     <Company>Microsoft Corporation.</Company>
-    <Copyright>Copyright © Microsoft Corporation</Copyright>
+    <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <IncludeSource>true</IncludeSource>
     <IncludeSymbols>true</IncludeSymbols>
     <NeutralLanguage>en-US</NeutralLanguage>


### PR DESCRIPTION
Resolves https://github.com/aspnet/Coherence-Signed/issues/789.

Also, I noticed the PackageAuthorRule was not running by default. I've updated to include this too.