### PR TITLE
Minor tweaks to settings for code signing and .symbols.nupkg generation

### DIFF
--- a/files/KoreBuild/modules/solutionbuild/Project.Inspection.targets
+++ b/files/KoreBuild/modules/solutionbuild/Project.Inspection.targets
@@ -28,7 +28,7 @@
       <Output TaskParameter="AbsolutePaths" ItemName="_ExcludePackageFileFromSigning" />
     </ConvertToAbsolutePath>
 
-    <ItemGroup Condition="'$(IsPackable)' == 'true' ">
+    <ItemGroup Condition="'$(IsPackable)' != 'false' ">
       <ArtifactInfo Include="$(FullPackageOutputPath)">
         <ArtifactType>NuGetPackage</ArtifactType>
         <PackageId>$(PackageId)</PackageId>

--- a/modules/KoreBuild.Tasks/CodeSign.targets
+++ b/modules/KoreBuild.Tasks/CodeSign.targets
@@ -45,7 +45,12 @@
       <SignToolOptions Include="$(SignToolDataWorkingDir)" />
     </ItemGroup>
 
-    <Message Importance="High" Text="Running SignTool.exe -DryRun:$(SignToolDryRun)" />
+    <PropertyGroup>
+      <_SignToolMessage>Running SignTool</_SignToolMessage>
+      <_SignToolMessage Condition=" '$(SignToolDryRun)' == 'true' ">$(_SignToolMessage) (dry-run)</_SignToolMessage>
+    </PropertyGroup>
+
+    <Message Importance="High" Text="$(_SignToolMessage)" />
 
     <Run FileName="$(RoslynSignToolPath)" Arguments="@(SignToolOptions)" Condition=" '$(SignToolDataFile)' != '' " StandardOutputImportance="Normal" />
   </Target>

--- a/modules/KoreBuild.Tasks/CodeSign.targets
+++ b/modules/KoreBuild.Tasks/CodeSign.targets
@@ -13,14 +13,15 @@
 
     <!-- Relative paths in SignToolData.json are relative to this path -->
     <SignToolDataWorkingDir Condition=" '$(SignToolDataWorkingDir)' == '' ">$(RepositoryRoot)</SignToolDataWorkingDir>
+
+    <!-- Dry run checks signing config without code signing. -->
+    <SignToolDryRun Condition=" '$(SignType)' != 'real' AND '$(SignType)' != 'test' ">true</SignToolDryRun>
+    <SignToolDryRun Condition=" '$(SignToolDryRun)' == '' ">false</SignToolDryRun>
   </PropertyGroup>
 
   <Target Name="CodeSign" Condition=" '$(SkipCodeSign)' != 'true' "
           AfterTargets="Package"
           DependsOnTargets="GetArtifactInfo">
-
-    <PropertyGroup>
-    </PropertyGroup>
 
     <GetPathToFullMSBuild>
       <Output TaskParameter="MSBuildx86Path" PropertyName="MSBuildx86Path" />
@@ -33,7 +34,7 @@
 
     <ItemGroup>
       <SignToolOptions Condition=" '$(MSBuildx86Path)' != '' " Include="-msbuildPath;$(MSBuildx86Path)" />
-      <SignToolOptions Condition=" '$(SignType)' != 'real' AND '$(SignType)' != 'test' "  Include="-test" />
+      <SignToolOptions Condition=" '$(SignToolDryRun)' == 'true' "  Include="-test" />
       <SignToolOptions Condition=" '$(SignType)' == 'test' " Include="-testSign" />
       <SignToolOptions Include="-nugetPackagesPath" />
       <SignToolOptions Include="$(NuGetPackageRoot)" />
@@ -44,7 +45,9 @@
       <SignToolOptions Include="$(SignToolDataWorkingDir)" />
     </ItemGroup>
 
-    <Run FileName="$(RoslynSignToolPath)" Arguments="@(SignToolOptions)" Condition=" '$(SignToolDataFile)' != '' " />
+    <Message Importance="High" Text="Running SignTool.exe -DryRun:$(SignToolDryRun)" />
+
+    <Run FileName="$(RoslynSignToolPath)" Arguments="@(SignToolOptions)" Condition=" '$(SignToolDataFile)' != '' " StandardOutputImportance="Normal" />
   </Target>
 
 </Project>

--- a/src/Internal.AspNetCore.Sdk/build/Common.targets
+++ b/src/Internal.AspNetCore.Sdk/build/Common.targets
@@ -15,11 +15,6 @@ For single-tfm projects, this will be imported from build/Internal.AspNetCore.Sd
     <NoWarn>$(NoWarn);NU5105</NoWarn>
   </PropertyGroup>
 
-  <!-- workaround https://github.com/NuGet/Home/issues/4726 -->
-  <PropertyGroup>
-    <IncludeSymbols Condition="'$(NuspecFile)'!=''">false</IncludeSymbols>
-  </PropertyGroup>
-
   <PropertyGroup Condition=" '$(IncludeSymbols)' != 'false' ">
     <GenerateNuspecDependsOn>$(GenerateNuspecDependsOn);_EnsureDebugTypeIsPortable</GenerateNuspecDependsOn>
     <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);_EnsureDebugTypeIsPortable</TargetsForTfmSpecificBuildOutput>


### PR DESCRIPTION
* Remove workaround for NuGet/Home#4276 - do not disable symbols generation just because custom nuspec is used
* Less-verbose console output from SignTool.exe
