### PR TITLE
Don't police tfm for extensions

### DIFF
--- a/src/Internal.AspNetCore.SiteExtension.Sdk/build/Internal.AspNetCore.SiteExtension.Sdk.targets
+++ b/src/Internal.AspNetCore.SiteExtension.Sdk/build/Internal.AspNetCore.SiteExtension.Sdk.targets
@@ -38,7 +38,10 @@
         <ManifestLines Include="&lt;PackageReference Remove=&quot;Internal.AspNetCore.Sdk&quot; /&gt;" />
         <ManifestLines Include="&lt;PackageReference Include=&quot;Microsoft.AspNetCore.App&quot; Version=&quot;$(MicrosoftAspNetCoreAppPackageVersion)&quot; IsImplicitlyDefined=&quot;true&quot;/&gt;" />
         <ManifestLines Include="&lt;PackageReference Include=&quot;%(HostingStartupPackageReference.Identity)&quot; Version=&quot;%(HostingStartupPackageReference.Version)&quot; /&gt;" />
-        <ManifestLines Include="&lt;/ItemGroup&gt;&lt;/Project&gt;" />
+        <ManifestLines Include="&lt;/ItemGroup&gt;" />
+        <ManifestLines Include="&lt;PropertyGroup&gt;" />
+        <ManifestLines Include="&lt;NETCoreAppMaximum&gt;99.9&lt;/NETCoreAppMaximum&gt;" />
+        <ManifestLines Include="&lt;/PropertyGroup&gt; &lt;/Project&gt;" />
 
     </ItemGroup>
 


### PR DESCRIPTION
Let's not run the TFM check for extensions, the same way we do for other projects, to avoid problems.