### PR TITLE
Implement MicroBuild code signing

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -1,6 +1,7 @@
 <Project>
   <PropertyGroup>
     <HtmlAgilityPackPackageVersion>1.5.1</HtmlAgilityPackPackageVersion>
+    <MicroBuildCorePackageVersion>0.2.0</MicroBuildCorePackageVersion>
     <MicrosoftDotNetPlatformAbstractionsVersion>2.0.0</MicrosoftDotNetPlatformAbstractionsVersion>
     <MicrosoftNETCoreApp21PackageVersion>2.1.0</MicrosoftNETCoreApp21PackageVersion>
     <MicrosoftNETTestSdkPackageVersion>15.6.1</MicrosoftNETTestSdkPackageVersion>
@@ -11,6 +12,7 @@
     <NewtonsoftJsonPackageVersion>10.0.1</NewtonsoftJsonPackageVersion>
     <NuGetPackagingPackageVersion>4.7.0-rtm.5148</NuGetPackagingPackageVersion>
     <NuGetProjectModelPackageVersion>4.7.0-rtm.5148</NuGetProjectModelPackageVersion>
+    <RoslynToolsSignToolPackageVersion>1.0.0-beta2-63206-01</RoslynToolsSignToolPackageVersion>
     <SystemCollectionsImmutablePackageVersion>1.4.0</SystemCollectionsImmutablePackageVersion>
     <SystemReflectionMetadataPackageVersion>1.5.0</SystemReflectionMetadataPackageVersion>
     <VSWherePackageVersion>2.2.7</VSWherePackageVersion>

--- a/build/sources.props
+++ b/build/sources.props
@@ -8,6 +8,7 @@
       https://dotnet.myget.org/F/dotnet-core/api/v3/index.json;
       https://dotnet.myget.org/F/nuget-build/api/v3/index.json;
       https://dotnet.myget.org/F/msbuild/api/v3/index.json;
+      https://dotnet.myget.org/F/roslyn-tools/api/v3/index.json;
       https://api.nuget.org/v3/index.json;
     </RestoreSources>
   </PropertyGroup>

--- a/docs/Signing.md
+++ b/docs/Signing.md
@@ -24,7 +24,7 @@ To sign NuGet packages, set the PackageSigningCertName property in the \*.csproj
 
 ```xml
 <PropertyGroup>
-  <PackageSigningCertName>NuGetCert</PackageSigningCertName>
+  <PackageSigningCertName>MyNuGetCert</PackageSigningCertName>
 </PropertyGroup>
 ```
 
@@ -35,8 +35,21 @@ For assemblies that ship in a NuGet package, you can specify multiple properties
 ```xml
 <PropertyGroup>
   <AssemblySigningCertName>MyCert</AssemblySigningCertName>
-  <PackageSigningCertName>NuGetCert</PackageSigningCertName>
+  <PackageSigningCertName>MyNuGetCert</PackageSigningCertName>
 </PropertyGroup>
+```
+
+### Recommended cert names for Microsoft projects
+
+The following certificate names should be used for Microsoft projects. These MSBuild properties are also available by using Internal.AspNetCore.SDK.
+
+```xml
+    <AssemblySigningCertName>Microsoft400</AssemblySigningCertName>
+    <AssemblySigning3rdPartyCertName>3PartySHA2</AssemblySigning3rdPartyCertName>
+    <PowerShellSigningCertName>Microsoft400</PowerShellSigningCertName>
+    <PackageSigningCertName>NuGet</PackageSigningCertName>
+    <VsixSigningCertName>VsixSHA2</VsixSigningCertName>
+    <JarSigningCertName>MicrosoftJAR</JarSigningCertName>
 ```
 
 ### Projects using nuspec
@@ -70,7 +83,7 @@ Sometimes other signable assemblies end up in a nupkg. Signing for these file ty
       PackagePath="tasks/net461/$(TargetFileName)" Visible="false" />
 
     <!-- Third-party cert -->
-    <SignedPackageFile Include="tools/Newtonsoft.Json.dll" Certificate="3PartyDual" Visible="false" />
+    <SignedPackageFile Include="tools/Newtonsoft.Json.dll" Certificate="3PartySHA2" Visible="false" />
 
     <!-- This should already be signed by the dotnet-core team -->
     <ExcludePackageFileFromSigning Include="tools/System.Runtime.CompilerServices.Unsafe.dll" />
