### PR TITLE
Add support for specifying Debug/Release configurations in VSTS templates

### DIFF
--- a/.vsts-pipelines/builds/ci.yml
+++ b/.vsts-pipelines/builds/ci.yml
@@ -10,7 +10,7 @@ phases:
     afterBuild:
     - task: PublishBuildArtifacts@1
       displayName: Upload KoreBuild artifact
-      condition: and(succeeded(), eq(variables['param.configuration', 'Release']), eq(variables['param.agentOs'], 'Windows'), eq(variables['system.pullrequest.isfork'], false))
+      condition: and(succeeded(), eq(variables['param.configuration'], 'Release'), eq(variables['param.agentOs'], 'Windows'), eq(variables['system.pullrequest.isfork'], false))
       inputs:
         pathtoPublish: artifacts/korebuild/
         artifactName: korebuild

--- a/.vsts-pipelines/builds/ci.yml
+++ b/.vsts-pipelines/builds/ci.yml
@@ -3,23 +3,14 @@ trigger:
 - release/*
 
 phases:
-- template: ../templates/phases/default-build.yml
+- template: ../templates/project-ci.yml
   parameters:
-    agentOs: macOS
-
-- template: ../templates/phases/default-build.yml
-  parameters:
-    agentOs: Linux
-
-- template: ../templates/phases/default-build.yml
-  parameters:
-    agentOs: Windows
     # Ensures the alignment of branch name and deployment params
     buildArgs: '/warnaserror:BUILD1001'
     afterBuild:
     - task: PublishBuildArtifacts@1
       displayName: Upload KoreBuild artifact
-      condition: and(succeeded(), eq(variables['system.pullrequest.isfork'], false))
+      condition: and(succeeded(), eq(variables['param.configuration', 'Release']), eq(variables['param.agentOs'], 'Windows'), eq(variables['system.pullrequest.isfork'], false))
       inputs:
         pathtoPublish: artifacts/korebuild/
         artifactName: korebuild

--- a/.vsts-pipelines/templates/phases/default-build.yml
+++ b/.vsts-pipelines/templates/phases/default-build.yml
@@ -10,19 +10,16 @@
 #       Additional steps to run before build.sh/cmd
 #   afterBuild: [steps]
 #       Additional steps to run after build.sh/cmd
-#   artifactsPath: string
-#       The path to the folder of build output to capture. Defaults to artifacts/build/.
-#       If this is set to empty, no artifacts will be published.
 
 parameters:
   agentOs: 'Windows'
+  configuration: 'Release'
   buildArgs: ''
   beforeBuild: []
   afterBuild: []
-  artifactsPath: 'artifacts/build/'
 
 phases:
-- phase: ${{ parameters.agentOs }}
+- phase: ${{ format('{0}:{1}', parameters.agentOs, parameters.configuration) }}
   queue:
     ${{ if eq(parameters.agentOs, 'macOS') }}:
       name: Hosted macOS Preview
@@ -31,17 +28,18 @@ phases:
     ${{ if eq(parameters.agentOs, 'Windows') }}:
       name: Hosted VS2017
   variables:
-    BuildScriptArgs: ${{ parameters.buildArgs }}
+    Build.ScriptArgs: ${{ parameters.buildArgs }}
+    Build.Configuration: ${{ parameters.configuration }}
     DOTNET_HOME: $(Agent.WorkFolder)/.dotnet
   steps:
   - checkout: self
     clean: true
   - ${{ parameters.beforeBuild }}
   - ${{ if eq(parameters.agentOs, 'Windows') }}:
-    - script: .\build.cmd -ci $(BuildScriptArgs)
+    - script: .\build.cmd -ci /p:Configuration=$(Build.Configuration) $(Build.ScriptArgs)
       displayName: Run build.cmd
   - ${{ if ne(parameters.agentOs, 'Windows') }}:
-    - script: ./build.sh -ci $(BuildScriptArgs)
+    - script: ./build.sh -ci -p:Configuration=$(Build.Configuration) $(Build.ScriptArgs)
       displayName: Run build.sh
   - task: PublishTestResults@2
     displayName: Publish test results
@@ -49,13 +47,13 @@ phases:
     inputs:
       testRunner: vstest
       testResultsFiles: 'artifacts/logs/**/*.trx'
