### PR TITLE
Use LocalPath

### DIFF
--- a/.vsts-pipelines/templates/phases/default-build.yml
+++ b/.vsts-pipelines/templates/phases/default-build.yml
@@ -28,6 +28,7 @@ phases:
       name: Hosted VS2017
   variables:
     BuildScriptArgs: ${{ parameters.buildArgs }}
+    DOTNET_HOME: $(Agent.WorkFolder)\.dotnet
   steps:
   - checkout: self
     clean: true

--- a/.vsts-pipelines/templates/phases/default-build.yml
+++ b/.vsts-pipelines/templates/phases/default-build.yml
@@ -28,7 +28,7 @@ phases:
       name: Hosted VS2017
   variables:
     BuildScriptArgs: ${{ parameters.buildArgs }}
-    DOTNET_HOME: $(Agent.WorkFolder)\.dotnet
+    DOTNET_HOME: $(Build.Repository.LocalPath)\.dotnet
   steps:
   - checkout: self
     clean: true

--- a/.vsts-pipelines/templates/phases/default-build.yml
+++ b/.vsts-pipelines/templates/phases/default-build.yml
@@ -29,6 +29,8 @@ phases:
   variables:
     BuildScriptArgs: ${{ parameters.buildArgs }}
     DOTNET_HOME: $(Build.Repository.LocalPath)\.dotnet
+    DOTNET_CLI_TELEMETRY_OPTOUT: 1
+    DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   steps:
   - checkout: self
     clean: true


### PR DESCRIPTION
Lets set the DOTNET_HOME enLets set the DOTNET_HOME env to LocalPath so that things get cleaned out on checkout, and also skip first time experience.v to LocalPath so that things get cleaned out on checkout, and also skip first time experience.