@@ -95,9 +108,9 @@ these elements to the `build/repo.props` file. (See also [KoreBuild.md](./KoreBu
 ```xml
 <!-- build/repo.props -->
 <ItemGroup>
-  <FilesToSign Include="$(ArtifactsDir)libuv.dll" Certificate="3PartyDual" />
+  <FilesToSign Include="$(ArtifactsDir)libuv.dll" Certificate="3PartySHA2" />
 
   <!-- Files can also be listed as "do not sign", for completeness -->
-  <FilesToExcludeFromSigning Include="$(ArtifactsDir)my.test.dll" Certificate="3PartyDual" />
+  <FilesToExcludeFromSigning Include="$(ArtifactsDir)my.test.dll" Certificate="3PartySHA2" />
 </ItemGroup>
 ```

--- a/files/KoreBuild/KoreBuild.Common.props
+++ b/files/KoreBuild/KoreBuild.Common.props
@@ -39,6 +39,12 @@ Default layout and configuration.
     <BuildDir>$(ArtifactsDir)build\</BuildDir>
     <LogOutputDir>$(ArtifactsDir)logs\</LogOutputDir>
     <IntermediateDir>$([MSBuild]::NormalizeDirectory('$(RepositoryRoot)'))obj\</IntermediateDir>
+
+    <NuGetPackageRoot Condition=" '$(NuGetPackageRoot)' == '' ">$(NUGET_PACKAGES)</NuGetPackageRoot>
+    <NuGetPackageRoot Condition=" '$(NuGetPackageRoot)' == '' AND '$(USERPROFILE)' != '' ">$(USERPROFILE)\.nuget\packages\</NuGetPackageRoot>
+    <NuGetPackageRoot Condition=" '$(NuGetPackageRoot)' == '' AND '$(HOME)' != '' ">$(HOME)\.nuget\packages\</NuGetPackageRoot>
+    <NuGetPackageRoot Condition=" '$(NuGetPackageRoot)' == '' ">$(RepositoryRoot)\.nuget\packages\</NuGetPackageRoot>
+    <NuGetPackageRoot>$([MSBuild]::NormalizeDirectory('$(NuGetPackageRoot)'))</NuGetPackageRoot>
   </PropertyGroup>
 
   <!-- Use build number from CI if available -->

--- a/files/KoreBuild/modules/solutionbuild/Project.Inspection.targets
+++ b/files/KoreBuild/modules/solutionbuild/Project.Inspection.targets
@@ -20,6 +20,14 @@
       <IncludeSource Condition="'$(IncludeSource)' == '' AND $(_ReferencesInternalAspNetCoreSdk)">true</IncludeSource>
     </PropertyGroup>
 
+    <ConvertToAbsolutePath Paths="@(SignedPackageFile)">
+      <Output TaskParameter="AbsolutePaths" ItemName="_SignedPackageFile" />
+    </ConvertToAbsolutePath>
+
+    <ConvertToAbsolutePath Paths="@(ExcludePackageFileFromSigning)">
+      <Output TaskParameter="AbsolutePaths" ItemName="_ExcludePackageFileFromSigning" />
+    </ConvertToAbsolutePath>
+
     <ItemGroup Condition="'$(IsPackable)' == 'true' ">
       <ArtifactInfo Include="$(FullPackageOutputPath)">
         <ArtifactType>NuGetPackage</ArtifactType>
@@ -32,7 +40,7 @@
         <RepositoryUrl>$(RepositoryUrl)</RepositoryUrl>
         <Category>$(PackageArtifactCategory)</Category>
         <Certificate>$(PackageSigningCertName)</Certificate>
-        <ShouldBeSigned Condition="'$(PackageSigningCertName)' != '' OR @(SignedPackageFile->Count()) != 0 ">true</ShouldBeSigned>
+        <ShouldBeSigned Condition="'$(PackageSigningCertName)' != '' OR @(_SignedPackageFile->Count()) != 0 ">true</ShouldBeSigned>
         <ShouldBeSigned Condition=" '$(DisableCodeSigning)' == 'true' ">false</ShouldBeSigned>
         <IsContainer>true</IsContainer>
       </ArtifactInfo>
@@ -49,27 +57,27 @@
         <RepositoryUrl>$(RepositoryUrl)</RepositoryUrl>
         <Category>$(PackageArtifactCategory)</Category>
         <Certificate>$(PackageSigningCertName)</Certificate>
-        <ShouldBeSigned Condition="'$(PackageSigningCertName)' != '' OR @(SignedPackageFile->Count()) != 0 ">true</ShouldBeSigned>
+        <ShouldBeSigned Condition="'$(PackageSigningCertName)' != '' OR @(_SignedPackageFile->Count()) != 0 ">true</ShouldBeSigned>
         <ShouldBeSigned Condition=" '$(DisableCodeSigning)' == 'true' ">false</ShouldBeSigned>
         <IsContainer>true</IsContainer>
       </ArtifactInfo>
 
-      <ArtifactInfo Include="@(SignedPackageFile)" Condition=" '$(DisableCodeSigning)' != 'true' ">
+      <ArtifactInfo Include="@(_SignedPackageFile)" Condition=" '$(DisableCodeSigning)' != 'true' ">
         <ShouldBeSigned>true</ShouldBeSigned>
         <Container>$(FullPackageOutputPath)</Container>
       </ArtifactInfo>
 
-      <ArtifactInfo Include="@(ExcludePackageFileFromSigning)">
+      <ArtifactInfo Include="@(_ExcludePackageFileFromSigning)">
         <ShouldBeSigned>false</ShouldBeSigned>
         <Container>$(FullPackageOutputPath)</Container>
       </ArtifactInfo>
 
-      <ArtifactInfo Include="@(SignedPackageFile)" Condition=" '$(DisableCodeSigning)' != 'true' AND '$(IncludeSymbols)' == 'true' ">
+      <ArtifactInfo Include="@(_SignedPackageFile)" Condition=" '$(DisableCodeSigning)' != 'true' AND '$(IncludeSymbols)' == 'true' ">
         <ShouldBeSigned>true</ShouldBeSigned>
         <Container>$(SymbolsPackageOutputPath)</Container>
       </ArtifactInfo>
 
-      <ArtifactInfo Include="@(ExcludePackageFileFromSigning)" Condition="'$(IncludeSymbols)' == 'true' ">
+      <ArtifactInfo Include="@(_ExcludePackageFileFromSigning)" Condition="'$(IncludeSymbols)' == 'true' ">
         <ShouldBeSigned>false</ShouldBeSigned>
         <Container>$(SymbolsPackageOutputPath)</Container>
       </ArtifactInfo>

--- a/modules/KoreBuild.Tasks/CodeSign.targets
+++ b/modules/KoreBuild.Tasks/CodeSign.targets
@@ -7,7 +7,12 @@
 
     <!-- Repos can explicitly define the signdata.json file if they want do. They must set SignToolDataFile to the path of the file. When set, file generation is skipped. -->
     <GenerateSignToolDataFile  Condition="'$(SignToolDataFile)' == '' ">true</GenerateSignToolDataFile>
+
+    <!-- The location of SignToolData.json. This can be handwritten if you don't want to use the generated version. -->
     <SignToolDataFile Condition="'$(GenerateSignToolDataFile)' == 'true'">$(_IntermediateSignToolDataFile)</SignToolDataFile>
+
+    <!-- Relative paths in SignToolData.json are relative to this path -->
+    <SignToolDataWorkingDir Condition=" '$(SignToolDataWorkingDir)' == '' ">$(RepositoryRoot)</SignToolDataWorkingDir>
   </PropertyGroup>
 
   <Target Name="CodeSign" Condition=" '$(SkipCodeSign)' != 'true' "
@@ -34,7 +39,7 @@
       <SignToolOptions Include="$(NuGetPackageRoot)" />
       <SignToolOptions Include="-config" />
       <SignToolOptions Include="$(SignToolDataFile)" />
-      <SignToolOptions Include="$(RepositoryRoot)" />
+      <SignToolOptions Include="$(SignToolDataWorkingDir)" />
     </ItemGroup>
 
     <Run FileName="$(RoslynSignToolPath)" Arguments="@(SignToolOptions)" Condition=" '$(SignToolDataFile)' != '' " />

--- a/modules/KoreBuild.Tasks/CodeSign.targets
+++ b/modules/KoreBuild.Tasks/CodeSign.targets
@@ -1,0 +1,43 @@
+<Project>
+  <PropertyGroup>
+    <RoslynSignToolPath>$(MSBuildThisFileDirectory)SignTool\SignTool.exe</RoslynSignToolPath>
+    <SkipCodeSign Condition=" '$(OS)' != 'Windows_NT' ">true</SkipCodeSign>
+
+    <_IntermediateSignToolDataFile>$(IntermediateDir)SignToolData.g.json</_IntermediateSignToolDataFile>
+
+    <!-- Repos can explicitly define the signdata.json file if they want do. They must set SignToolDataFile to the path of the file. When set, file generation is skipped. -->
+    <GenerateSignToolDataFile  Condition="'$(SignToolDataFile)' == '' ">true</GenerateSignToolDataFile>
+    <SignToolDataFile Condition="'$(GenerateSignToolDataFile)' == 'true'">$(_IntermediateSignToolDataFile)</SignToolDataFile>
+  </PropertyGroup>
+
+  <Target Name="CodeSign" Condition=" '$(SkipCodeSign)' != 'true' "
+          AfterTargets="Package"
+          DependsOnTargets="GetArtifactInfo">
+
+    <PropertyGroup>
+    </PropertyGroup>
+
+    <GetPathToFullMSBuild>
+      <Output TaskParameter="MSBuildx86Path" PropertyName="MSBuildx86Path" />
+    </GetPathToFullMSBuild>
+
+    <GenerateSignToolDataFile Condition=" '$(GenerateSignToolDataFile)' != 'false' "
+      Files="@(FilesToSign)"
+      Exclusions="@(FilesToExcludeFromSigning)"
+      OutputPath="$(_IntermediateSignToolDataFile)" />
+
+    <ItemGroup>
+      <SignToolOptions Condition=" '$(MSBuildx86Path)' != '' " Include="-msbuildPath;$(MSBuildx86Path)" />
+      <SignToolOptions Condition=" '$(SignType)' != 'real' AND '$(SignType)' != 'test' "  Include="-test" />
+      <SignToolOptions Condition=" '$(SignType)' == 'test' " Include="-testSign" />
+      <SignToolOptions Include="-nugetPackagesPath" />
+      <SignToolOptions Include="$(NuGetPackageRoot)" />
+      <SignToolOptions Include="-config" />
+      <SignToolOptions Include="$(SignToolDataFile)" />
+      <SignToolOptions Include="$(RepositoryRoot)" />
+    </ItemGroup>
+
+    <Run FileName="$(RoslynSignToolPath)" Arguments="@(SignToolOptions)" Condition=" '$(SignToolDataFile)' != '' " />
+  </Target>
+
+</Project>

--- a/modules/KoreBuild.Tasks/GenerateSignToolDataFile.cs
+++ b/modules/KoreBuild.Tasks/GenerateSignToolDataFile.cs
@@ -1,0 +1,87 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.Build.Framework;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace KoreBuild.Tasks
+{
+    /// <summary>
+    /// Generates a signdata.json file for the Roslyn SignTool to execute
+    /// </summary>
+    public class GenerateSignToolDataFile : Microsoft.Build.Utilities.Task
+    {
+        [Required]
+        public ITaskItem[] Files { get; set; }
+        public ITaskItem[] Exclusions { get; set; }
+
+        /// <summary>
+        /// The path to SignData.json file
+        /// </summary>
+        [Required]
+        public string OutputPath { get; set; }
+
+        public override bool Execute()
+        {
+            OutputPath = OutputPath.Replace('\\', '/');
+
+            var data = new JObject();
+            var signData = new JArray();
+            data["sign"] = signData;
+
+            if (Files != null)
+            {
+                foreach (var certificateGroup in Files.GroupBy(i => (Certificate: i.GetMetadata("Certificate"), StrongName: i.GetMetadata("StrongName"))))
+                {
+                    var values = new HashSet<string>();
+                    foreach (var item in certificateGroup)
+                    {
+                        values.Add(item.ItemSpec);
+                    }
+
+                    var certName = string.IsNullOrEmpty(certificateGroup.Key.Certificate)
+                        ? null // needs to be null, not an empty string,
+                        : certificateGroup.Key.Certificate;
+
+                    var strongName = string.IsNullOrEmpty(certificateGroup.Key.StrongName)
+                        ? null // needs to be null, not an empty string,
+                        : certificateGroup.Key.StrongName;
+
+                    signData.Add(new JObject
+                    {
+                        ["certificate"] = certName,
+                        ["strongName"] = strongName,
+                        ["values"] = new JArray(values),
+                    });
+                }
+            }
+
+            if (Exclusions != null)
+            {
+                var exclusions = new HashSet<string>();
+                foreach (var item in Exclusions)
+                {
+                    exclusions.Add(Path.GetFileName(item.ItemSpec));
+                }
+
+                data["exclude"] = new JArray(exclusions);
+            }
+
+            Directory.CreateDirectory(Path.GetDirectoryName(OutputPath));
+
+            Log.LogMessage("Generating sign data in {0}", OutputPath);
+
+            using (var file = File.CreateText(OutputPath))
+            using (var jsonWriter = new JsonTextWriter(file) { Formatting = Formatting.Indented })
+            {
+                data.WriteTo(jsonWriter);
+            }
+
+            return !Log.HasLoggedErrors;
+        }
+    }
+}

--- a/modules/KoreBuild.Tasks/GetPathToFullMSBuild.cs
+++ b/modules/KoreBuild.Tasks/GetPathToFullMSBuild.cs
@@ -1,0 +1,42 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Runtime.InteropServices;
+using KoreBuild.Tasks.Utilities;
+using Microsoft.Build.Framework;
+
+namespace KoreBuild.Tasks
+{
+    /// <summary>
+    /// Finds toolset information as listed in korebuild.json
+    /// </summary>
+    public class GetPathToFullMSBuild : Microsoft.Build.Utilities.Task
+    {
+        /// <summary>
+        /// The path to MSBuild.exe (x86).
+        /// </summary>
+        [Output]
+        public string MSBuildx86Path { get; set; }
+
+        public override bool Execute()
+        {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                Log.LogError("Full MSBuild is not available on non-Windows.");
+                return false;
+            }
+
+            var vs = VsWhere.FindLatestInstallation(includePrerelease: true, Log);
+
+            if (vs == null)
+            {
+                Log.LogError($"Could not find an installation of Visual Studio.");
+                return false;
+            }
+
+            MSBuildx86Path = vs.GetMSBuildx86SubPath();
+
+            return !Log.HasLoggedErrors;
+        }
+    }
+}

--- a/modules/KoreBuild.Tasks/KoreBuild.Tasks.csproj
+++ b/modules/KoreBuild.Tasks/KoreBuild.Tasks.csproj
@@ -4,7 +4,9 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <AssemblyName>Internal.AspNetCore.KoreBuild.Tasks</AssemblyName>
+    <RoslynSignToolDir>$(NuGetPackageRoot)roslyntools.signtool\$(RoslynToolsSignToolPackageVersion)\</RoslynSignToolDir>
   </PropertyGroup>
+
   <ItemGroup>
     <Content Include="*.props" CopyToPublishDirectory="PreserveNewest" />
     <Content Include="*.targets" CopyToPublishDirectory="PreserveNewest" />
@@ -13,8 +15,10 @@
     <Compile Include="..\BuildTools.Tasks\Utilities\FileHelpers.cs" Link="Utilities\FileHelpers.cs" />
     <Compile Include="..\..\tools\KoreBuildSettings.cs" />
     <Content Include="$(VSWhereDir)vswhere.exe" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest" />
+    <Content Include="$(RoslynSignToolDir)tools\**\*" Link="SignTool\%(RecursiveDir)%(FileName)%(Extension)" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest" />
     <Content Include="$(MSBuildThisFileDirectory)SkipStrongNames.xml" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest" />
   </ItemGroup>
+
   <ItemGroup>
     <!-- set as private assets all so these assemblies get resolved from the version bundled in the .NET Core SDK -->
     <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildPackageVersion)" PrivateAssets="All" />
