### PR TITLE
Redirect output from tests

### DIFF
--- a/modules/BuildTools.Tasks/Run.cs
+++ b/modules/BuildTools.Tasks/Run.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
 
 namespace Microsoft.AspNetCore.BuildTools
 {
@@ -24,6 +25,11 @@ namespace Microsoft.AspNetCore.BuildTools
         [Required]
         public string FileName { get; set; }
 
-        protected override string GetExecutable() => FileName;
+        protected override string ToolName => FileName;
+
+        protected override string GenerateFullPathToTool()
+        {
+            return FileName;
+        }
     }
 }

--- a/modules/BuildTools.Tasks/RunDotNet.cs
+++ b/modules/BuildTools.Tasks/RunDotNet.cs
@@ -18,7 +18,9 @@ namespace Microsoft.AspNetCore.BuildTools
 #endif
         : RunBase
     {
-        protected override string GetExecutable()
+        protected override string ToolName => "dotnet";
+
+        protected override string GenerateFullPathToTool()
 #if NET46
             => "dotnet";
 #else


### PR DESCRIPTION
Tested against the BuildTools repo with and without error output, it seems to do the job (though we lose colorization as we expected).

Fixes #624 and #623.