### PR TITLE
Unify to RepositoryCommit as the property for storing the commit hash

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,7 +8,7 @@
     <_AspNetToolsSdkPath>$(MSBuildThisFileDirectory)src\Internal.AspNetCore.Sdk</_AspNetToolsSdkPath>
     <CustomAfterMicrosoftCommonTargets>$(_AspNetToolsSdkPath)\build\Internal.AspNetCore.Sdk.targets</CustomAfterMicrosoftCommonTargets>
     <CustomAfterMicrosoftCommonCrossTargetingTargets>$(_AspNetToolsSdkPath)\buildMultiTargeting\Internal.AspNetCore.Sdk.targets</CustomAfterMicrosoftCommonCrossTargetingTargets>
-    <GenerateCommitHashAttribute Condition="'$(CommitHash)'==''">false</GenerateCommitHashAttribute>
+    <GenerateCommitHashAttribute Condition="'$(RepositoryCommit)'==''">false</GenerateCommitHashAttribute>
     <GenerateSourceLinkFile>false</GenerateSourceLinkFile>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <EnableApiCheck>false</EnableApiCheck>

--- a/build/repo.targets
+++ b/build/repo.targets
@@ -23,18 +23,15 @@
     </ArtifactInfo>
   </ItemGroup>
 
-  <Target Name="ResolveCommitHash" Condition="'$(CommitHash)'==''" BeforeTargets="Prepare">
+  <Target Name="ResolveRepositoryCommit" Condition="'$(RepositoryCommit)'==''" BeforeTargets="Prepare">
 
     <GetGitCommitInfo WorkingDirectory="$(RepositoryRoot)"
-                      Condition="'$(CommitHash)' == ''">
-      <!-- Set both CommitHash and RepositoryCommit. CommitHash was the property we started using at first. RepositoryCommit was introduced when NuGet started adding this to nuspec. -->
-      <Output TaskParameter="CommitHash" PropertyName="CommitHash" />
+                      Condition="'$(RepositoryCommit)' == ''">
       <Output TaskParameter="CommitHash" PropertyName="RepositoryCommit" />
       <Output TaskParameter="Branch" PropertyName="RepositoryBranch" />
     </GetGitCommitInfo>
 
     <PropertyGroup>
-      <SolutionProperties Condition="'$(CommitHash)' != ''">$(SolutionProperties);CommitHash=$(CommitHash)</SolutionProperties>
       <SolutionProperties Condition="'$(RepositoryCommit)' != ''">$(SolutionProperties);RepositoryCommit=$(RepositoryCommit)</SolutionProperties>
       <SolutionProperties Condition="'$(RepositoryBranch)' != ''">$(SolutionProperties);RepositoryBranch=$(RepositoryBranch)</SolutionProperties>
     </PropertyGroup>
@@ -44,10 +41,10 @@
     <RemoveDir Directories="$(_KoreBuildIntermediateDir);$(ArtifactsDir)korebuild\" />
   </Target>
 
-  <Target Name="PackageKoreBuild" DependsOnTargets="ResolveCommitHash;CleanKoreBuild" AfterTargets="Package">
+  <Target Name="PackageKoreBuild" DependsOnTargets="ResolveRepositoryCommit;CleanKoreBuild" AfterTargets="Package">
     <Error Text="Missing property: KoreBuildChannel" Condition="'$(KoreBuildChannel)' == ''" />
     <Error Text="Missing property: Version" Condition="'$(Version)' == ''" />
-    <Error Text="Missing property: CommitHash" Condition="'$(CommitHash)' == ''" />
+    <Error Text="Missing property: RepositoryCommit" Condition="'$(RepositoryCommit)' == ''" />
 
     <!-- passing /warnaserror:BUILD1001 on CI to prevent channel/branch mismatch -->
     <Warning Text="Current branch '$(RepositoryBranch)' does not match the value of KoreBuildChannel: '$(KoreBuildChannel)'"
