### PR TITLE
Publish artifacts from VSTS builds

### DIFF
--- a/.vsts-pipelines/builds/ci.yml
+++ b/.vsts-pipelines/builds/ci.yml
@@ -14,3 +14,13 @@ phases:
 - template: ../templates/phases/default-build.yml
   parameters:
     agentOs: Windows
+    # Ensures the alignment of branch name and deployment params
+    buildArgs: '/warnaserror:BUILD1001'
+    afterBuild:
+    - task: PublishBuildArtifacts@1
+      displayName: Upload KoreBuild artifact
+      condition: and(succeeded(), eq(variables['system.pullrequest.isfork'], false))
+      inputs:
+        pathtoPublish: artifacts/korebuild/
+        artifactName: korebuild
+        artifactType: Container

--- a/.vsts-pipelines/templates/phases/default-build.yml
+++ b/.vsts-pipelines/templates/phases/default-build.yml
@@ -10,12 +10,16 @@
 #       Additional steps to run before build.sh/cmd
 #   afterBuild: [steps]
 #       Additional steps to run after build.sh/cmd
+#   artifactsPath: string
+#       The path to the folder of build output to capture. Defaults to artifacts/build/.
+#       If this is set to empty, no artifacts will be published.
 
 parameters:
   agentOs: 'Windows'
   buildArgs: ''
   beforeBuild: []
   afterBuild: []
+  artifactsPath: 'artifacts/build/'
 
 phases:
 - phase: ${{ parameters.agentOs }}
@@ -45,5 +49,13 @@ phases:
     inputs:
       testRunner: vstest
       testResultsFiles: 'artifacts/logs/**/*.trx'
+  - ${{ if ne(parameters.artifactsPath, '') }}:
+    - task: PublishBuildArtifacts@1
+      displayName: Upload artifacts
+      condition: and(succeeded(), eq(variables['system.pullrequest.isfork'], false))
+      inputs:
+        pathtoPublish: ${{ parameters.artifactsPath }}
+        artifactName: ${{ format('build-{0}', parameters.agentOs) }}
+        artifactType: Container
   - ${{ parameters.afterBuild }}
 

--- a/build/repo.targets
+++ b/build/repo.targets
@@ -6,16 +6,24 @@
     <_KoreBuildOutDir>$(ArtifactsDir)korebuild\artifacts\$(Version)\</_KoreBuildOutDir>
     <_ChannelOutDir>$(ArtifactsDir)korebuild\channels\$(KoreBuildChannel)\</_ChannelOutDir>
     <KoreBuildArchiveFile>$(_KoreBuildOutDir)korebuild.$(Version).zip</KoreBuildArchiveFile>
+    <KoreBuildUploadScriptFile>$(ArtifactsDir)korebuild\upload.ps1</KoreBuildUploadScriptFile>
     <KoreBuildBadgeFile>$(_ChannelOutDir)badge.svg</KoreBuildBadgeFile>
     <KoreBuildLatestTxtFile>$(_ChannelOutDir)latest.txt</KoreBuildLatestTxtFile>
+    <KoreBuildChannelTxtFile>$(ArtifactsDir)korebuild\channel.txt</KoreBuildChannelTxtFile>
     <PrepareDependsOn>$(PrepareDependsOn);SetTeamCityBuildNumberToVersion</PrepareDependsOn>
   </PropertyGroup>
 
   <ItemGroup>
+    <ArtifactInfo Include="$(KoreBuildUploadScriptFile)">
+      <ArtifactType>PowershellScript</ArtifactType>
+    </ArtifactInfo>
     <ArtifactInfo Include="$(KoreBuildArchiveFile)">
       <ArtifactType>ZipArchive</ArtifactType>
     </ArtifactInfo>
     <ArtifactInfo Include="$(KoreBuildLatestTxtFile)">
+      <ArtifactType>TextFile</ArtifactType>
+    </ArtifactInfo>
+    <ArtifactInfo Include="$(KoreBuildChannelTxtFile)">
       <ArtifactType>TextFile</ArtifactType>
     </ArtifactInfo>
     <ArtifactInfo Include="$(KoreBuildBadgeFile)">
@@ -48,7 +56,7 @@
 
     <!-- passing /warnaserror:BUILD1001 on CI to prevent channel/branch mismatch -->
     <Warning Text="Current branch '$(RepositoryBranch)' does not match the value of KoreBuildChannel: '$(KoreBuildChannel)'"
-      Condition="'$(RepositoryBranch)' != '$(KoreBuildChannel)' AND '$(CI)' == 'true'"
+      Condition="'$(RepositoryBranch)' != '$(KoreBuildChannel)' AND '$(CI)' == 'true' AND '$(BUILD_REASON)' != 'PullRequest'"
       Code="BUILD1001" />
 
     <ItemGroup>
@@ -88,7 +96,9 @@
       <KoreBuildFiles Include="$(_KoreBuildIntermediateDir)**\*" />
     </ItemGroup>
 
+    <Copy SourceFiles="$(RepositoryRoot)scripts\UploadKoreBuild.ps1" DestinationFiles="$(KoreBuildUploadScriptFile)" SkipUnchangedFiles="true" />
     <WriteLinesToFile File="$(KoreBuildLatestTxtFile)" Lines="@(VersionFileLines)" Overwrite="true"/>
+    <WriteLinesToFile File="$(KoreBuildChannelTxtFile)" Lines="$(KoreBuildChannel)" Overwrite="true"/>
     <GenerateSvgBadge Label="version" Value="$(Version)" OutputPath="$(KoreBuildBadgeFile)" />
     <ZipArchive WorkingDirectory="$(_KoreBuildIntermediateDir)" File="$(KoreBuildArchiveFile)" SourceFiles="@(KoreBuildFiles)" />
   </Target>

