### PR TITLE
Fix missing build number from TC output

### DIFF
--- a/files/KoreBuild/modules/teamcity/module.targets
+++ b/files/KoreBuild/modules/teamcity/module.targets
@@ -1,7 +1,7 @@
 <Project>
 
   <Target Name="SetTeamCityBuildNumberToVersion">
-    <Message Text="##teamcity[buildNumber '$(Version)']" Condition=" '$(TEAMCITY_VERSION)' != '' "/>
+    <Message Text="##teamcity[buildNumber '$(Version)']" Importance="High" Condition=" '$(TEAMCITY_VERSION)' != '' "/>
   </Target>
 
 </Project>


### PR DESCRIPTION
TC stopped showing the right build number after https://github.com/aspnet/BuildTools/pull/636

![image](https://user-images.githubusercontent.com/2696087/38884294-0c3cc164-4224-11e8-847d-2a6b3b3b87af.png)