@@ -68,7 +65,7 @@
     <ItemGroup>
       <Content Include="$(RepositoryRoot)files\KoreBuild\**\*" />
       <VersionFileLines Include="version:$(Version)" />
-      <VersionFileLines Include="commithash:$(CommitHash)" />
+      <VersionFileLines Include="commithash:$(RepositoryCommit)" />
     </ItemGroup>
 
     <MakeDir Directories="$(_ChannelOutDir);$(_KoreBuildOutDir);$(_KoreBuildIntermediateDir)" />

--- a/modules/BuildTools.Tasks/module.targets
+++ b/modules/BuildTools.Tasks/module.targets
@@ -4,17 +4,17 @@
     <PrepareDependsOn>$(PrepareDependsOn);_UseVolatileFeed;ResolveCommitHash</PrepareDependsOn>
   </PropertyGroup>
 
-  <Target Name="ResolveCommitHash" Condition="'$(CommitHash)' == '' OR '$(RepositoryCommit)' == ''">
-    <PropertyGroup Condition=" '$(CommitHash)' == '' ">
-      <CommitHash Condition="'$(APPVEYOR_REPO_COMMIT)' != ''">$(APPVEYOR_REPO_COMMIT)</CommitHash>
-      <CommitHash Condition="'$(TRAVIS_COMMIT)' != ''">$(TRAVIS_COMMIT)</CommitHash>
-      <CommitHash Condition="'$(RepositoryCommit)' != ''">$(RepositoryCommit)</CommitHash>
+  <Target Name="ResolveCommitHash" Condition="'$(RepositoryCommit)' == ''">
+    <PropertyGroup>
+      <RepositoryCommit Condition="'$(APPVEYOR_REPO_COMMIT)' != ''">$(APPVEYOR_REPO_COMMIT)</RepositoryCommit>
+      <RepositoryCommit Condition="'$(TRAVIS_COMMIT)' != ''">$(TRAVIS_COMMIT)</RepositoryCommit>
+      <RepositoryCommit Condition="'$(CommitHash)' != ''">$(CommitHash)</RepositoryCommit>
     </PropertyGroup>
 
     <GetGitCommitHash WorkingDirectory="$(RepositoryRoot)"
-                      Condition="'$(CommitHash)' == ''"
+                      Condition="'$(RepositoryCommit)' == ''"
                       ContinueOnError="WarnAndContinue">
-      <Output TaskParameter="CommitHash" PropertyName="CommitHash" />
+      <Output TaskParameter="CommitHash" PropertyName="RepositoryCommit" />
     </GetGitCommitHash>
 
     <PropertyGroup>
@@ -23,9 +23,9 @@
         We use CommitHash for backwards compatibility with build scripts.
         Setting RepositoryCommit enables NuGet features added in NuGet/NuGet.Client#2036.
       -->
-      <RepositoryCommit>$(CommitHash)</RepositoryCommit>
-      <SolutionProperties Condition="'$(CommitHash)' != ''">$(SolutionProperties);CommitHash=$(CommitHash)</SolutionProperties>
-      <SolutionProperties Condition="'$(CommitHash)' != ''">$(SolutionProperties);RepositoryCommit=$(RepositoryCommit)</SolutionProperties>
+      <CommitHash>$(RepositoryCommit)</CommitHash>
+      <SolutionProperties Condition="'$(RepositoryCommit)' != ''">$(SolutionProperties);CommitHash=$(RepositoryCommit)</SolutionProperties>
+      <SolutionProperties Condition="'$(RepositoryCommit)' != ''">$(SolutionProperties);RepositoryCommit=$(RepositoryCommit)</SolutionProperties>
     </PropertyGroup>
   </Target>
 

