### PR TITLE
Adds command to install VS components

### DIFF
--- a/build/tasks/RepoTasks.csproj
+++ b/build/tasks/RepoTasks.csproj
@@ -20,6 +20,7 @@
     <Compile Include="..\..\modules\BuildTools.Tasks\ZipArchive.cs" />
 
     <Compile Include="..\..\modules\KoreBuild.Tasks\DownloadFile.cs" />
+    <Compile Include="..\..\modules\KoreBuild.Tasks\Utilities\DownloadFileHelper.cs" />
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), version.props))\build\sdk.targets" />

--- a/docs/KoreBuild.md
+++ b/docs/KoreBuild.md
@@ -13,6 +13,7 @@ Previously repositories were runable in only one way, by doing `.\build.cmd`. Bu
 Command               | Purpose                                                          | Example
 ----------------------|------------------------------------------------------------------|----------
 install-tools         | Installs dotnet, CLI and Shared runtimes.                        | .\run.ps1 install-tools
+install vs            | Installs/Updates VS components                                   | .\run.ps1 install vs --quiet --product Enterprise
 docker-build          | Runs the build inside docker.                                    | .\run.ps1 docker-build {jessie\|winservercore} /t:SomeTarget /p:Parameters
 default-build         | Runs install-tools followed by msbuild (like build.cmd used to). | .\run.ps1 default-build /t:SomeTarget /p:Parameters
 msbuild               | Runs the build normally.                                         | .\run.ps1 msbuild /t:SomeTarget /p:Parameters

--- a/modules/KoreBuild.Tasks/DownloadFile.cs
+++ b/modules/KoreBuild.Tasks/DownloadFile.cs
@@ -43,7 +43,7 @@ namespace KoreBuild.Tasks
 
         public Task<bool> ExecuteAsync()
         {
-            return DownloadFileHelper.DownloadFileAsync(Uri, DestinationPath, Overwrite,  _cts, TimeoutSeconds, Log);
+            return DownloadFileHelper.DownloadFileAsync(Uri, DestinationPath, Overwrite,  _cts.Token, TimeoutSeconds, Log);
         }
     }
 }

--- a/modules/KoreBuild.Tasks/GetToolsets.cs
+++ b/modules/KoreBuild.Tasks/GetToolsets.cs
@@ -98,7 +98,7 @@ namespace KoreBuild.Tasks
                 if (vsToolset.Required != KoreBuildSettings.RequiredPlatforms.None)
                 {
                     Log.LogError($"Could not find an installation of Visual Studio that satisifies the specified requirements in {ConfigFile}" +
-                        "See https://docs.microsoft.com/en-us/visualstudio/install/workload-component-id-vs-community for more details on any missing components.");
+                        "Execute run.ps1 install vs to update or install the current vs installation.");
                 }
                 return;
             }

