### PR TITLE
 Merge branch 'release/2.1' into release/2.2

### DIFF
--- a/.vsts-pipelines/templates/phases/default-build.yml
+++ b/.vsts-pipelines/templates/phases/default-build.yml
@@ -75,7 +75,7 @@ phases:
     demands: ${{ parameters.demands }}
   variables:
     AgentOsName: ${{ parameters.agentOs }}
-    ASPNETCORE_TEST_LOG_DIR: ${{ format('{0}/logs/testlogs', parameters.artifacts.path) }}
+    ASPNETCORE_TEST_LOG_DIR: $(Build.SourcesDirectory)/artifacts/logs/testlogs
     DOTNET_HOME: $(Agent.WorkFolder)/.dotnet
     BuildScriptArgs: ${{ parameters.buildArgs }}
     BuildConfiguration: ${{ parameters.configuration }}


### PR DESCRIPTION
I can't seem to push to release/2.2 directly because of 
```
remote: error: GH006: Protected branch update failed for refs/heads/release/2.2.
remote: error: 2 of 2 required status checks are expected.
To github.com:aspnet/BuildTools
 ! [remote rejected] release/2.2 -> release/2.2 (protected branch hook declined)
error: failed to push some refs to 'git@github.com:aspnet/BuildTools'
```

I assume I'll need to open a PR so tests will run?