--- a/src/Internal.AspNetCore.Sdk/build/Common.props
+++ b/src/Internal.AspNetCore.Sdk/build/Common.props
@@ -23,7 +23,6 @@ Usage: this should be imported once via NuGet at the top of the file.
     <NoPackageAnalysis>true</NoPackageAnalysis>
     <Serviceable Condition="'$(Configuration)' == 'Release'">true</Serviceable>
     <LangVersion Condition="'$(LangVersion)' == ''">7.2</LangVersion>
-    <RepositoryCommit Condition="'$(RepositoryCommit)' == ''">$(CommitHash)</RepositoryCommit>
     <!-- Instructs the compiler to use SHA256 instead of SHA1 when adding file hashes to PDBs. -->
     <ChecksumAlgorithm>SHA256</ChecksumAlgorithm>
     <!-- Suppress the message about using a preview version of .NET Core SDK. We are okay with this and don't need the warning. -->

--- a/src/Internal.AspNetCore.Sdk/build/Git.targets
+++ b/src/Internal.AspNetCore.Sdk/build/Git.targets
@@ -1,6 +1,7 @@
 ﻿<Project>
 
   <PropertyGroup>
+    <CommitHash Condition="'$(RepositoryCommit)' == ''">$(RepositoryCommit)</CommitHash>
     <GenerateCommitHashAttribute Condition="'$(GenerateCommitHashAttribute)'==''">true</GenerateCommitHashAttribute>
     <GeneratedCommitHashAttributeFile Condition="'$(GeneratedCommitHashAttributeFile)'==''">$(IntermediateOutputPath)$(AssemblyName).CommitHash$(DefaultLanguageSourceExtension)</GeneratedCommitHashAttributeFile>
     <SourceLinkDestination Condition="'$(SourceLinkDestination)' == ''">$(IntermediateOutputPath)sourcelink.json</SourceLinkDestination>
@@ -25,18 +26,24 @@
     <PathMap Condition=" '$(DeterministicSourceRoot)' != '' ">$(RepositoryRoot)=$(DeterministicSourceRoot)</PathMap>
   </PropertyGroup>
 
-  <Target Name="ResolveCommitHash" Condition="'$(CommitHash)'==''">
+  <Target Name="ResolveCommitHash" Condition="'$(RepositoryCommit)'==''">
 
     <PropertyGroup>
-      <CommitHash Condition="'$(APPVEYOR_REPO_COMMIT)' != ''">$(APPVEYOR_REPO_COMMIT)</CommitHash>
-      <CommitHash Condition="'$(TRAVIS_COMMIT)' != ''">$(TRAVIS_COMMIT)</CommitHash>
+      <RepositoryCommit Condition="'$(APPVEYOR_REPO_COMMIT)' != ''">$(APPVEYOR_REPO_COMMIT)</RepositoryCommit>
+      <RepositoryCommit Condition="'$(TRAVIS_COMMIT)' != ''">$(TRAVIS_COMMIT)</RepositoryCommit>
+      <RepositoryCommit Condition="'$(CommitHash)' != ''">$(CommitHash)</RepositoryCommit>
     </PropertyGroup>
 
     <Sdk_GetGitCommitHash WorkingDirectory="$(MSBuildProjectDirectory)"
-                      Condition="'$(CommitHash)' == ''"
+                      Condition="'$(RepositoryCommit)' == ''"
                       ContinueOnError="WarnAndContinue">
-      <Output TaskParameter="CommitHash" PropertyName="CommitHash" />
+      <Output TaskParameter="CommitHash" PropertyName="RepositoryCommit" />
     </Sdk_GetGitCommitHash>
+
+    <PropertyGroup>
+      <!-- Set both CommitHash and RepositoryCommit. CommitHash was the property we started using at first. RepositoryCommit was introduced when NuGet started adding this to nuspec. -->
+      <CommitHash>$(RepositoryCommit)</CommitHash>
+    </PropertyGroup>
   </Target>
 
   <Target Name="CreateSourceLink"