-  - ${{ if ne(parameters.artifactsPath, '') }}:
+  - ${{ if and(eq(parameters.agentOs, 'Windows'), ne(parameters.artifactsPath, '')) }}:
     - task: PublishBuildArtifacts@1
       displayName: Upload artifacts
       condition: and(succeeded(), eq(variables['system.pullrequest.isfork'], false))
       inputs:
-        pathtoPublish: ${{ parameters.artifactsPath }}
-        artifactName: ${{ format('build-{0}', parameters.agentOs) }}
+        pathtoPublish: artifacts/build/ # TODO: this is going to change when we converge with dotnet/arcade tooling
+        artifactName: ${{ format('packages-{0}-{1}', parameters.agentOs, parameters.configuration) }}
         artifactType: Container
   - ${{ parameters.afterBuild }}
 

--- a/.vsts-pipelines/templates/phases/default-build.yml
+++ b/.vsts-pipelines/templates/phases/default-build.yml
@@ -10,6 +10,11 @@
 #       Additional steps to run before build.sh/cmd
 #   afterBuild: [steps]
 #       Additional steps to run after build.sh/cmd
+#   artifacts:
+#      publish: (boolean)
+#          Should artifacts be published
+#      path: (string) the path
+#          The file path to artifacts output
 
 parameters:
   agentOs: 'Windows'
@@ -17,6 +22,9 @@ parameters:
   buildArgs: ''
   beforeBuild: []
   afterBuild: []
+  artifacts:
+    publish: true
+    path: 'artifacts/build/'  # TODO: this is going to change when we converge with dotnet/arcade tooling
 
 phases:
 - phase: ${{ format('{0}:{1}', parameters.agentOs, parameters.configuration) }}
@@ -28,18 +36,19 @@ phases:
     ${{ if eq(parameters.agentOs, 'Windows') }}:
       name: Hosted VS2017
   variables:
-    Build.ScriptArgs: ${{ parameters.buildArgs }}
-    Build.Configuration: ${{ parameters.configuration }}
+    param.agentOS: ${{ parameters.agentOs }}
+    param.buildArgs: ${{ parameters.buildArgs }}
+    param.configuration: ${{ parameters.configuration }}
     DOTNET_HOME: $(Agent.WorkFolder)/.dotnet
   steps:
   - checkout: self
     clean: true
   - ${{ parameters.beforeBuild }}
   - ${{ if eq(parameters.agentOs, 'Windows') }}:
-    - script: .\build.cmd -ci /p:Configuration=$(Build.Configuration) $(Build.ScriptArgs)
+    - script: .\build.cmd -ci /p:Configuration=$(param.configuration) $(param.buildArgs)
       displayName: Run build.cmd
   - ${{ if ne(parameters.agentOs, 'Windows') }}:
-    - script: ./build.sh -ci -p:Configuration=$(Build.Configuration) $(Build.ScriptArgs)
+    - script: ./build.sh -ci -p:Configuration=$(param.configuration) $(param.buildArgs)
       displayName: Run build.sh
   - task: PublishTestResults@2
     displayName: Publish test results
@@ -47,12 +56,12 @@ phases:
     inputs:
       testRunner: vstest
       testResultsFiles: 'artifacts/logs/**/*.trx'
-  - ${{ if and(eq(parameters.agentOs, 'Windows'), ne(parameters.artifactsPath, '')) }}:
+  - ${{ if eq(parameters.artifacts.publish, 'true') }}:
     - task: PublishBuildArtifacts@1
       displayName: Upload artifacts
       condition: and(succeeded(), eq(variables['system.pullrequest.isfork'], false))
       inputs:
-        pathtoPublish: artifacts/build/ # TODO: this is going to change when we converge with dotnet/arcade tooling
+        pathtoPublish: ${{ parameters.artifacts.path }}
         artifactName: ${{ format('packages-{0}-{1}', parameters.agentOs, parameters.configuration) }}
         artifactType: Container
   - ${{ parameters.afterBuild }}

