### PR TITLE
Support setting package versions in dependencies.props which are not overridable

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,8 +12,11 @@ trim_trailing_whitespace = true
 insert_final_newline     = true
 
 [*.cs]
-indent_size                         = 4
-dotnet_sort_system_directives_first = true : warning
+indent_size                            = 4
+dotnet_sort_system_directives_first    = true : warning
+csharp_style_var_when_type_is_apparent = true : warning
+csharp_style_var_for_built_in_types    = true : warning
+csharp_style_var_elsewhere             = true : warning
 
 [*.{xml,config,*proj,nuspec,props,resx,targets,yml,tasks}]
 indent_size = 2

--- a/docs/PackageReferenceManagement.md
+++ b/docs/PackageReferenceManagement.md
@@ -50,15 +50,22 @@ Each repository should have this file, and it should look like this.
   <PropertyGroup>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>
-  <PropertyGroup Label="Package Versions">
+  <PropertyGroup Label="Package Versions: Auto">
     <NewtonsoftJsonPackageVersion>10.0.1</NewtonsoftJsonPackageVersion>
     <MicrosoftNETTestSdkPackageVersion>15.3.0</MicrosoftNETTestSdkPackageVersion>
     <MoqPackageVersion>4.7.49</MoqPackageVersion>
     <XunitPackageVersion>2.3.0</XunitPackageVersion>
   </PropertyGroup>
   <Import Project="$(DotNetPackageVersionPropsPath)" Condition=" '$(DotNetPackageVersionPropsPath)' != '' " />