@@ -25,6 +29,7 @@
     <PackageReference Include="NuGet.Build.Tasks" Version="$(Tooling_NuGetBuildTasksPackageVersion)" PrivateAssets="All" />
     <PackageReference Include="Newtonsoft.Json" Version="$(Tooling_NewtonsoftJsonPackageVersion)" PrivateAssets="All" />
     <PackageReference Include="vswhere" Version="$(VSWherePackageVersion)" PrivateAssets="All" />
+    <PackageReference Include="RoslynTools.SignTool" Version="$(RoslynToolsSignToolPackageVersion)" />
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), version.props))\build\sdk.targets" />

--- a/modules/KoreBuild.Tasks/Utilities/VsWhere.cs
+++ b/modules/KoreBuild.Tasks/Utilities/VsWhere.cs
@@ -26,6 +26,9 @@ namespace KoreBuild.Tasks.Utilities
                 args.Add("-prerelease");
             }
 
+            args.Add("-products");
+            args.Add("*");
+
             return GetInstallations(args, log).FirstOrDefault();
         }
 

--- a/modules/KoreBuild.Tasks/module.props
+++ b/modules/KoreBuild.Tasks/module.props
@@ -10,6 +10,8 @@
   <UsingTask TaskName="KoreBuild.Tasks.FindVisualStudio" AssemblyFile="$(KoreBuildTasksDll)" />
   <UsingTask TaskName="KoreBuild.Tasks.GenerateDependenciesPropsFile" AssemblyFile="$(KoreBuildTasksDll)" />
   <UsingTask TaskName="KoreBuild.Tasks.GeneratePackageVersionPropsFile" AssemblyFile="$(KoreBuildTasksDll)" />
