### PR TITLE
[WIP] Add support for setting env-vars in VSTS template

### DIFF
--- a/.vsts-pipelines/templates/phases/default-build.yml
+++ b/.vsts-pipelines/templates/phases/default-build.yml
@@ -23,6 +23,8 @@
 #           The name of the artifact container
 #   variables: { string: string }
 #     A map of custom variables
+#   env: { string: string }
+#     A map of environment variables to set during the build script.
 #   matrix: { string: { string: string } }
 #     A map of matrix configurations and variables. https://docs.microsoft.com/en-us/vsts/pipelines/yaml-schema?view=vsts#matrix
 #   demands: string | [ string ]
@@ -46,6 +48,7 @@ parameters:
   variables: {}
   dependsOn: ''
   # matrix: {} - don't define an empty object default because there is no way in template expression yet to check "if isEmpty(parameters.matrix)"
+  # env: {} - don't define an empty object default because there is no way in template expression yet to check "if isEmpty(parameters.env)"
   artifacts:
     publish: true
     path: 'artifacts/build/'  # TODO: this is going to change when we converge with dotnet/arcade tooling
@@ -81,9 +84,13 @@ phases:
   - ${{ if eq(parameters.agentOs, 'Windows') }}:
     - script: .\build.cmd -ci /p:Configuration=$(BuildConfiguration) $(BuildScriptArgs)
       displayName: Run build.cmd
+      ${{ if ne(parameters.env, '') }}:
+        env: ${{ parameters.env }}
   - ${{ if ne(parameters.agentOs, 'Windows') }}:
     - script: ./build.sh -ci -p:Configuration=$(BuildConfiguration) $(BuildScriptArgs)
       displayName: Run build.sh
+      ${{ if ne(parameters.env, '') }}:
+        env: ${{ parameters.env }}
   - task: PublishTestResults@2
     displayName: Publish test results
     condition: always()


### PR DESCRIPTION
Adds a new parameter 'env' to the default build template that sets environment variables in the `script` task that runs the build script. Useful for passing secret variables in as environment variables, because they don't flow unless explicitly specified.

We need this in SignalR to flow credentials for Sauce Labs down into the build script. Just putting the macros in the `buildArgs` parameter doesn't seem to work.

WIP because I'm still testing this. I'll come back and confirm when it's working, but I wanted to throw this out for review because I don't expect it to change if it works and it's pretty simple :).