### PR TITLE
Remove MicroBuild.Core as a dependency of Internal.AspNetCore.Sdk

### DIFF
--- a/modules/BundledPackages/BundledPackages.proj
+++ b/modules/BundledPackages/BundledPackages.proj
@@ -27,7 +27,6 @@
   <Sdk Name="Internal.AspNetCore.Sdk" Version="$(Version)" />
 
   <PropertyGroup>
-    <DisableMicroBuild>true</DisableMicroBuild>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
   </PropertyGroup>

--- a/modules/BundledPackages/BundledPackages.proj
+++ b/modules/BundledPackages/BundledPackages.proj
@@ -32,6 +32,10 @@
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="MicroBuild.Core" Version="$(MicroBuildCorePackageVersion)" />
+  </ItemGroup>
+
   <Target Name="noop" />
 </Project>
 ]]>

--- a/src/Internal.AspNetCore.Sdk/Internal.AspNetCore.Sdk.csproj
+++ b/src/Internal.AspNetCore.Sdk/Internal.AspNetCore.Sdk.csproj
@@ -46,7 +46,6 @@
 <Project>
   <PropertyGroup>
     <MicrosoftAspNetCoreBuildToolsApiCheckPackageVersion>$(ApiCheckPackageVersion)</MicrosoftAspNetCoreBuildToolsApiCheckPackageVersion>
-    <MicroBuildCorePackageVersion>$(MicroBuildCorePackageVersion)</MicroBuildCorePackageVersion>
     <MicrosoftBuildPackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildPackageVersion>
     <JsonInMSBuildVersion>$(JsonInMSBuildVersion)</JsonInMSBuildVersion>
   </PropertyGroup>
@@ -61,7 +60,6 @@
       <NuspecProperties>$(NuspecProperties);id=$(PackageId)</NuspecProperties>
       <NuspecProperties>$(NuspecProperties);bundledVersionFile=$(IntermediateOutputPath)BundledVersions.props</NuspecProperties>
       <NuspecProperties>$(NuspecProperties);apicheckVersion=$(ApiCheckPackageVersion)</NuspecProperties>
-      <NuspecProperties>$(NuspecProperties);microbuildVersion=$(MicroBuildCorePackageVersion)</NuspecProperties>
       <NuspecProperties>$(NuspecProperties);config=$(Configuration)</NuspecProperties>
       <NuspecProperties>$(NuspecProperties);version=$(PackageVersion)</NuspecProperties>
       <NuspecProperties>$(NuspecProperties);description=$(Description)</NuspecProperties>

--- a/src/Internal.AspNetCore.Sdk/Internal.AspNetCore.Sdk.nuspec
+++ b/src/Internal.AspNetCore.Sdk/Internal.AspNetCore.Sdk.nuspec
@@ -9,7 +9,6 @@
     <copyright>$copyright$</copyright>
     <dependencies>
       <dependency id="Microsoft.AspNetCore.BuildTools.ApiCheck" version="$apicheckversion$" />
-      <dependency id="MicroBuild.Core" version="$microbuildversion$" />
     </dependencies>
   </metadata>
   <files>

--- a/src/Internal.AspNetCore.Sdk/sdk/DefaultItems.targets
+++ b/src/Internal.AspNetCore.Sdk/sdk/DefaultItems.targets
@@ -12,14 +12,6 @@
       Publish="false" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(DisableMicroBuild)' != 'true'">
-    <PackageReference Include="MicroBuild.Core"
-      Version="$(MicroBuildCorePackageVersion)"
-      PrivateAssets="All"
-      IsImplicitlyDefined="true"
-      Publish="false" />
-  </ItemGroup>
-
   <ItemGroup Condition="'$(ProjectType)' == 'RepoTasks' AND '$(DisableImplicitFrameworkReferences)' != 'true'">
     <!-- set as private assets all since we don't need this in the publish output folder -->
     <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildPackageVersion)" IsImplicitlyDefined="true" PrivateAssets="All" />


### PR DESCRIPTION
Most microbuild tasks do not support .NET Core, so this causes task assembly load issues. We don't really need MicroBuild.Core in the project context. We just need it restored to disk for CI builds. This should still put the package in the cache without causing task assembly load errors.