--- a/files/KoreBuild/KoreBuild.Common.props
+++ b/files/KoreBuild/KoreBuild.Common.props
@@ -42,12 +42,21 @@ Default layout and configuration.
   </PropertyGroup>
 
   <!-- Use build number from CI if available -->
-  <PropertyGroup Condition=" '$(BuildNumber)' == '' ">
+  <PropertyGroup>
     <!--
       See https://confluence.jetbrains.com/display/TCD10/Predefined+Build+Parameters.
       This environment variable is automatically set by TeamCity.
     -->
-    <BuildNumber Condition=" '$(BUILD_NUMBER)' != '' ">$(BUILD_NUMBER)</BuildNumber>
+    <BuildNumber Condition=" '$(BuildNumber)' == '' ">$(BUILD_NUMBER)</BuildNumber>
+    <!--
+      See https://docs.microsoft.com/en-us/vsts/pipelines/build/variables
+      This environment variable is automatically set by VSTS.
+    -->
+    <BuildNumber Condition=" '$(BuildNumber)' == '' ">$(BUILD_BUILDNUMBER)</BuildNumber>
+    <RepositoryBranch Condition=" '$(RepositoryBranch)' == '' ">$(BUILD_SOURCEBRANCH)</RepositoryBranch>
+    <RepositoryBranch Condition=" '$(RepositoryBranch)' != '' AND $(RepositoryBranch.StartsWith('refs/heads/')) ">$(RepositoryBranch.Substring(11))</RepositoryBranch>
+    <RepositoryBranch Condition=" '$(RepositoryBranch)' != '' AND $(RepositoryBranch.StartsWith('refs/pull/')) ">$(RepositoryBranch.Substring(10))</RepositoryBranch>
+    <RepositoryCommit Condition=" '$(RepositoryCommit)' == '' ">$(BUILD_SOURCEVERSION)</RepositoryCommit>
   </PropertyGroup>
 
   <!-- Create a temporary build number if not assigned by the CI server -->
@@ -68,6 +77,8 @@ Default layout and configuration.
 
   <PropertyGroup>
     <SolutionProperties Condition="'$(BuildNumber)' != ''">$(SolutionProperties);BuildNumber=$(BuildNumber)</SolutionProperties>
+    <SolutionProperties Condition="'$(RepositoryCommit)' != ''">$(SolutionProperties);RepositoryCommit=$(RepositoryCommit)</SolutionProperties>
+    <SolutionProperties Condition="'$(RepositoryBranch)' != ''">$(SolutionProperties);RepositoryBranch=$(RepositoryBranch)</SolutionProperties>
   </PropertyGroup>
 
 </Project>

--- a/modules/BuildTools.Tasks/module.targets
+++ b/modules/BuildTools.Tasks/module.targets
@@ -4,6 +4,14 @@
     <PrepareDependsOn>$(PrepareDependsOn);_UseVolatileFeed;ResolveCommitHash</PrepareDependsOn>
   </PropertyGroup>
 
+  <!-- This target is optional. You can manually chain it into a repo build if you need branch name. -->
+  <Target Name="ResolveRepositoryBranch" Condition="'$(RepositoryBranch)' == ''">
+    <GetGitCommitHash WorkingDirectory="$(RepositoryRoot)"
+                      ContinueOnError="WarnAndContinue">
+      <Output TaskParameter="Branch" PropertyName="RepositoryBranch" />
+    </GetGitCommitHash>
+  </Target>
+
   <Target Name="ResolveCommitHash" Condition="'$(RepositoryCommit)' == ''">
     <PropertyGroup>
       <RepositoryCommit Condition="'$(APPVEYOR_REPO_COMMIT)' != ''">$(APPVEYOR_REPO_COMMIT)</RepositoryCommit>

--- a/push.ps1
+++ b/push.ps1
@@ -53,9 +53,9 @@ if ($PublishType -eq 'default') {
 
     Write-Host "Pushing azure artifacts for '$channelName' channel"
 
-    & "$PSScriptRoot/scripts/UploadBlobs.ps1" `
+    & "$artifacts/korebuild/upload.ps1" `
         -Channel $channelName `
-        -ArtifactsDir $artifacts `
+        -ArtifactsDir "$artifacts/korebuild" `
         -AzureStorageAccount $AzureStorageAccount `
         -WhatIf:$WhatIfPreference
 }

--- a/src/Internal.AspNetCore.Sdk/build/Git.targets
+++ b/src/Internal.AspNetCore.Sdk/build/Git.targets
@@ -26,6 +26,14 @@
     <PathMap Condition=" '$(DeterministicSourceRoot)' != '' ">$([MSBuild]::NormalizeDirectory($(RepositoryRoot)))=$(DeterministicSourceRoot)</PathMap>
   </PropertyGroup>
 
+  <!-- This target is optional. Projects can manually call it if they need it. -->
+  <Target Name="ResolveRepositoryBranch" Condition="'$(RepositoryBranch)'==''">
+    <Sdk_GetGitBranch WorkingDirectory="$(MSBuildProjectDirectory)"
+                      ContinueOnError="WarnAndContinue">
+      <Output TaskParameter="Branch" PropertyName="RepositoryBranch" />
+    </Sdk_GetGitBranch>
+  </Target>
+
   <Target Name="ResolveCommitHash" Condition="'$(RepositoryCommit)'==''">
 
     <PropertyGroup>


### PR DESCRIPTION
Changes:

* Template: Publish artifacts placed in artifacts/build by default, but not for PRs from external forks
* KoreBuild: make upload.ps1 part of the artifacts output and modify the format so it can be consumed by VSTS deployment pipelines.

Part of https://github.com/aspnet/Coherence-Signed/issues/694