+  <UsingTask TaskName="KoreBuild.Tasks.GenerateSignToolDataFile" AssemblyFile="$(KoreBuildTasksDll)" />
+  <UsingTask TaskName="KoreBuild.Tasks.GetPathToFullMSBuild" AssemblyFile="$(KoreBuildTasksDll)" />
   <UsingTask TaskName="KoreBuild.Tasks.GetToolsets" AssemblyFile="$(KoreBuildTasksDll)" />
   <UsingTask TaskName="KoreBuild.Tasks.InstallDotNet" AssemblyFile="$(KoreBuildTasksDll)" />
   <UsingTask TaskName="KoreBuild.Tasks.InstallToolsets" AssemblyFile="$(KoreBuildTasksDll)" />

--- a/modules/KoreBuild.Tasks/module.targets
+++ b/modules/KoreBuild.Tasks/module.targets
@@ -1,5 +1,7 @@
 <Project>
 
+  <Import Project="CodeSign.targets" />
+
   <PropertyGroup>
     <PrepareDependsOn Condition=" '$(DisableDefaultTargets)' != 'true' ">GetToolsets;$(PrepareDependsOn)</PrepareDependsOn>
     <RestoreDependsOn Condition=" '$(DisableDefaultTargets)' != 'true' ">InstallDotNet;CheckPackageReferences;$(RestoreDependsOn)</RestoreDependsOn>