+  <PropertyGroup Label="Package Versions: Pinned">
+    <StablePackageVersion>10.0.1</StablePackageVersion>
+  </PropertyGroup>
 </Project>
 ```
+
+The `<PropertyGroup Label="Package Versions: Auto">` section is for variables which should be automatically updated.
+
+The `<PropertyGroup Label="Package Versions: Pinned">` section is for variables which upgrade automation should not touch.
 
 ### 2. PackageReference's should use variables to set versions
 

--- a/modules/KoreBuild.Tasks/CheckPackageReferences.cs
+++ b/modules/KoreBuild.Tasks/CheckPackageReferences.cs
@@ -53,9 +53,9 @@ namespace KoreBuild.Tasks
                 return false;
             }
 
-            if (!depsFile.HasVersionsPropertyGroup())
+            if (!depsFile.HasVersionsPropertyGroup)
             {
-                Log.LogKoreBuildWarning(KoreBuildErrors.PackageRefPropertyGroupNotFound, $"No PropertyGroup with Label=\"{DependencyVersionsFile.PackageVersionsLabel}\" could be found in {DependenciesFile}");
+                Log.LogKoreBuildWarning(KoreBuildErrors.PackageRefPropertyGroupNotFound, $"No PropertyGroup with Label=\"{DependencyVersionsFile.PackageVersionsLabel}\" or Label=\"{DependencyVersionsFile.AutoPackageVersionsLabel}\" could be found in {DependenciesFile}");
             }
 
             foreach (var proj in Projects)
@@ -79,7 +79,7 @@ namespace KoreBuild.Tasks
             return !Log.HasLoggedErrors;
         }
 
-        private void VerifyPackageReferences(string filePath, IReadOnlyDictionary<string, string> versionVariables)
+        private void VerifyPackageReferences(string filePath, IReadOnlyDictionary<string, PackageVersionVariable> versionVariables)
         {
             ProjectRootElement doc;
             try
@@ -127,12 +127,13 @@ namespace KoreBuild.Tasks
 
                 var versionVarName = versionRaw.Substring(2, versionRaw.Length - 3);
 
-                if (!versionVariables.TryGetValue(versionVarName, out var versionValue))
+                if (!versionVariables.TryGetValue(versionVarName, out var variable))
                 {
                     Log.LogKoreBuildError(pkgRef.Location.File, pkgRef.Location.Line, KoreBuildErrors.VariableNotFoundInDependenciesPropsFile, $"The variable {versionRaw} could not be found in {DependenciesFile}");
                     continue;
                 }
 
+                var versionValue = variable.Version;
                 if (!VersionRange.TryParse(versionValue, out var nugetVersion))
                 {
                     Log.LogKoreBuildError(pkgRef.Location.File, pkgRef.Location.Line, KoreBuildErrors.InvalidPackageVersion, $"PackageReference to {id} has an invalid version identifier: '{versionValue}'");

--- a/modules/KoreBuild.Tasks/GeneratePackageVersionPropsFile.cs
+++ b/modules/KoreBuild.Tasks/GeneratePackageVersionPropsFile.cs
@@ -76,10 +76,10 @@ namespace KoreBuild.Tasks
                     continue;
                 }
 
-                var item = depsFile.Set(packageVarName, packageVersion);
+                var item = depsFile.Update(packageVarName, packageVersion);
                 if (!SuppressVariableLabels)
                 {
-                    item.Label = pkg.ItemSpec;
+                    item.SetLabel(pkg.ItemSpec);
                 }
             }
 

--- a/modules/KoreBuild.Tasks/Utilities/PackageVersionVariable.cs
+++ b/modules/KoreBuild.Tasks/Utilities/PackageVersionVariable.cs
@@ -1,0 +1,56 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Build.Construction;
+
+namespace KoreBuild.Tasks.Utilities
+{
+    public class PackageVersionVariable
+    {
+        private readonly ProjectPropertyElement _element;
+
+        public PackageVersionVariable(ProjectPropertyElement element, bool isReadOnly)
+            : this(element, element.Value?.Trim(), isReadOnly)
+        {
+        }
+
+        public PackageVersionVariable(ProjectPropertyElement element, string version, bool isReadOnly)
+        {
+            _element = element ?? throw new ArgumentNullException(nameof(element));
+            IsReadOnly = isReadOnly;
+            Name = element.Name.ToString();
+            Version = version ?? string.Empty;
+        }
+
+        public string Name { get; }
+
+        public string Version
+        {
+            get => _element.Value;
+            private set => _element.Value = value;
+        }
+
+        public bool IsReadOnly { get; private set; }
+
+        public void UpdateVersion(string version)
+        {
+            if (IsReadOnly)
+            {
+                throw new InvalidOperationException("You cannot updated a pinned package version variable automatically");
+            }
+
+            Version = version;
+        }
+
+        public void AddToGroup(ProjectPropertyGroupElement group)
+        {
+            group.AppendChild(_element);
+        }
+
+        public void SetLabel(string label)
+        {
+            _element.Label = label;
+        }
+    }
+}

--- a/test/KoreBuild.Tasks.Tests/CheckPackageReferenceTests.cs
+++ b/test/KoreBuild.Tasks.Tests/CheckPackageReferenceTests.cs
@@ -30,6 +30,46 @@ namespace KoreBuild.Tasks.Tests
         }
 
         [Fact]
+        public void ItAllowsPinnedAndUnpinnedVersions()
+        {
+            var depsProps = Path.Combine(_tempDir, "dependencies.props");
+            File.WriteAllText(depsProps, $@"
+<Project>
+  <PropertyGroup Label=`Package Versions: Latest`>
+    <LatestPackageVersion>1.0.0</LatestPackageVersion>
+  </PropertyGroup>
+
+  <Import Project=`$(DotNetPackageVersionsPropsPath)` />
+
+  <PropertyGroup Label=`Package Versions: Pinned`>
+    <BaseLinePackageVersion>1.0.0</BaseLinePackageVersion>
+  </PropertyGroup>
+</Project>
+".Replace('`', '"'));
+
+            var csproj = Path.Combine(_tempDir, "Test.csproj");
+            File.WriteAllText(csproj, $@"
+<Project>
+  <ItemGroup>
+    <PackageReference Include=`Latest` Version=`$(LatestPackageVersion)` />
+    <PackageReference Include=`BaseLine`>
+       <Version>$(BaseLinePackageVersion)</Version>
+    </PackageReference>
+  </ItemGroup>
+</Project>
+".Replace('`', '"'));
+
+            var task = new CheckPackageReferences
+            {
+                BuildEngine = _engine,
+                DependenciesFile = depsProps,
+                Projects = new[] { new TaskItem(csproj) }
+            };
+
+            Assert.True(task.Execute(), "Task is expected to pass");
+        }
+
+        [Fact]
         public void PassesWhenAllRequirementsAreSatisifed()
         {
             var depsProps = Path.Combine(_tempDir, "dependencies.props");
@@ -53,7 +93,6 @@ namespace KoreBuild.Tasks.Tests
 </Project>
 ".Replace('`', '"'));
 
-            _engine.ContinueOnError = true;
             var task = new CheckPackageReferences
             {
                 BuildEngine = _engine,

--- a/test/KoreBuild.Tasks.Tests/DependencyVersionsFileTests.cs
+++ b/test/KoreBuild.Tasks.Tests/DependencyVersionsFileTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections;
 using System.IO;
+using System.Linq;
 using BuildTools.Tasks.Tests;
 using KoreBuild.Tasks.Utilities;
 using Microsoft.Build.Construction;
@@ -38,14 +39,14 @@ namespace KoreBuild.Tasks.Tests
         public void ItSortsVariablesAlphabetically()
         {
             var depsFile = DependencyVersionsFile.Create(addOverrideImport: true);
-            depsFile.Set("XyzPackageVersion", "123");
-            depsFile.Set("AbcPackageVersion", "456");
+            depsFile.Update("XyzPackageVersion", "123");
+            depsFile.Update("AbcPackageVersion", "456");
             depsFile.Save(_tempFile);
 
             var project = ProjectRootElement.Open(_tempFile);
             _output.WriteLine(File.ReadAllText(_tempFile));
 
-            var versions = Assert.Single(project.PropertyGroups, p => !string.IsNullOrEmpty(p.Label));
+            var versions = Assert.Single(project.PropertyGroups, p => p.Label == DependencyVersionsFile.AutoPackageVersionsLabel);
             Assert.Collection(versions.Properties,
                 v => Assert.Equal("AbcPackageVersion", v.Name),
                 v => Assert.Equal("XyzPackageVersion", v.Name));
@@ -55,14 +56,14 @@ namespace KoreBuild.Tasks.Tests
         public void SetIsCaseInsensitive()
         {
             var depsFile = DependencyVersionsFile.Create(addOverrideImport: true);
-            depsFile.Set("XunitRunnerVisualStudioVersion", "2.3.0");
-            depsFile.Set("XunitRunnerVisualstudioVersion", "2.4.0");
+            depsFile.Update("XunitRunnerVisualStudioVersion", "2.3.0");
+            depsFile.Update("XunitRunnerVisualstudioVersion", "2.4.0");
             depsFile.Save(_tempFile);
 
             var project = ProjectRootElement.Open(_tempFile);
             _output.WriteLine(File.ReadAllText(_tempFile));
 
-            var versions = Assert.Single(project.PropertyGroups, p => !string.IsNullOrEmpty(p.Label));
+            var versions = Assert.Single(project.PropertyGroups, p => p.Label == DependencyVersionsFile.AutoPackageVersionsLabel);
             var prop = Assert.Single(versions.Properties);
             Assert.Equal("XunitRunnerVisualStudioVersion", prop.Name);
             Assert.Equal("2.4.0", prop.Value);

--- a/test/KoreBuild.Tasks.Tests/GenerateDependenciesPropsFileTests.cs
+++ b/test/KoreBuild.Tasks.Tests/GenerateDependenciesPropsFileTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections;
 using System.IO;
 using BuildTools.Tasks.Tests;
+using KoreBuild.Tasks.Utilities;
 using Microsoft.Build.Construction;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
@@ -45,7 +46,7 @@ namespace KoreBuild.Tasks.Tests
             Assert.True(task.Execute(), "Task is expected to pass");
             var depsFile = ProjectRootElement.Open(generatedFile);
             _output.WriteLine(File.ReadAllText(generatedFile));
-            var pg = Assert.Single(depsFile.PropertyGroups, p => p.Label == "Package Versions");
+            var pg = Assert.Single(depsFile.PropertyGroups, p => p.Label == DependencyVersionsFile.AutoPackageVersionsLabel);
             var prop = Assert.Single(pg.Properties, p => p.Name == "MyDependencyPackageVersion");
             Assert.Equal("1.2.3", prop.Value);
         }
@@ -73,7 +74,7 @@ namespace KoreBuild.Tasks.Tests
             Assert.True(task.Execute(), "Task is expected to pass");
             var depsFile = ProjectRootElement.Open(generatedFile);
             _output.WriteLine(File.ReadAllText(generatedFile));
-            var pg = Assert.Single(depsFile.PropertyGroups, p => p.Label == "Package Versions");
+            var pg = Assert.Single(depsFile.PropertyGroups, p => p.Label == DependencyVersionsFile.AutoPackageVersionsLabel);
             Assert.Empty(pg.Properties);
         }
 

--- a/test/KoreBuild.Tasks.Tests/GeneratePackageVersionPropsFileTests.cs
+++ b/test/KoreBuild.Tasks.Tests/GeneratePackageVersionPropsFileTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections;
 using System.IO;
 using BuildTools.Tasks.Tests;
+using KoreBuild.Tasks.Utilities;
 using Microsoft.Build.Construction;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
@@ -57,7 +58,7 @@ namespace KoreBuild.Tasks.Tests
             Assert.Empty(allProjectsProp.Condition);
             Assert.Equal("$(MSBuildAllProjects);$(MSBuildThisFileFullPath)", allProjectsProp.Value);
 
-            var versions = Assert.Single(project.PropertyGroups, pg => pg.Label == "Package Versions");
+            var versions = Assert.Single(project.PropertyGroups, pg => pg.Label == DependencyVersionsFile.AutoPackageVersionsLabel);
 
             // Order is important. These should be sorted.
             Assert.Collection(versions.Properties,


### PR DESCRIPTION
Resolves https://github.com/aspnet/BuildTools/issues/463

Required to unblock for the 2.1.3 patch.