### PR TITLE
Don't override NUGET_PACKAGES if already defined

### DIFF
--- a/files/KoreBuild/KoreBuild.sh
+++ b/files/KoreBuild/KoreBuild.sh
@@ -24,10 +24,21 @@ set_korebuildsettings() {
         export CI=true
         export DOTNET_CLI_TELEMETRY_OPTOUT=true
         export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true
+        export TEMP="$repo_path/.build/tmp"
+        export TMP="$TEMP"
         export NUGET_SHOW_STACK=true
-        export NUGET_PACKAGES="$repo_path/.nuget/packages"
         export DOTNET_HOME="$dot_net_home"
         export MSBUILDDEBUGPATH="$repo_path/artifacts/logs"
+        mkdir -p "$TMP"
+        mkdir -p "$HOME"
+        mkdir -p "$dot_net_home"
+        if [[ -z "${NUGET_PACKAGES:-}" ]]; then
+            export NUGET_PACKAGES="$repo_path/.build/.nuget/packages"
+        fi
+    else
+        if [[ -z "${NUGET_PACKAGES:-}" ]]; then
+            export NUGET_PACKAGES="$HOME/.nuget/packages"
+        fi
     fi
 
     export DOTNET_ROOT="$DOTNET_HOME"

--- a/files/KoreBuild/scripts/KoreBuild.psm1
+++ b/files/KoreBuild/scripts/KoreBuild.psm1
@@ -297,9 +297,18 @@ function Set-KoreBuildSettings(
         $env:DOTNET_CLI_TELEMETRY_OPTOUT = 'true'
         $env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE = 'true'
         $env:NUGET_SHOW_STACK = 'true'
-        $env:NUGET_PACKAGES = Join-Paths $RepoPath ('.nuget', 'packages')
         $env:MSBUILDDEBUGPATH = Join-Paths $RepoPath ('artifacts', 'logs')
+        if (-not $env:NUGET_PACKAGES) {
+            $env:NUGET_PACKAGES = Join-Paths $RepoPath ('.nuget', 'packages')
+        }
     }
+    else {
+        if (-not $env:NUGET_PACKAGES) {
+            $env:NUGET_PACKAGES = Join-Paths $env:USERPROFILE ('.nuget', 'packages')
+        }
+    }
+
+    $env:NUGET_PACKAGES = $env:NUGET_PACKAGES.TrimEnd('\') + '\'
 
     $arch = __get_dotnet_arch
     $env:DOTNET_ROOT = if ($IS_WINDOWS) { Join-Path $DotNetHome $arch } else { $DotNetHome }


### PR DESCRIPTION
Using `-ci` in Universe causes the NuGet cache for each repo build to be different. This means we end up restoring everything like 53 times.

This changes `-ci` builds so sub-repo builds can use the same NuGet cache