### PR TITLE
Use real TC statuses

### DIFF
--- a/modules/NuGetPackageVerifier/console/Logging/TeamCityLogger.cs
+++ b/modules/NuGetPackageVerifier/console/Logging/TeamCityLogger.cs
@@ -34,7 +34,7 @@ namespace NuGetPackageVerifier.Logging
                     status = "NORMAL";
                     break;
                 default:
-                    status = "INFORMATION";
+                    status = "NORMAL";
                     break;
             }
 


### PR DESCRIPTION
Fixes #758.

As per https://confluence.jetbrains.com/display/TCD18/Build+Script+Interaction+with+TeamCity "INFORMATION" is not a valid status. Use Normal instead.