### PR TITLE
Only run benchmark validation for runnable benchmark projects

### DIFF
--- a/files/KoreBuild/modules/vstest/module.targets
+++ b/files/KoreBuild/modules/vstest/module.targets
@@ -118,7 +118,10 @@ Runs the VSTest on all projects in the ProjectsToTest itemgroup.
       <Output TaskParameter="TargetOutputs" ItemName="BenchmarkExecPath" />
     </MSBuild>
 
-    <RunDotNet Arguments="%(BenchmarkExecPath.Identity);*;--validate-fast" />
+    <RunDotNet Condition="'%(BenchmarkExecPath.TargetFrameworkIdentifier)' == '.NETCoreApp'"
+      Arguments="%(BenchmarkExecPath.Identity);*;--validate-fast" />
+    <Run Condition="'%(BenchmarkExecPath.TargetFrameworkIdentifier)' == '.NETFramework'"
+      FileName="%(BenchmarkExecPath.Identity)" Arguments="*;--validate-fast" />
   </Target>
 
 </Project>

--- a/modules/KoreBuild.Tasks/CodeSign.targets
+++ b/modules/KoreBuild.Tasks/CodeSign.targets
@@ -37,6 +37,8 @@
       <SignToolOptions Condition=" '$(SignType)' == 'test' " Include="-testSign" />
       <SignToolOptions Include="-nugetPackagesPath" />
       <SignToolOptions Include="$(NuGetPackageRoot)" />
+      <SignToolOptions Include="-intermediateOutputPath" />
+      <SignToolOptions Include="$(IntermediateDir)" />
       <SignToolOptions Include="-config" />
       <SignToolOptions Include="$(SignToolDataFile)" />
       <SignToolOptions Include="$(SignToolDataWorkingDir)" />


### PR DESCRIPTION
Current defaults attempt to run .NET Standard projects under benchmarks/*