--- a/.vsts-pipelines/templates/phases/default-build.yml
+++ b/.vsts-pipelines/templates/phases/default-build.yml
@@ -27,7 +27,7 @@ parameters:
     path: 'artifacts/build/'  # TODO: this is going to change when we converge with dotnet/arcade tooling
 
 phases:
-- phase: ${{ format('{0}:{1}', parameters.agentOs, parameters.configuration) }}
+- phase: ${{ format('{0}_{1}', parameters.agentOs, parameters.configuration) }}
   queue:
     ${{ if eq(parameters.agentOs, 'macOS') }}:
       name: Hosted macOS Preview

--- a/.vsts-pipelines/templates/project-ci.yml
+++ b/.vsts-pipelines/templates/project-ci.yml
@@ -3,9 +3,15 @@
 #   buildArgs: string
 #       Additional arguments to pass to the build.sh/cmd script.
 #       Note: -ci is always passed
+#   beforeBuild: [steps]
+#       Additional steps to run before build.sh/cmd
+#   afterBuild: [steps]
+#       Additional steps to run after build.sh/cmd
 
 parameters:
   buildArgs: ''
+  beforeBuild: []
+  afterBuild: []
 
 phases:
 - template: phases/default-build.yml
@@ -13,28 +19,40 @@ phases:
     agentOs: Windows
     configuration: Release
     buildArgs: ${{ parameters.buildArgs }}
+    beforeBuild: ${{ parameters.beforeBuild }}
+    afterBuild: ${{ parameters.afterBuild }}
 - template: phases/default-build.yml
   parameters:
     agentOs: Windows
     configuration: Debug
     buildArgs: ${{ parameters.buildArgs }}
+    beforeBuild: ${{ parameters.beforeBuild }}
+    afterBuild: ${{ parameters.afterBuild }}
 - template: phases/default-build.yml
   parameters:
     agentOs: macOS
     configuration: Release
     buildArgs: ${{ parameters.buildArgs }}
+    beforeBuild: ${{ parameters.beforeBuild }}
+    afterBuild: ${{ parameters.afterBuild }}
 - template: phases/default-build.yml
   parameters:
     agentOs: macOS
     configuration: Debug
     buildArgs: ${{ parameters.buildArgs }}
+    beforeBuild: ${{ parameters.beforeBuild }}
+    afterBuild: ${{ parameters.afterBuild }}
 - template: phases/default-build.yml
   parameters:
     agentOs: Linux
     configuration: Release
     buildArgs: ${{ parameters.buildArgs }}
+    beforeBuild: ${{ parameters.beforeBuild }}
+    afterBuild: ${{ parameters.afterBuild }}
 - template: phases/default-build.yml
   parameters:
     agentOs: Linux
     configuration: Debug
     buildArgs: ${{ parameters.buildArgs }}
+    beforeBuild: ${{ parameters.beforeBuild }}
+    afterBuild: ${{ parameters.afterBuild }}

--- a/.vsts-pipelines/templates/project-ci.yml
+++ b/.vsts-pipelines/templates/project-ci.yml
@@ -10,13 +10,31 @@ parameters:
 phases:
 - template: phases/default-build.yml
   parameters:
-    agentOs: macOS
+    agentOs: Windows
+    configuration: Release
     buildArgs: ${{ parameters.buildArgs }}
 - template: phases/default-build.yml
   parameters:
     agentOs: Windows
+    configuration: Debug
+    buildArgs: ${{ parameters.buildArgs }}
+- template: phases/default-build.yml
+  parameters:
+    agentOs: macOS
+    configuration: Release
+    buildArgs: ${{ parameters.buildArgs }}
+- template: phases/default-build.yml
+  parameters:
+    agentOs: macOS
+    configuration: Debug
     buildArgs: ${{ parameters.buildArgs }}
 - template: phases/default-build.yml
   parameters:
     agentOs: Linux
+    configuration: Release
+    buildArgs: ${{ parameters.buildArgs }}
+- template: phases/default-build.yml
+  parameters:
+    agentOs: Linux
+    configuration: Debug
     buildArgs: ${{ parameters.buildArgs }}


### PR DESCRIPTION
Changes:

* Add `configuration` parameter to default-build.yml template to control Debug/Release builds.
* By default, compile Debug and Release for project-ci
* Update this repo to use the project-ci.yml template
