### PR TITLE
Set MSBUILDDISABLENODEREUSE to disable node reuse when building on a CI server

### DIFF
--- a/files/KoreBuild/KoreBuild.sh
+++ b/files/KoreBuild/KoreBuild.sh
@@ -32,6 +32,9 @@ set_korebuildsettings() {
 
     export DOTNET_ROOT="$DOTNET_HOME"
 
+    # Workaround perpetual issues in node reuse and custom task assemblies
+    export MSBUILDDISABLENODEREUSE=1
+
     return 0
 }
 

--- a/files/KoreBuild/scripts/KoreBuild.psm1
+++ b/files/KoreBuild/scripts/KoreBuild.psm1
@@ -304,6 +304,9 @@ function Set-KoreBuildSettings(
     $arch = __get_dotnet_arch
     $env:DOTNET_ROOT = if ($IS_WINDOWS) { Join-Path $DotNetHome $arch } else { $DotNetHome }
 
+    # Workaround perpetual issues in node reuse and custom task assemblies
+    $env:MSBUILDDISABLENODEREUSE = 1
+
     $global:KoreBuildSettings = @{
         ToolsSource = $ToolsSource
         DotNetHome  = $DotNetHome


### PR DESCRIPTION
Workaround for https://github.com/Microsoft/msbuild/issues/3572

Resolves https://github.com/aspnet/Universe/issues/1311

We already pass `/nodeReuse:false` on commandline by default. Setting this env variable takes this one more step to ensure functional tests which launch MSBuild don't use nodeReuse on CI.