### PR TITLE
React to renaming aspnet/Home => aspnet/AspNetCore

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
 Contributing
 ======
 
-Information on contributing to this repo is in the [Contributing Guide](https://github.com/aspnet/Home/blob/dev/CONTRIBUTING.md) in the Home repo.
+Information on contributing to this repo is in the [Contributing Guide](https://github.com/aspnet/AspNetCore/blob/master/CONTRIBUTING.md) in the AspNetCore repo.

--- a/README.md
+++ b/README.md
@@ -1,13 +1,9 @@
 Build Tools
 ===========
 
-[![AppVeyor build status][appveyor-badge]](https://ci.appveyor.com/project/aspnetci/buildtools/branch/dev)
-
-[appveyor-badge]: https://img.shields.io/appveyor/ci/aspnetci/buildtools/dev.svg?label=appveyor&style=flat-square
-
 Utilities used in the build system for projects that are used with ASP.NET Core and Entity Framework Core.
 
-This project is part of ASP.NET Core. You can find samples, documentation and getting started instructions for ASP.NET Core at the [Home](https://github.com/aspnet/home) repo.
+This project is part of ASP.NET Core. You can find samples, documentation and getting started instructions for ASP.NET Core at the [AspNetCore](https://github.com/aspnet/AspNetCore) repo.
 
 ## Docs
 

--- a/src/ApiCheck.Console/Program.cs
+++ b/src/ApiCheck.Console/Program.cs
@@ -323,7 +323,7 @@ namespace ApiCheck
             if (newBreakingChanges.Count > 0 || incorrectBreakingChanges.Count > 0)
             {
                 Console.WriteLine(
-                    "The process for breaking changes is described in: https://github.com/aspnet/Home/wiki/Engineering-guidelines#breaking-changes");
+                    "The process for breaking changes is described in: https://github.com/aspnet/AspNetCore/wiki/Engineering-guidelines#breaking-changes");
                 Console.WriteLine(
                     "The process to add an exclusion to this tool is described in: https://github.com/aspnet/BuildTools/wiki/Api-Check#apicheck-exceptions");
                 Console.WriteLine();

--- a/src/Internal.AspNetCore.Sdk/build/Common.props
+++ b/src/Internal.AspNetCore.Sdk/build/Common.props
@@ -15,7 +15,7 @@ Usage: this should be imported once via NuGet at the top of the file.
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <IncludeSymbols>true</IncludeSymbols>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <PackageLicenseUrl>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</PackageLicenseUrl>
+    <PackageLicenseUrl>https://raw.githubusercontent.com/aspnet/AspNetCore/2.0.0/LICENSE.txt</PackageLicenseUrl>
     <PackageIconUrl>https://go.microsoft.com/fwlink/?LinkID=288859</PackageIconUrl>
     <PackageProjectUrl>https://asp.net</PackageProjectUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>


### PR DESCRIPTION
@Eilon this includes updating the license link in packages to https://raw.githubusercontent.com/aspnet/AspNetCore/2.0.0/LICENSE.txt. This has the same content as https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt