### PR TITLE
SiteExtensions use netcoreapp2.2

### DIFF
--- a/src/Internal.AspNetCore.SiteExtension.Sdk/build/Internal.AspNetCore.SiteExtension.Sdk.targets
+++ b/src/Internal.AspNetCore.SiteExtension.Sdk/build/Internal.AspNetCore.SiteExtension.Sdk.targets
@@ -17,8 +17,8 @@
     </PropertyGroup>
 
     <ItemGroup Condition="'@(HostingStartupRuntimeStoreFrameworks->Count())' == '0'">
-      <HostingStartupRuntimeStoreTargets Include="netcoreapp2.1" Runtime="win7-x64" />
-      <HostingStartupRuntimeStoreTargets Include="netcoreapp2.1" Runtime="win7-x86" />
+      <HostingStartupRuntimeStoreTargets Include="$(TargetFramework)" Runtime="win7-x64" />
+      <HostingStartupRuntimeStoreTargets Include="$(TargetFramework)" Runtime="win7-x86" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
We get errors like `error NU1202: Package is not compatible with netcoreapp2.1 (.NETCoreApp,Version=v2.1). Package Microsoft.AspNetCore.App 2.2.0-preview1-34201 supports: netcoreapp2.2 (.NETCoreApp,Version=v2.2)` on the CI because our extensions are still trying to build against netcoreapp2.2. I've created this PR to change that, but I'm not 100% if it's the correct fix. Thoughts?