### PR TITLE
Escape quote in arguments passed to dotnet-install.ps1

### DIFF
--- a/files/KoreBuild/scripts/dotnet-install.cmd
+++ b/files/KoreBuild/scripts/dotnet-install.cmd
@@ -1,3 +1,4 @@
+@ECHO OFF
 SET Args=%*
 SET Args=%Args:"='%
 PowerShell -NoProfile -NoLogo -ExecutionPolicy unrestricted -Command "[System.Threading.Thread]::CurrentThread.CurrentCulture = ''; [System.Threading.Thread]::CurrentThread.CurrentUICulture = '';& '%~dp0dotnet-install.ps1' %Args%; exit $LASTEXITCODE"

--- a/files/KoreBuild/scripts/dotnet-install.cmd
+++ b/files/KoreBuild/scripts/dotnet-install.cmd
@@ -1,2 +1,3 @@
-@ECHO OFF
-PowerShell -NoProfile -NoLogo -ExecutionPolicy unrestricted -Command "[System.Threading.Thread]::CurrentThread.CurrentCulture = ''; [System.Threading.Thread]::CurrentThread.CurrentUICulture = '';& '%~dp0dotnet-install.ps1' %*; exit $LASTEXITCODE"
+SET Args=%*
+SET Args=%Args:"='%
+PowerShell -NoProfile -NoLogo -ExecutionPolicy unrestricted -Command "[System.Threading.Thread]::CurrentThread.CurrentCulture = ''; [System.Threading.Thread]::CurrentThread.CurrentUICulture = '';& '%~dp0dotnet-install.ps1' %Args%; exit $LASTEXITCODE"


### PR DESCRIPTION
A workaround for #666. Maybe unexpected side effect there but works for me.