### PR TITLE
Set DOTNET_HOME to repo path when `-ci` is specified

### DIFF
--- a/files/KoreBuild/KoreBuild.sh
+++ b/files/KoreBuild/KoreBuild.sh
@@ -14,13 +14,20 @@ set_korebuildsettings() {
     local config_file="${4:-}" # optional. Not used yet.
     local ci="${5:-}"
 
-    [ -z "${dot_net_home:-}" ] && dot_net_home="$HOME/.dotnet"
+    [ -z "${dot_net_home:-}" ] && dot_net_home="${DOTNET_HOME:-}"
+
+    if [ -z "$dot_net_home" ]; then
+        if [ "$ci" = true ]; then
+            dot_net_home="$repo_path/.dotnet"
+        else
+            dot_net_home="$HOME/.dotnet"
+        fi
+    fi
+
     [ -z "${tools_source:-}" ] && tools_source="$default_tools_source"
 
 
     if [ "$ci" = true ]; then
-        dot_net_home="$repo_path/.dotnet"
-
         export CI=true
         export DOTNET_CLI_TELEMETRY_OPTOUT=true
         export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true

--- a/files/KoreBuild/scripts/KoreBuild.psm1
+++ b/files/KoreBuild/scripts/KoreBuild.psm1
@@ -282,16 +282,15 @@ function Set-KoreBuildSettings(
     [switch]$CI) {
     if (!$DotNetHome) {
         $DotNetHome = if ($env:DOTNET_HOME) { $env:DOTNET_HOME } `
+            elseif ($CI) { Join-Path $RepoPath '.dotnet'}
             elseif ($env:USERPROFILE) { Join-Path $env:USERPROFILE '.dotnet'} `
             elseif ($env:HOME) {Join-Path $env:HOME '.dotnet'}`
-            else { Join-Path $PSScriptRoot '.dotnet'}
+            else { Join-Path $RepoPath '.dotnet'}
     }
 
     if (!$ToolsSource) { $ToolsSource = 'https://aspnetcore.blob.core.windows.net/buildtools' }
 
     if ($CI) {
-        $DotNetHome = Join-Path $RepoPath ".dotnet"
-
         $env:CI = 'true'
         $env:DOTNET_HOME = $DotNetHome
         $env:DOTNET_CLI_TELEMETRY_OPTOUT = 'true'

--- a/scripts/bootstrapper/run.ps1
+++ b/scripts/bootstrapper/run.ps1
@@ -186,12 +186,13 @@ if (Test-Path $ConfigFile) {
 
 if (!$DotNetHome) {
     $DotNetHome = if ($env:DOTNET_HOME) { $env:DOTNET_HOME } `
+        elseif ($CI) { Join-Path $PSScriptRoot '.dotnet' } `
         elseif ($env:USERPROFILE) { Join-Path $env:USERPROFILE '.dotnet'} `
         elseif ($env:HOME) {Join-Path $env:HOME '.dotnet'}`
         else { Join-Path $PSScriptRoot '.dotnet'}
 }
 
-if (!$Channel) { $Channel = 'dev' }
+if (!$Channel) { $Channel = 'master' }
 if (!$ToolsSource) { $ToolsSource = 'https://aspnetcore.blob.core.windows.net/buildtools' }
 
 # Execute

--- a/scripts/bootstrapper/run.sh
+++ b/scripts/bootstrapper/run.sh
@@ -11,7 +11,6 @@ RED="\033[0;31m"
 YELLOW="\033[0;33m"
 MAGENTA="\033[0;95m"
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-[ -z "${DOTNET_HOME:-}" ] && DOTNET_HOME="$HOME/.dotnet"
 verbose=false
 update=false
 reinstall=false
@@ -188,6 +187,9 @@ while [[ $# -gt 0 ]]; do
             ;;
         --ci|-[Cc][Ii])
             ci=true
+            if [[ -z "${DOTNET_HOME:-}" ]]; then
+                DOTNET_HOME="$DIR/.dotnet"
+            fi
             ;;
         --verbose|-Verbose)
             verbose=true
@@ -237,7 +239,8 @@ if [ -f "$config_file" ]; then
     [ ! -z "${config_tools_source:-}" ] && tools_source="$config_tools_source"
 fi
 
-[ -z "$channel" ] && channel='dev'
+[ -z "${DOTNET_HOME:-}" ] && DOTNET_HOME="$HOME/.dotnet"
+[ -z "$channel" ] && channel='master'
 [ -z "$tools_source" ] && tools_source='https://aspnetcore.blob.core.windows.net/buildtools'
 
 get_korebuild


### PR DESCRIPTION
Fixes a bug in the bootstrapper. When calling just `-ci`, KoreBuild was still installing to `HOME` or `USERPROFILE`. This lifts the local-or-not setting for DOTNET_HOME into the bootstrapper so both the .NET Core SDK *and* korebuild end up in the same folder.