### PR TITLE
Skip validation of assembly version attributes for global CLI tool packages

### DIFF
--- a/modules/NuGetPackageVerifier/console/Constants.cs
+++ b/modules/NuGetPackageVerifier/console/Constants.cs
@@ -1,0 +1,12 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using NuGet.Packaging.Core;
+
+namespace NuGetPackageVerifier
+{
+    public class Constants
+    {
+        public static PackageType DotNetTool = new PackageType("DotnetTool", PackageType.EmptyVersion);
+    }
+}

--- a/modules/NuGetPackageVerifier/console/Rules/DotNetToolPackageRule.cs
+++ b/modules/NuGetPackageVerifier/console/Rules/DotNetToolPackageRule.cs
@@ -14,11 +14,9 @@ namespace NuGetPackageVerifier.Rules
     {
         private const string ToolManifestFileName = "DotnetToolSettings.xml";
 
-        private static PackageType DotNetTool = new PackageType("DotnetTool", PackageType.EmptyVersion);
-
         public IEnumerable<PackageVerifierIssue> Validate(PackageAnalysisContext context)
         {
-            if (!context.Metadata.PackageTypes.Any(p => p == DotNetTool))
+            if (!context.Metadata.PackageTypes.Any(p => p == Constants.DotNetTool))
             {
                 yield break;
             }
@@ -28,7 +26,7 @@ namespace NuGetPackageVerifier.Rules
 
             if (packageFiles == null || manifests.Count() == 0)
             {
-                yield return PackageIssueFactory.DotNetToolMustHaveManifest(DotNetTool.Name, ToolManifestFileName);
+                yield return PackageIssueFactory.DotNetToolMustHaveManifest(Constants.DotNetTool.Name, ToolManifestFileName);
                 yield break;
             }
 

--- a/modules/NuGetPackageVerifier/console/Rules/PackageVersionMatchesAssemblyVersionRule.cs
+++ b/modules/NuGetPackageVerifier/console/Rules/PackageVersionMatchesAssemblyVersionRule.cs
@@ -13,6 +13,12 @@ namespace NuGetPackageVerifier.Rules
     {
         public IEnumerable<PackageVerifierIssue> Validate(PackageAnalysisContext context)
         {
+            if (context.Metadata.PackageTypes.Any(p => p == Constants.DotNetTool))
+            {
+                // Skip for dotnet global tool packages which contain assemblies from other teams and projects
+                yield break;
+            }
+
             AssemblyAttributesDataHelper.SetAssemblyAttributesData(context);
             foreach (var assemblyData in context.AssemblyData)
             {

--- a/version.props
+++ b/version.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <KoreBuildChannel>release/2.1</KoreBuildChannel>
-    <VersionPrefix>2.1.0</VersionPrefix>
+    <VersionPrefix>2.1.1</VersionPrefix>
     <VersionSuffix>rtm</VersionSuffix>
     <BuildNumber Condition="'$(BuildNumber)' == ''">t000</BuildNumber>
     <VersionSuffix Condition="'$(VersionSuffix)' != '' AND '$(BuildNumber)' != ''">$(VersionSuffix)-$(BuildNumber)</VersionSuffix>


### PR DESCRIPTION
This will help us when patching tools like dotnet-ef which have assemblies from our team and others. Skip the validation of assembly attributes because these are not important for CLI tool packages.

Required to unblock https://github.com/aspnet/Universe/pull/1175