@@ -47,10 +54,10 @@
     <Sdk_CreateSourceLink
           SourceLinkRoot="$(SourceLinkRoot)"
           OriginUrl="$(RepositoryUrl)"
-          Commit="$(CommitHash)"
+          Commit="$(RepositoryCommit)"
           DestinationFile="$(SourceLinkDestination)"
           ContinueOnError="WarnAndContinue"
-          Condition="'$(CommitHash)' != '' AND '$(RepositoryUrl)' != '' AND '$(SourceLinkRoot)' != ''">
+          Condition="'$(RepositoryCommit)' != '' AND '$(RepositoryUrl)' != '' AND '$(SourceLinkRoot)' != ''">
       <Output TaskParameter="SourceLinkFile" PropertyName="SourceLink" />
     </Sdk_CreateSourceLink>
 
@@ -58,7 +65,7 @@
              Condition="'$(RepositoryUrl)' == ''" />
 
     <Warning Text="SourceLink not enabled because this is not a git repo."
-             Condition="'$(CommitHash)' == ''" />
+             Condition="'$(RepositoryCommit)' == ''" />
 
     <Warning Text="SourceLink not enabled because SourceLinkRoot wasn't set."
              Condition="'$(SourceLinkRoot)' == ''" />
@@ -74,14 +81,14 @@ Generates an assembly attribute with commit hash
           BeforeTargets="CoreCompile"
           DependsOnTargets="ResolveCommitHash;PrepareForBuild;GenerateIntermediateCommitHash;CoreGenerateCommitHashAttribute;CreateSourceLink"
           Condition="'$(GenerateCommitHashAttribute)'=='true' and '$(DesignTimeBuild)'!='true'" >
-    <Warning Text="Property 'CommitHash' was not set"
-             Condition="'$(CommitHash)'==''" />
+    <Warning Text="Property 'RepositoryCommit' was not set"
+             Condition="'$(RepositoryCommit)'==''" />
   </Target>
 
-  <Target Name="GenerateIntermediateCommitHash" Condition="'$(CommitHash)' != ''">
+  <Target Name="GenerateIntermediateCommitHash" Condition="'$(RepositoryCommit)' != ''">
     <PropertyGroup>
       <!-- shorten to help avoid max path length issues -->
-      <IntermediateCommitHash>$(IntermediateOutputPath)$(CommitHash.Substring(0, 10)).commit</IntermediateCommitHash>
+      <IntermediateCommitHash>$(IntermediateOutputPath)$(RepositoryCommit.Substring(0, 10)).commit</IntermediateCommitHash>
     </PropertyGroup>
 
     <ItemGroup>
@@ -93,7 +100,7 @@ Generates an assembly attribute with commit hash
   </Target>
 
   <Target Name="CoreGenerateCommitHashAttribute"
-          Condition="'$(CommitHash)'!='' and '$(GenerateCommitHashAttribute)'=='true'"
+          Condition="'$(RepositoryCommit)'!='' and '$(GenerateCommitHashAttribute)'=='true'"
           Inputs="$(IntermediateCommitHash)"
           Outputs="$(GeneratedCommitHashAttributeFile)">
 
@@ -101,7 +108,7 @@ Generates an assembly attribute with commit hash
       <_CustomAttributes Remove="@(_CustomAttributes)" />
       <_CustomAttributes Include="System.Reflection.AssemblyMetadataAttribute">
         <_Parameter1>CommitHash</_Parameter1>
-        <_Parameter2>$(CommitHash)</_Parameter2>
+        <_Parameter2>$(RepositoryCommit)</_Parameter2>
       </_CustomAttributes>
     </ItemGroup>
 


### PR DESCRIPTION
`dotnet pack` on .nuspec files because we have started using $(RepositoryCommit) everwhere, but Internal.AspNetCore.Sdk was only setting the CommitHash property.

workaround for https://github.com/NuGet/Home/issues/6722