### PR TITLE
Set dotnet home env

### DIFF
--- a/.vsts-pipelines/templates/phases/default-build.yml
+++ b/.vsts-pipelines/templates/phases/default-build.yml
@@ -28,6 +28,7 @@ phases:
       name: Hosted VS2017
   variables:
     BuildScriptArgs: ${{ parameters.buildArgs }}
+    DOTNET_HOME: $(Agent.WorkFolder)\.dotnet
   steps:
   - checkout: self
     clean: true


### PR DESCRIPTION
This keeps everything in the work directory in case we ever have to worry about keeping agents clean.