--- a/src/Internal.AspNetCore.Sdk/Internal.AspNetCore.Sdk.csproj
+++ b/src/Internal.AspNetCore.Sdk/Internal.AspNetCore.Sdk.csproj
@@ -46,6 +46,7 @@
 <Project>
   <PropertyGroup>
     <MicrosoftAspNetCoreBuildToolsApiCheckPackageVersion>$(ApiCheckPackageVersion)</MicrosoftAspNetCoreBuildToolsApiCheckPackageVersion>
+    <MicroBuildCorePackageVersion>$(MicroBuildCorePackageVersion)</MicroBuildCorePackageVersion>
     <MicrosoftBuildPackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildPackageVersion>
     <JsonInMSBuildVersion>$(JsonInMSBuildVersion)</JsonInMSBuildVersion>
   </PropertyGroup>
@@ -60,6 +61,7 @@
       <NuspecProperties>$(NuspecProperties);id=$(PackageId)</NuspecProperties>
       <NuspecProperties>$(NuspecProperties);bundledVersionFile=$(IntermediateOutputPath)BundledVersions.props</NuspecProperties>
       <NuspecProperties>$(NuspecProperties);apicheckVersion=$(ApiCheckPackageVersion)</NuspecProperties>
+      <NuspecProperties>$(NuspecProperties);microbuildVersion=$(MicroBuildCorePackageVersion)</NuspecProperties>
       <NuspecProperties>$(NuspecProperties);config=$(Configuration)</NuspecProperties>
       <NuspecProperties>$(NuspecProperties);version=$(PackageVersion)</NuspecProperties>
       <NuspecProperties>$(NuspecProperties);description=$(Description)</NuspecProperties>

--- a/src/Internal.AspNetCore.Sdk/Internal.AspNetCore.Sdk.nuspec
+++ b/src/Internal.AspNetCore.Sdk/Internal.AspNetCore.Sdk.nuspec
@@ -9,6 +9,7 @@
     <copyright>$copyright$</copyright>
     <dependencies>
       <dependency id="Microsoft.AspNetCore.BuildTools.ApiCheck" version="$apicheckversion$" />
+      <dependency id="MicroBuild.Core" version="$microbuildversion$" />
     </dependencies>
   </metadata>
   <files>

--- a/src/Internal.AspNetCore.Sdk/build/Common.props
+++ b/src/Internal.AspNetCore.Sdk/build/Common.props
@@ -28,6 +28,16 @@ Usage: this should be imported once via NuGet at the top of the file.
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
   </PropertyGroup>
 
+  <!-- Code signing certificate names -->
+  <PropertyGroup Condition=" '$(DisableMicrosoftCodeSigning)' != 'false' ">
+    <AssemblySigningCertName>Microsoft400</AssemblySigningCertName>
+    <AssemblySigning3rdPartyCertName>3PartySHA2</AssemblySigning3rdPartyCertName>
+    <PowerShellSigningCertName>Microsoft400</PowerShellSigningCertName>
+    <PackageSigningCertName>NuGet</PackageSigningCertName>
+    <VsixSigningCertName>VsixSHA2</VsixSigningCertName>
+    <JarSigningCertName>MicrosoftJAR</JarSigningCertName>
+  </PropertyGroup>
+
   <!-- common build options -->
   <PropertyGroup>
     <!-- make disabling warnings opt-out -->

