### PR TITLE
Update NGPV to use runtime rollforward

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,5 +1,2 @@
 <Project>
-  <PropertyGroup>
-    <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">$(MicrosoftNETCoreApp21PackageVersion)</RuntimeFrameworkVersion>
-  </PropertyGroup>
 </Project>

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <HtmlAgilityPackPackageVersion>1.5.1</HtmlAgilityPackPackageVersion>
     <MicrosoftDotNetPlatformAbstractionsVersion>2.0.0</MicrosoftDotNetPlatformAbstractionsVersion>
-    <MicrosoftNETCoreApp21PackageVersion>2.1.0</MicrosoftNETCoreApp21PackageVersion>
     <MicrosoftNETTestSdkPackageVersion>15.6.1</MicrosoftNETTestSdkPackageVersion>
     <MicrosoftWin32RegistryPackageVersion>4.4.0</MicrosoftWin32RegistryPackageVersion>
     <MonoCecilPackageVersion>0.10.0-beta6</MonoCecilPackageVersion>

--- a/modules/NuGetPackageVerifier/NuGetPackageVerifier.proj
+++ b/modules/NuGetPackageVerifier/NuGetPackageVerifier.proj
@@ -13,15 +13,5 @@
       Properties="PublishDir=$(PublishDir);Configuration=$(Configuration)" />
 
     <Copy SourceFiles="module.targets" DestinationFolder="$(PublishDir)" />
-
-    <MSBuild Projects="$(MSBuildThisFileDirectory)console\NuGetPackageVerifier.Console.csproj"
-      Targets="GetRuntimeVersion"
-      Properties="Configuration=$(Configuration)">
-      <Output TaskParameter="TargetOutputs" PropertyName="NgpvRuntimeFrameworkVersion" />
-    </MSBuild>
-
-    <GenerateFileFromTemplate TemplateFile="$(MSBuildThisFileDirectory)module.props.in"
-      Properties="RuntimeFrameworkVersion=$(NgpvRuntimeFrameworkVersion)"
-      OutputPath="$(PublishDir)module.props" />
   </Target>
 </Project>

--- a/modules/NuGetPackageVerifier/console/NuGetPackageVerifier.Console.csproj
+++ b/modules/NuGetPackageVerifier/console/NuGetPackageVerifier.Console.csproj
@@ -18,6 +18,4 @@
     <PackageReference Include="NuGet.Packaging" Version="$(NuGetPackagingPackageVersion)" />
   </ItemGroup>
 
-  <Target Name="GetRuntimeVersion" Returns="$(RuntimeFrameworkVersion)" />
-
 </Project>

--- a/modules/NuGetPackageVerifier/console/runtimeconfig.template.json
+++ b/modules/NuGetPackageVerifier/console/runtimeconfig.template.json
@@ -1,0 +1,4 @@
+{
+  // Major rollforward
+  "rollForwardOnNoCandidateFx": 2
+}

--- a/modules/NuGetPackageVerifier/module.props.in
+++ b/modules/NuGetPackageVerifier/module.props.in
@@ -1,6 +1,0 @@
-<Project>
-  <ItemGroup>
-    <!-- Ensure we have the runtime required to execute the nuget package verifier -->
-    <DotNetCoreRuntime Include="${RuntimeFrameworkVersion}" />
-  </ItemGroup>
-</Project>

--- a/src/Microsoft.DotNet.GlobalTools.Sdk/sdk/Microsoft.DotNetTool.ShimGeneration.targets
+++ b/src/Microsoft.DotNet.GlobalTools.Sdk/sdk/Microsoft.DotNetTool.ShimGeneration.targets
@@ -80,6 +80,7 @@
       Properties="
         TargetFramework=$(TargetFramework);
         RuntimeIdentifier=%(GeneratedDotNetToolShim.RuntimeIdentifier);
+        RuntimeFrameworkVersion=$(RuntimeFrameworkVersion);
         _ShimRelativeAppBinaryFilePath=%(GeneratedDotNetToolShim.RelativeAppBinaryFilePath);
         _ShimOutputDir=%(GeneratedDotNetToolShim.OutputDir)"
       Condition="'%(GeneratedDotNetToolShim.Identity)' != ''" />

--- a/test/KoreBuild.FunctionalTests/GenerateTestProps.targets
+++ b/test/KoreBuild.FunctionalTests/GenerateTestProps.targets
@@ -6,7 +6,6 @@
 <Project>
   <PropertyGroup>
     <RestoreSources>$([MSBuild]::Escape($(RestoreSources)))</RestoreSources>
-    <RuntimeFrameworkVersion Condition="'%24(TargetFramework)' == 'netcoreapp2.1'">$(MicrosoftNETCoreApp21PackageVersion)</RuntimeFrameworkVersion>
   </PropertyGroup>
 </Project>
 ]]>


### PR DESCRIPTION
Instead of always installing the .NET Core 2.1.0 runtime, this uses runtime rollforward to lift NGPV's console tool to any version of .NET Core it finds.