--- a/modules/KoreBuild.Tasks/GetToolsets.cs
+++ b/modules/KoreBuild.Tasks/GetToolsets.cs
@@ -97,7 +97,7 @@ namespace KoreBuild.Tasks
             {
                 if (vsToolset.Required != KoreBuildSettings.RequiredPlatforms.None)
                 {
-                    Log.LogError($"Could not find an installation of Visual Studio that satisifies the specified requirements in {ConfigFile}. " + 
+                    Log.LogError($"Could not find an installation of Visual Studio that satisifies the specified requirements in {ConfigFile}" +
                         "See https://docs.microsoft.com/en-us/visualstudio/install/workload-component-id-vs-community for more details on any missing components.");
                 }
                 return;

--- a/modules/KoreBuild.Tasks/InstallToolsets.cs
+++ b/modules/KoreBuild.Tasks/InstallToolsets.cs
@@ -27,7 +27,7 @@ namespace KoreBuild.Tasks
         /// Whether to install toolsets with or without user interation.
         /// It will default prompting users to confirm and see installation steps.
         /// </summary>
-        public bool QuietInstallationOfToolsets { get; set; }
+        public bool QuietVSInstallation { get; set; }
 
         /// <summary>
         /// Whether to upgrade existing toolsets.
@@ -95,7 +95,7 @@ namespace KoreBuild.Tasks
             }
 
             var vs = VsWhere.FindLatestCompatibleInstallation(vsToolset, Log);
-            var vsExePath = await VsInstallerHelper.DownloadVsExe(Log);
+            var vsExePath = await VsInstallerHelper.DownloadVsExe(Log, VSProductVersionType);
             var vsJsonFilePath = VsInstallerHelper.CreateVsFileFromRequiredToolset(vsToolset, Log, VSProductVersionType);
 
             var args = GetVisualStudioArgs(vs, vsJsonFilePath);
@@ -138,7 +138,7 @@ namespace KoreBuild.Tasks
             args.Add("--wait");
             args.Add("--norestart");
 
-            if (QuietInstallationOfToolsets)
+            if (QuietVSInstallation)
             {
                 args.Add("--quiet");
             }

--- a/modules/KoreBuild.Tasks/InstallToolsets.cs
+++ b/modules/KoreBuild.Tasks/InstallToolsets.cs
@@ -1,0 +1,142 @@
+// Copyright(c) .NET Foundation.All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using KoreBuild.Tasks.Utilities;
+using Microsoft.Build.Framework;
+using Microsoft.Extensions.CommandLineUtils;
+
+namespace KoreBuild.Tasks
+{
+    /// <summary>
+    /// Installs toolset information as listed in korebuild.json
+    /// </summary>
+    public class InstallToolsets : Microsoft.Build.Utilities.Task
+    {
+        /// <summary>
+        /// The path to the korebuild.json file.
+        /// </summary>
+        [Required]
+        public string ConfigFile { get; set; }
+
+        /// <summary>
+        /// Whether to install toolsets with or without user interation.
+        /// It will default prompting users to confirm and see installation steps.
+        /// </summary>
+        public bool Quiet { get; set; }
+
+        /// <summary>
+        /// Whether to upgrade existing toolsets.
+        /// It will default to only adding tools that were not previously installed.
+        /// </summary>
+        public bool Upgrade { get; set; }
+
+        public override bool Execute()
+        {
+            return ExecuteAsync().GetAwaiter().GetResult();
+        }
+
+        public async Task<bool> ExecuteAsync()
+        {
+            if (!File.Exists(ConfigFile))
+            {
+                Log.LogError($"Could not load the korebuild config file from '{ConfigFile}'");
+                return false;
+            }
+
+            var settings = KoreBuildSettings.Load(ConfigFile);
+
+            if (settings?.Toolsets == null)
+            {
+                Log.LogMessage(MessageImportance.Normal, "No recognized toolsets specified.");
+                return true;
+            }
+
+            foreach (var toolset in settings.Toolsets)
+            {
+                switch (toolset)
+                {
+                    case KoreBuildSettings.VisualStudioToolset vs:
+                        await InstallVsComponents(vs);
+                        break;
+                    // TODO support NodeJSToolset
+                    default:
+                        Log.LogWarning("Toolset checks not implemented for " + toolset.GetType().Name);
+                        break;
+                }
+            }
+
+            return true;
+        }
+
+        private async Task InstallVsComponents(KoreBuildSettings.VisualStudioToolset vsToolset)
+        {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                if ((vsToolset.Required & ~KoreBuildSettings.RequiredPlatforms.Windows) != 0)
+                {
+                    Log.LogError("Visual Studio is not available on non-Windows. Change korebuild.json to 'required: [\"windows\"]'.");
+                }
+                else
+                {
+                    Log.LogMessage(MessageImportance.Low, "Skipping Visual Studio verification on non-Windows platforms.");
+                }
+                return;
+            }
+
+            var vs = VsWhere.FindLatestCompatibleInstallation(vsToolset, Log);
+            var vsExePath = await VsInstallerHelper.DownloadVsExe(Log);
+            var vsJsonFilePath = VsInstallerHelper.CreateVsFileFromRequiredToolset(vsToolset, Log);
+
+            var args = GetVisualStudioArgs(vs, vsJsonFilePath);
+
+            var psi = new ProcessStartInfo
+            {
+                FileName = vsExePath,
+                Arguments = args
+            };
+
+            Log.LogMessage($"Calling: {psi.FileName} {psi.Arguments}");
+
+            var process = Process.Start(psi);
+
+            process.WaitForExit();
+
+            return;
+        }
+
+        private string GetVisualStudioArgs(VsInstallation vs, string vsJsonFilePath)
+        {
+            var args = new List<string>();
+
+            if (vs != null)
+            {
+                if (Upgrade)
+                {
+                    args.Add("upgrade");
+                }
+                else
+                {
+                    args.Add("modify");
+                }
+            }
+
+            args.Add("--installPath");
+            args.Add($"{vs.InstallationPath}");
+            args.Add("--in");
+            args.Add($"{vsJsonFilePath}");
+            args.Add("--wait");
+            args.Add("--norestart");
+
+            if (Quiet)
+            {
+                args.Add("--quiet");
+            }
+            return ArgumentEscaper.EscapeAndConcatenate(args);
+        }
+    }
+}