--- a/src/Internal.AspNetCore.Sdk/build/DotNetTool.targets
+++ b/src/Internal.AspNetCore.Sdk/build/DotNetTool.targets
@@ -8,7 +8,7 @@
   <Target Name="_GetSignedPackageFilesForGeneratedShims" Condition="'$(AssemblySigningCertName)' != ''">
     <ItemGroup>
       <_ShimRids Include="$(PackAsToolShimRuntimeIdentifiers)" />
-      <SignedPackageFile Condition="'%(_ShimRids.Identity)' != ''" Include="$(IntermediateOutputPath)shims/%(_ShimRids.Identity)/$(AssemblyName).exe" Certificate="$(AssemblySigningCertName)">
+      <SignedPackageFile Condition="'%(_ShimRids.Identity)' != ''" Include="$(IntermediateOutputPath)shims/$(TargetFramework)/%(_ShimRids.Identity)/$(AssemblyName).exe" Certificate="$(AssemblySigningCertName)">
         <PackagePath>tools/$(TargetFramework)/any/shims/%(_ShimRids.Identity)/</PackagePath>
       </SignedPackageFile>
       <SignedPackageFile Include="$(TargetPath)" Certificate="$(AssemblySigningCertName)">

--- a/src/Internal.AspNetCore.Sdk/sdk/DefaultItems.targets
+++ b/src/Internal.AspNetCore.Sdk/sdk/DefaultItems.targets
@@ -12,6 +12,14 @@
       Publish="false" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(DisableMicroBuild)' != 'true'">
+    <PackageReference Include="MicroBuild.Core"
+      Version="$(MicroBuildCorePackageVersion)"
+      PrivateAssets="All"
+      IsImplicitlyDefined="true"
+      Publish="false" />
+  </ItemGroup>
+
   <ItemGroup Condition="'$(ProjectType)' == 'RepoTasks' AND '$(DisableImplicitFrameworkReferences)' != 'true'">
     <!-- set as private assets all since we don't need this in the publish output folder -->
     <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildPackageVersion)" IsImplicitlyDefined="true" PrivateAssets="All" />


### PR DESCRIPTION
This transforms MSBuild items (see docs/Signing.md) into a manifest which is then invoked by the Roslyn sign tool. In environments with MicroBuild enabled, this will run code signing. In local developer builds, this tool will do a dry run that validates the assemblies in .nupkgs are account file in the sign data.