### PR TITLE
Specify Expand-Archive cmd module explicitly

### DIFF
--- a/scripts/bootstrapper/run.ps1
+++ b/scripts/bootstrapper/run.ps1
@@ -113,9 +113,9 @@ function Get-KoreBuild {
         try {
             $tmpfile = Join-Path ([IO.Path]::GetTempPath()) "KoreBuild-$([guid]::NewGuid()).zip"
             Get-RemoteFile $remotePath $tmpfile $ToolsSourceSuffix
-            if (Get-Command -Name 'Expand-Archive' -ErrorAction Ignore) {
+            if (Get-Command -Name 'Microsoft.PowerShell.Archive\Expand-Archive' -ErrorAction Ignore) {
                 # Use built-in commands where possible as they are cross-plat compatible
-                Expand-Archive -Path $tmpfile -DestinationPath $korebuildPath
+                Microsoft.PowerShell.Archive\Expand-Archive -Path $tmpfile -DestinationPath $korebuildPath
             }
             else {
                 # Fallback to old approach for old installations of PowerShell


### PR DESCRIPTION
Moved from https://github.com/aspnet/Blazor/pull/421

Recommendation: Specify the `Expand-Archive` command module (`Microsoft.PowerShell.Archive`) explicitly in the *run.ps1* script. Anyone who has the [PowerShell Community Extensions (Pscx)](https://github.com/Pscx/Pscx) installed gets a big 'ole :boom: if it isn't specified ...

```
Expand-Archive : A parameter cannot be found that matches parameter name 'DestinationPath'.
At C:\Users\xxxxxxx\Documents\GitHub\Blazor\run.ps1:106 char:47
 ...                Expand-Archive -Path $tmpfile -DestinationPath $korebu ...
                                                  ~~~~~~~~~~~~~~~~
     CategoryInfo          : InvalidArgument: (:) [Expand-Archive], ParentContainsErrorRecordException
     FullyQualifiedErrorId : NamedParameterNotFound,Pscx.Commands.IO.Compression.ExpandArchiveCommand
```