--- a/modules/KoreBuild.Tasks/InstallToolsets.cs
+++ b/modules/KoreBuild.Tasks/InstallToolsets.cs
@@ -99,11 +99,11 @@ namespace KoreBuild.Tasks
 
             if (vs != null)
             {
-                Log.LogMessage(MessageImportance.Low, $"Found vs installation located at {vs.InstallationPath}");
+                Log.LogMessage($"Found vs installation located at {vs.InstallationPath}");
             }
             else
             {
-                Log.LogMessage(MessageImportance.Low, $"No vs installation found.");
+                Log.LogMessage($"No vs installation found.");
             }
 
             var vsExePath = await VsInstallerHelper.DownloadVsExe(Log, VSProductVersionType);

--- a/modules/KoreBuild.Tasks/InstallToolsets.cs
+++ b/modules/KoreBuild.Tasks/InstallToolsets.cs
@@ -27,13 +27,19 @@ namespace KoreBuild.Tasks
         /// Whether to install toolsets with or without user interation.
         /// It will default prompting users to confirm and see installation steps.
         /// </summary>
-        public bool Quiet { get; set; }
+        public bool QuietInstallationOfToolsets { get; set; }
 
         /// <summary>
         /// Whether to upgrade existing toolsets.
         /// It will default to only adding tools that were not previously installed.
         /// </summary>
-        public bool Upgrade { get; set; }
+        public bool UpgradeVSInstallation { get; set; }
+
+        /// <summary>
+        /// Specifies what version of VS to install.
+        /// Defaults to Enterprise.
+        /// </summary>
+        public string VSProductVersionType { get; set; } = "Enterprise";
 
         public override bool Execute()
         {
@@ -70,7 +76,7 @@ namespace KoreBuild.Tasks
                 }
             }
 
-            return true;
+            return !Log.HasLoggedErrors;
         }
 
         private async Task InstallVsComponents(KoreBuildSettings.VisualStudioToolset vsToolset)
@@ -90,7 +96,7 @@ namespace KoreBuild.Tasks
 
             var vs = VsWhere.FindLatestCompatibleInstallation(vsToolset, Log);
             var vsExePath = await VsInstallerHelper.DownloadVsExe(Log);
-            var vsJsonFilePath = VsInstallerHelper.CreateVsFileFromRequiredToolset(vsToolset, Log);
+            var vsJsonFilePath = VsInstallerHelper.CreateVsFileFromRequiredToolset(vsToolset, Log, VSProductVersionType);
 
             var args = GetVisualStudioArgs(vs, vsJsonFilePath);
 
@@ -115,7 +121,7 @@ namespace KoreBuild.Tasks
 
             if (vs != null)
             {
-                if (Upgrade)
+                if (UpgradeVSInstallation)
                 {
                     args.Add("upgrade");
                 }
@@ -132,7 +138,7 @@ namespace KoreBuild.Tasks
             args.Add("--wait");
             args.Add("--norestart");
 
-            if (Quiet)
+            if (QuietInstallationOfToolsets)
             {
                 args.Add("--quiet");
             }

--- a/modules/KoreBuild.Tasks/Utilities/DownloadFileHelper.cs
+++ b/modules/KoreBuild.Tasks/Utilities/DownloadFileHelper.cs
@@ -1,0 +1,76 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Build.Utilities;
+using Task = System.Threading.Tasks.Task;
+
+namespace KoreBuild.Tasks.Utilities
+{
+    public class DownloadFileHelper
+    {
+        public static async Task<bool> DownloadFileAsync(string uri, string destinationPath, bool overwrite, CancellationTokenSource cts, int timeoutSeconds, TaskLoggingHelper log)
+        {
+            if (File.Exists(destinationPath) && !overwrite)
+            {
+                return true;
+            }
+
+            const string FileuriProtocol = "file://";
+
+            if (uri.StartsWith(FileuriProtocol, StringComparison.OrdinalIgnoreCase))
+            {
+                var filePath = uri.Substring(FileuriProtocol.Length);
+                log.LogMessage($"Copying '{filePath}' to '{destinationPath}'");
+                File.Copy(filePath, destinationPath);
+            }
+            else
+            {
+                log.LogMessage($"Downloading '{uri}' to '{destinationPath}'");
+
+                using (var httpClient = new HttpClient
+                {
+                    // Timeout if no response starts in 2 minutes
+                    Timeout = TimeSpan.FromMinutes(2),
+                })
+                {
+                    try
+                    {
+                        var response = await httpClient.GetAsync(uri, cts.Token);
+                        response.EnsureSuccessStatusCode();
+                        cts.Token.ThrowIfCancellationRequested();
+
+                        Directory.CreateDirectory(Path.GetDirectoryName(destinationPath));
+
+                        using (var outStream = File.Create(destinationPath))
+                        {
+                            var responseStream = response.Content.ReadAsStreamAsync();
+                            var finished = await Task.WhenAny(responseStream, Task.Delay(TimeSpan.FromSeconds(timeoutSeconds)));
+
+                            if (!ReferenceEquals(responseStream, finished))
+                            {
+                                throw new TimeoutException($"Download failed to complete in {timeoutSeconds} seconds.");
+                            }
+
+                            responseStream.Result.CopyTo(outStream);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        log.LogError($"Downloading '{uri}' failed.");
+                        log.LogErrorFromException(ex, showStackTrace: true);
+
+                        File.Delete(destinationPath);
+                        return false;
+                    }
+                }
+            }
+
+            return !log.HasLoggedErrors;
+        }
+    }
+}

--- a/modules/KoreBuild.Tasks/Utilities/DownloadFileHelper.cs
+++ b/modules/KoreBuild.Tasks/Utilities/DownloadFileHelper.cs
@@ -13,7 +13,7 @@ namespace KoreBuild.Tasks.Utilities
 {
     public class DownloadFileHelper
     {
-        public static async Task<bool> DownloadFileAsync(string uri, string destinationPath, bool overwrite, CancellationTokenSource cts, int timeoutSeconds, TaskLoggingHelper log)
+        public static async Task<bool> DownloadFileAsync(string uri, string destinationPath, bool overwrite, CancellationToken cancellationToken, int timeoutSeconds, TaskLoggingHelper log)
         {
             if (File.Exists(destinationPath) && !overwrite)
             {
@@ -40,9 +40,9 @@ namespace KoreBuild.Tasks.Utilities
                 {
                     try
                     {
-                        var response = await httpClient.GetAsync(uri, cts.Token);
+                        var response = await httpClient.GetAsync(uri, cancellationToken);
                         response.EnsureSuccessStatusCode();
-                        cts.Token.ThrowIfCancellationRequested();
+                        cancellationToken.ThrowIfCancellationRequested();
 
                         Directory.CreateDirectory(Path.GetDirectoryName(destinationPath));
 

--- a/modules/KoreBuild.Tasks/Utilities/VsInstallerHelper.cs
+++ b/modules/KoreBuild.Tasks/Utilities/VsInstallerHelper.cs
@@ -17,10 +17,10 @@ namespace KoreBuild.Tasks.Utilities
             // TODO put this in an obj folder instead of temp?
             var tempPath = Path.Combine(Path.GetTempPath(), "vs_enterprise.exe");
 
-            await DownloadFileHelper.DownloadFileAsync(uri: "https://aka.ms/vs/15/pre/vs_enterprise.exe",
+            await DownloadFileHelper.DownloadFileAsync(uri: "https://aka.ms/vs/15/release/vs_enterprise.exe",
                 destinationPath: tempPath,
                 overwrite: false,
-                cts: new CancellationTokenSource(),
+                cancellationToken: new CancellationToken(),
                 timeoutSeconds: 60 * 15,
                 log);
 
@@ -45,13 +45,13 @@ namespace KoreBuild.Tasks.Utilities
             public List<string> Add { get; set; }
         }
 
-        public static string CreateVsFileFromRequiredToolset(KoreBuildSettings.VisualStudioToolset vsToolset, TaskLoggingHelper log)
+        public static string CreateVsFileFromRequiredToolset(KoreBuildSettings.VisualStudioToolset vsToolset, TaskLoggingHelper log, string vsProductType)
         {
             var vsFile = new VsJsonFile
             {
                 ChannelUri = "https://aka.ms/vs/15/release/channel",
                 ChannelId = "VisualStudio.15.Release",
-                ProductId = "Microsoft.VisualStudio.Product.Enterprise",
+                ProductId = $"Microsoft.VisualStudio.Product.{vsProductType}",
                 IncludeRecommended = false,
                 AddProductLang = new List<string>
                 {

--- a/modules/KoreBuild.Tasks/Utilities/VsInstallerHelper.cs
+++ b/modules/KoreBuild.Tasks/Utilities/VsInstallerHelper.cs
@@ -14,10 +14,10 @@ namespace KoreBuild.Tasks.Utilities
     { 
         public static async Task<string> DownloadVsExe(TaskLoggingHelper log, string vsProductType)
         {
-            // TODO put this in an obj folder instead of temp?
-            var tempPath = Path.Combine(Path.GetTempPath(), "vs.exe");
+            var exeName = $"vs_{vsProductType}.exe";
+            var tempPath = Path.Combine(Path.GetTempPath(), exeName);
 
-            await DownloadFileHelper.DownloadFileAsync(uri: $"https://aka.ms/vs/15/release/vs_{vsProductType}.exe",
+            await DownloadFileHelper.DownloadFileAsync(uri: $"https://aka.ms/vs/15/release/{exeName}",
                 destinationPath: tempPath,
                 overwrite: true,
                 cancellationToken: new CancellationToken(),
@@ -60,7 +60,7 @@ namespace KoreBuild.Tasks.Utilities
                 Add = new List<string>(vsToolset.RequiredWorkloads)
             };
 
-            var tempFile = Path.Combine(Path.GetTempPath(), "vs.json");
+            var tempFile = Path.Combine(Path.GetTempPath(), $"vs_{vsProductType}.json");
 
             var json = JsonConvert.SerializeObject(vsFile);
             File.WriteAllText(tempFile, json);

--- a/modules/KoreBuild.Tasks/Utilities/VsInstallerHelper.cs
+++ b/modules/KoreBuild.Tasks/Utilities/VsInstallerHelper.cs
@@ -1,0 +1,71 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Build.Utilities;
+using Newtonsoft.Json;
+
+namespace KoreBuild.Tasks.Utilities
+{
+    internal class VsInstallerHelper
+    { 
+        public static async Task<string> DownloadVsExe(TaskLoggingHelper log)
+        {
+            // TODO put this in an obj folder instead of temp?
+            var tempPath = Path.Combine(Path.GetTempPath(), "vs_enterprise.exe");
+
+            await DownloadFileHelper.DownloadFileAsync(uri: "https://aka.ms/vs/15/pre/vs_enterprise.exe",
+                destinationPath: tempPath,
+                overwrite: false,
+                cts: new CancellationTokenSource(),
+                timeoutSeconds: 60 * 15,
+                log);
+
+            log.LogMessage($"Downloaded visual studio exe to {tempPath}.");
+
+            return tempPath;
+        }
+
+        private class VsJsonFile
+        {
+            [JsonProperty(PropertyName = "channelUri")]
+            public string ChannelUri { get; set; }
+            [JsonProperty(PropertyName = "channelId")]
+            public string ChannelId { get; set; }
+            [JsonProperty(PropertyName = "productId")]
+            public string ProductId { get; set; }
+            [JsonProperty(PropertyName = "includeRecommended")]
+            public bool IncludeRecommended { get; set; }
+            [JsonProperty(PropertyName = "addProductLang")]
+            public List<string> AddProductLang { get; set; }
+            [JsonProperty(PropertyName = "add")]
+            public List<string> Add { get; set; }
+        }
+
+        public static string CreateVsFileFromRequiredToolset(KoreBuildSettings.VisualStudioToolset vsToolset, TaskLoggingHelper log)
+        {
+            var vsFile = new VsJsonFile
+            {
+                ChannelUri = "https://aka.ms/vs/15/release/channel",
+                ChannelId = "VisualStudio.15.Release",
+                ProductId = "Microsoft.VisualStudio.Product.Enterprise",
+                IncludeRecommended = false,
+                AddProductLang = new List<string>
+                {
+                    "en-US"
+                },
+                Add = new List<string>(vsToolset.RequiredWorkloads)
+            };
+
+            var tempFile = Path.Combine(Path.GetTempPath(), "vs.json");
+
+            var json = JsonConvert.SerializeObject(vsFile);
+            File.WriteAllText(tempFile, json);
+
+            return tempFile;
+        }
+    }
+}

--- a/modules/KoreBuild.Tasks/Utilities/VsInstallerHelper.cs
+++ b/modules/KoreBuild.Tasks/Utilities/VsInstallerHelper.cs
@@ -12,14 +12,14 @@ namespace KoreBuild.Tasks.Utilities
 {
     internal class VsInstallerHelper
     { 
-        public static async Task<string> DownloadVsExe(TaskLoggingHelper log)
+        public static async Task<string> DownloadVsExe(TaskLoggingHelper log, string vsProductType)
         {
             // TODO put this in an obj folder instead of temp?
-            var tempPath = Path.Combine(Path.GetTempPath(), "vs_enterprise.exe");
+            var tempPath = Path.Combine(Path.GetTempPath(), "vs.exe");
 
-            await DownloadFileHelper.DownloadFileAsync(uri: "https://aka.ms/vs/15/release/vs_enterprise.exe",
+            await DownloadFileHelper.DownloadFileAsync(uri: $"https://aka.ms/vs/15/release/vs_{vsProductType}.exe",
                 destinationPath: tempPath,
-                overwrite: false,
+                overwrite: true,
                 cancellationToken: new CancellationToken(),
                 timeoutSeconds: 60 * 15,
                 log);

--- a/modules/KoreBuild.Tasks/Utilities/VsWhere.cs
+++ b/modules/KoreBuild.Tasks/Utilities/VsWhere.cs
@@ -29,6 +29,22 @@ namespace KoreBuild.Tasks.Utilities
             return GetInstallations(args, log).FirstOrDefault();
         }
 
+        public static VsInstallation FindLatestInstallation(bool includePrerelease, string vsProductVersion, TaskLoggingHelper log)
+        {
+            var args = new List<string>
+            {
+                "-latest",
+            };
+            if (includePrerelease)
+            {
+                args.Add("-prerelease");
+            }
+            args.Add("-products");
+            args.Add(vsProductVersion);
+
+            return GetInstallations(args, log).FirstOrDefault();
+        }
+
         public static VsInstallation FindLatestCompatibleInstallation(KoreBuildSettings.VisualStudioToolset toolset, TaskLoggingHelper log)
         {
             var args = new List<string> { "-latest" };

--- a/modules/KoreBuild.Tasks/Utilities/VsWhere.cs
+++ b/modules/KoreBuild.Tasks/Utilities/VsWhere.cs
@@ -40,7 +40,7 @@ namespace KoreBuild.Tasks.Utilities
                 args.Add("-prerelease");
             }
             args.Add("-products");
-            args.Add(vsProductVersion);
+            args.Add($"Microsoft.VisualStudio.Product.{vsProductVersion}");
 
             return GetInstallations(args, log).FirstOrDefault();
         }

--- a/modules/KoreBuild.Tasks/module.props
+++ b/modules/KoreBuild.Tasks/module.props
@@ -15,6 +15,7 @@
   <UsingTask TaskName="KoreBuild.Tasks.GenerateSignRequest" AssemblyFile="$(KoreBuildTasksDll)" />
   <UsingTask TaskName="KoreBuild.Tasks.GetToolsets" AssemblyFile="$(KoreBuildTasksDll)" />
   <UsingTask TaskName="KoreBuild.Tasks.InstallDotNet" AssemblyFile="$(KoreBuildTasksDll)" />
+  <UsingTask TaskName="KoreBuild.Tasks.InstallToolsets" AssemblyFile="$(KoreBuildTasksDll)" />
   <UsingTask TaskName="KoreBuild.Tasks.MergeXmlFiles" AssemblyFile="$(KoreBuildTasksDll)" />
   <UsingTask TaskName="KoreBuild.Tasks.PackNuSpec" AssemblyFile="$(KoreBuildTasksDll)" />
   <UsingTask TaskName="KoreBuild.Tasks.PushNuGetPackages" AssemblyFile="$(KoreBuildTasksDll)" />

--- a/modules/KoreBuild.Tasks/module.targets
+++ b/modules/KoreBuild.Tasks/module.targets
@@ -115,8 +115,9 @@ Installs all VS components specified in the korebuild.json required components.
 -->
   <Target Name="InstallToolsets">
     <InstallToolsets ConfigFile="$(KoreBuildConfigFile)"
-      Quiet="$(Quiet)"
-      Upgade="$(Upgrade)" />
+      QuietVSInstallation="$(QuietVSInstallation)"
+      UpgradeVSInstallation="$(UpgradeVSInstallation)"
+      VSProductVersionType="$(VSProductVersionType)" />
   </Target>
 
 <!--

--- a/modules/KoreBuild.Tasks/module.targets
+++ b/modules/KoreBuild.Tasks/module.targets
@@ -50,7 +50,6 @@ Downloads and extracts .NET Core shared runtimes and SDKs.
       InstallScript="$(_DotNetInstall)"/>
   </Target>
 
-
 <!--
 ####################################################################################
 Target: CheckPackageReferences
@@ -105,6 +104,19 @@ dependencies.props file in the current project to use latest versions.
       LineupPackageVersion="$(LineupPackageVersion)"
       LineupPackageRestoreSource="$(LineupPackageRestoreSource)"
       LineupDependenciesFile="$(LineupDependenciesFile)" />
+  </Target>
+
+<!--
+####################################################################################
+Target: InstallToolsets
+
+Installs all VS components specified in the korebuild.json required components.
+####################################################################################
+-->
+  <Target Name="InstallToolsets">
+    <InstallToolsets ConfigFile="$(KoreBuildConfigFile)"
+      Quiet="$(Quiet)"
+      Upgade="$(Upgrade)" />
   </Target>
 
 <!--

--- a/test/KoreBuild.Tasks.Tests/InstallToolsetsTests.cs
+++ b/test/KoreBuild.Tasks.Tests/InstallToolsetsTests.cs
@@ -44,7 +44,7 @@ namespace KoreBuild.Tasks.Tests
 }");
             var task = new InstallToolsets
             {
-                BuildEngine = new MockEngine(),
+                BuildEngine = new MockEngine { ContinueOnError = true },
                 ConfigFile = _configFile,
             };
 

--- a/test/KoreBuild.Tasks.Tests/InstallToolsetsTests.cs
+++ b/test/KoreBuild.Tasks.Tests/InstallToolsetsTests.cs
@@ -1,0 +1,54 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using BuildTools.Tasks.Tests;
+using Xunit;
+
+namespace KoreBuild.Tasks.Tests
+{
+    public class InstallToolsetsTests : IDisposable
+    {
+        private readonly string _configFile;
+
+        public InstallToolsetsTests()
+        {
+            _configFile = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        }
+
+        public void Dispose()
+        {
+            if (File.Exists(_configFile))
+            {
+                File.Delete(_configFile);
+            }
+        }
+
+        [Fact]
+        public void FailsIfVsIsRequiredOnNonWindows()
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return;
+            }
+
+            File.WriteAllText(_configFile, @"
+{
+  ""toolsets"": {
+    ""visualstudio"": {
+      ""required"": [""macos"", ""linux""]
+    },
+  }
+}");
+            var task = new InstallToolsets
+            {
+                BuildEngine = new MockEngine(),
+                ConfigFile = _configFile,
+            };
+
+            Assert.True(task.Execute(), "Task is expected to pass");
+        }
+    }
+}

--- a/test/KoreBuild.Tasks.Tests/InstallToolsetsTests.cs
+++ b/test/KoreBuild.Tasks.Tests/InstallToolsetsTests.cs
@@ -48,7 +48,7 @@ namespace KoreBuild.Tasks.Tests
                 ConfigFile = _configFile,
             };
 
-            Assert.True(task.Execute(), "Task is expected to pass");
+            Assert.False(task.Execute(), "Task is expected to fail");
         }
     }
 }

--- a/tools/KoreBuild.Console/Commands/InstallToolsetsCommand.cs
+++ b/tools/KoreBuild.Console/Commands/InstallToolsetsCommand.cs
@@ -28,8 +28,8 @@ MORE INFO:
             _quietOpt = application.Option("-q|--quiet",
                 "Install toolsets without requiring user interation.",
                 CommandOptionType.NoValue);
-            _productOpt = application.Option("-p|--product",
-                "Which vs product version to install.",
+            _productOpt = application.Option("--product <PRODUCT_NAME>",
+                "Which vs product version to install. Valid values are Enterprise, Professional, or Community.",
                 CommandOptionType.SingleValue);
             _upgradeOpt = application.Option("-u|--upgrade",
                 "Upgrade existing toolsets.",
@@ -65,6 +65,8 @@ MORE INFO:
             {
                 args.Add("-v:n");
             }
+
+            Reporter.Verbose($"Starting msbuild with arguments: {ArgumentEscaper.EscapeAndConcatenate(args)}");
 
             return RunDotnet(args, Context.RepoPath);
         }

--- a/tools/KoreBuild.Console/Commands/InstallToolsetsCommand.cs
+++ b/tools/KoreBuild.Console/Commands/InstallToolsetsCommand.cs
@@ -1,0 +1,63 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.Extensions.CommandLineUtils;
+
+namespace KoreBuild.Console.Commands
+{
+    internal class InstallToolsetsCommand : SubCommandBase
+    {
+        private CommandOption _quietOpt;
+        private CommandOption _upgradeOpt;
+
+        public InstallToolsetsCommand(CommandContext context) : base(context)
+        {
+        }
+
+        public override void Configure(CommandLineApplication application)
+        {
+            application.Description = "Installs the toolsets necessary to build the current project.";
+            application.ExtendedHelpText = @"
+MORE INFO:
+
+    Uses the toolsets specified in korebuild.json to install all toolsets.
+";
+            _quietOpt = application.Option("-q|--quiet",
+                "Install toolsets without requiring user interation.",
+                CommandOptionType.NoValue);
+            _upgradeOpt = application.Option("-u|--upgrade",
+                "Upgrade existing toolsets.",
+                CommandOptionType.NoValue);
+            base.Configure(application);
+        }
+
+        protected override int Execute()
+        {
+            var args = new List<string>
+            {
+                "msbuild",
+                Path.Combine(Context.KoreBuildDir, "KoreBuild.proj"),
+                "-t:InstallToolsets",
+            };
+
+            if (_quietOpt.HasValue())
+            {
+                args.Add("-p:Upgrade=true");
+            }
+
+            if (_quietOpt.HasValue())
+            {
+                args.Add("-p:Quiet=true");
+            }
+
+            if (Reporter.IsVerbose)
+            {
+                args.Add("-v:n");
+            }
+
+            return RunDotnet(args, Context.RepoPath);
+        }
+    }
+}

--- a/tools/KoreBuild.Console/Commands/InstallToolsetsCommand.cs
+++ b/tools/KoreBuild.Console/Commands/InstallToolsetsCommand.cs
@@ -10,6 +10,7 @@ namespace KoreBuild.Console.Commands
     internal class InstallToolsetsCommand : SubCommandBase
     {
         private CommandOption _quietOpt;
+        private CommandOption _productOpt;
         private CommandOption _upgradeOpt;
 
         public InstallToolsetsCommand(CommandContext context) : base(context)
@@ -27,6 +28,9 @@ MORE INFO:
             _quietOpt = application.Option("-q|--quiet",
                 "Install toolsets without requiring user interation.",
                 CommandOptionType.NoValue);
+            _productOpt = application.Option("-p|--product",
+                "Which vs product version to install.",
+                CommandOptionType.SingleValue);
             _upgradeOpt = application.Option("-u|--upgrade",
                 "Upgrade existing toolsets.",
                 CommandOptionType.NoValue);
@@ -42,15 +46,22 @@ MORE INFO:
                 "-t:InstallToolsets",
             };
 
-            if (_quietOpt.HasValue())
+            if (_upgradeOpt.HasValue())
             {
-                args.Add("-p:Upgrade=true");
+                args.Add("-p:UpgradeVSInstallation=true");
             }
 
             if (_quietOpt.HasValue())
             {
-                args.Add("-p:Quiet=true");
+                args.Add("-p:QuietVSInstallation=true");
             }
+
+            
+            if (_productOpt.HasValue())
+            {
+                args.Add($"-p:VSProductVersionType={_productOpt.Value()}");
+            }
+
 
             if (Reporter.IsVerbose)
             {

--- a/tools/KoreBuild.Console/Commands/InstallToolsetsCommand.cs
+++ b/tools/KoreBuild.Console/Commands/InstallToolsetsCommand.cs
@@ -55,13 +55,11 @@ MORE INFO:
             {
                 args.Add("-p:QuietVSInstallation=true");
             }
-
             
             if (_productOpt.HasValue())
             {
                 args.Add($"-p:VSProductVersionType={_productOpt.Value()}");
             }
-
 
             if (Reporter.IsVerbose)
             {

--- a/tools/KoreBuild.Console/Commands/RootCommand.cs
+++ b/tools/KoreBuild.Console/Commands/RootCommand.cs
@@ -15,6 +15,15 @@ namespace KoreBuild.Console.Commands
             application.FullName = "korebuild";
 
             application.Command("install-tools", new InstallToolsCommand(context).Configure, throwOnUnexpectedArg: false);
+            application.Command("install", c => {
+                c.HelpOption("-h|--help");
+                c.Command("vs", new InstallToolsetsCommand(context).Configure, throwOnUnexpectedArg: false);
+                c.OnExecute(() =>
+                {
+                    c.ShowHelp();
+                    return 2;
+                });
+            });
             application.Command("msbuild", new MSBuildCommand(context).Configure, throwOnUnexpectedArg: false);
             application.Command("docker-build", new DockerBuildCommand(context).Configure, throwOnUnexpectedArg: false);
 

--- a/tools/KoreBuild.Console/Program.cs
+++ b/tools/KoreBuild.Console/Program.cs
@@ -1,9 +1,9 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using KoreBuild.Console.Commands;
 using Microsoft.Extensions.CommandLineUtils;
-using System;
 
 namespace KoreBuild.Console
 {


### PR DESCRIPTION
For #445 

- Adds InstallToolsets task in korebuild that installs all toolsets specified in korebuild.json
   - Can invoke in a project by calling run.ps1 install vs
   - Currently only implements installing vs toolsets, but can extend to node toolsets
- Moves DownloadFile task into a helper, which is shared with InstallToolsets
- Adds VsInstallerHelpers which contains methods to download vs_enterprise.exe and creating the vs.json file for specifying requirements to vs

Unresolved issues:
- Choose vs_exe to download? (vs community or pro can't be used today)
- Testing is tricky because actually invoking this test will start vs_enterprise.exe. Is there a way to invoke a test run with vs.json options.
- Decent chunk of code is shared with GetToolsets, can potentially refactor into one msbuild task.

cc/ @mikeharder 