### PR TITLE
Update YAML templates to use new DevOps features

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -2,7 +2,7 @@ trigger:
 - master
 - release/*
 
-phases:
+jobs:
 - template: ../templates/project-ci.yml
   parameters:
     # Ensures the alignment of branch name and deployment params

--- a/.azure/templates/jobs/default-build.yml
+++ b/.azure/templates/jobs/default-build.yml
@@ -96,10 +96,6 @@ jobs:
   steps:
   - checkout: self
     clean: true
-  - ${{ if eq(parameters.artifacts.publish, 'true') }}:
-    # Workaround for PublishBuildArtifacts failing when this folder does not exist
-    - script: mkdir $(ASPNETCORE_TEST_LOG_DIR)
-      displayName: Make test log directory
   - ${{ if and(eq(parameters.agentOs, 'Windows'), eq(parameters.codeSign, 'true')) }}:
     - task: MicroBuildSigningPlugin@1
       displayName: Install MicroBuild Signing plugin
@@ -109,9 +105,17 @@ jobs:
         zipSources: false
   - ${{ parameters.beforeBuild }}
   - ${{ if eq(parameters.agentOs, 'Windows') }}:
+    - ${{ if eq(parameters.artifacts.publish, 'true') }}:
+      # Workaround for PublishBuildArtifacts failing when this folder does not exist
+      - powershell: mkdir $(ASPNETCORE_TEST_LOG_DIR)
+        displayName: Make test log directory
     - script: .\build.cmd -ci /p:Configuration=$(BuildConfiguration) $(BuildScriptArgs)
       displayName: Run build.cmd
   - ${{ if ne(parameters.agentOs, 'Windows') }}:
+    - ${{ if eq(parameters.artifacts.publish, 'true') }}:
+      # Workaround for PublishBuildArtifacts failing when this folder does not exist
+      - bash: mkdir $(ASPNETCORE_TEST_LOG_DIR)
+        displayName: Make test log directory
     - script: ./build.sh -ci -p:Configuration=$(BuildConfiguration) $(BuildScriptArgs)
       displayName: Run build.sh
   - task: PublishTestResults@2

--- a/.azure/templates/jobs/default-build.yml
+++ b/.azure/templates/jobs/default-build.yml
@@ -1,9 +1,11 @@
 # default-build.yml
 # Description: Defines a build phase for invoking build.sh/cmd
 # Parameters:
-#   phaseName: string
-#       The name of the phase. Defaults to the name of the OS.
-#   queueName: string
+#   jobName: string
+#       The name of the job. Defaults to the name of the OS. No spaces allowed
+#   jobDisplayName: string
+#       The friendly job name to display in the UI. Defaults to the name of the OS.
+#   poolName: string
 #       The name of the VSTS agent queue to use.
 #   agentOs: string
 #       Used in templates to define variables which are OS specific. Typically from the set { Windows, Linux, macOS }
@@ -29,6 +31,8 @@
 #     A list of agent demands. https://docs.microsoft.com/en-us/vsts/pipelines/yaml-schema?view=vsts#demands
 #   dependsOn: string | [ string ]
 #     For fan-out/fan-in. https://docs.microsoft.com/en-us/vsts/pipelines/yaml-schema?view=vsts#phase
+#   codeSign: boolean
+#       This build definition is enabled for code signing. (Only applies to Windows)
 
 #
 # See https://docs.microsoft.com/en-us/vsts/pipelines/yaml-schema for details
@@ -36,48 +40,73 @@
 
 parameters:
   agentOs: 'Windows'
-  # phaseName: ''
-  queueName: ''
+  poolName: ''
   buildArgs: ''
   configuration: 'Release'
   demands: []
   beforeBuild: []
   afterBuild: []
+  codeSign: false
   variables: {}
   dependsOn: ''
+  # jobName: '' - use agentOs by default.
+  # jobDisplayName: '' - use agentOs by default.
   # matrix: {} - don't define an empty object default because there is no way in template expression yet to check "if isEmpty(parameters.matrix)"
   artifacts:
     publish: true
-    path: 'artifacts/'  # TODO: this is going to change when we converge with dotnet/arcade tooling
+    path: 'artifacts/'
 
-phases:
-- phase: ${{ coalesce(parameters.phaseName, parameters.agentOs) }}
+jobs:
+- job: ${{ coalesce(parameters.jobName, parameters.agentOs) }}
+  displayName: ${{ coalesce(parameters.jobDisplayName, parameters.agentOs) }}
   dependsOn: ${{ parameters.dependsOn }}
-  queue:
-    # If a matrix of builds has been configured, run the matrix in parallel
+  workspace:
+    clean: all
+  strategy:
     ${{ if ne(parameters.matrix, '') }}:
-      parallel: 4 # Pick 4 as the default because we usually don't have a matrix of more than 4 configs, and there is no way to say parallel: all
+      maxParallel: 8
       matrix: ${{ parameters.matrix }}
-    # Map friendly OS names to the right queue
-    ${{ if ne(parameters.queueName, '') }}:
-      name: ${{ parameters.queueName }}
-    ${{ if and(eq(parameters.queueName, ''), eq(parameters.agentOs, 'macOS')) }}:
-      name: Hosted macOS Preview
-    ${{ if and(eq(parameters.queueName, ''), eq(parameters.agentOs, 'Linux')) }}:
-      name: Hosted Linux Preview
-    ${{ if and(eq(parameters.queueName, ''), eq(parameters.agentOs, 'Windows')) }}:
-      name: Hosted VS2017
-    demands: ${{ parameters.demands }}
+  # Map friendly OS names to the right queue
+  pool:
+    ${{ if ne(parameters.poolName, '') }}:
+      name: ${{ parameters.poolName }}
+    ${{ if and(eq(parameters.poolName, ''), eq(parameters.agentOs, 'macOS')) }}:
+      name: Hosted macOS
+      vmImage: macOS-10.13
+    ${{ if and(eq(parameters.poolName, ''), eq(parameters.agentOs, 'Linux')) }}:
+      name: Hosted Ubuntu 1604
+      vmImage: ubuntu-16.04
+    ${{ if and(eq(parameters.poolName, ''), eq(parameters.agentOs, 'Windows')) }}:
+      ${{ if ne(parameters.codeSign, 'true') }}:
+        name: Hosted VS2017
+        vmImage: vs2017-win2016
+      ${{ if eq(parameters.codeSign, 'true') }}:
+        name: DotNetCore-Windows
   variables:
     AgentOsName: ${{ parameters.agentOs }}
-    ASPNETCORE_TEST_LOG_DIR: ${{ format('{0}/logs/testlogs', parameters.artifacts.path) }}
+    ASPNETCORE_TEST_LOG_DIR: $(Build.ArtifactStagingDirectory)/testlogs
     DOTNET_HOME: $(Agent.WorkFolder)/.dotnet
     BuildScriptArgs: ${{ parameters.buildArgs }}
     BuildConfiguration: ${{ parameters.configuration }}
+    VSTS_OVERWRITE_TEMP: false # Workaround for https://github.com/dotnet/core-eng/issues/2812
+    ${{ if eq(parameters.codeSign, 'true') }}:
+      TeamName: AspNetCore
+      _SignType: real
     ${{ insert }}: ${{ parameters.variables }}
   steps:
   - checkout: self
     clean: true
+  - ${{ if eq(parameters.artifacts.publish, 'true') }}:
+    # Workaround for PublishBuildArtifacts failing when this folder does not exist
+    - script: mkdir $(ASPNETCORE_TEST_LOG_DIR)
+      displayName: Make test log directory
+  - ${{ if and(eq(parameters.agentOs, 'Windows'), eq(parameters.codeSign, 'true')) }}:
+    - task: MicroBuildSigningPlugin@1
+      displayName: Install MicroBuild Signing plugin
+      condition: and(succeeded(), in(variables['_SignType'], 'test', 'real'))
+      inputs:
+        signType: $(_SignType)
+        zipSources: false
   - ${{ parameters.beforeBuild }}
   - ${{ if eq(parameters.agentOs, 'Windows') }}:
     - script: .\build.cmd -ci /p:Configuration=$(BuildConfiguration) $(BuildScriptArgs)
@@ -89,8 +118,10 @@ phases:
     displayName: Publish test results
     condition: always()
     inputs:
+      testRunTitle: $(AgentOsName)-$(BuildConfiguration)
       testRunner: vstest
       testResultsFiles: 'artifacts/logs/**/*.trx'
+      mergeTestResults: true
   - ${{ if eq(parameters.artifacts.publish, 'true') }}:
     - task: PublishBuildArtifacts@1
       displayName: Upload artifacts
@@ -102,5 +133,17 @@ phases:
         ${{ if ne(parameters.artifacts.name, '') }}:
           artifactName: ${{ parameters.artifacts.name }}
         artifactType: Container
+        parallel: true
+    - task: PublishBuildArtifacts@1
+      displayName: Upload test logs
+      condition: succeededOrFailed()
+      inputs:
+        pathtoPublish: $(ASPNETCORE_TEST_LOG_DIR)
+        artifactName: testlogs-$(AgentOsName)-$(BuildConfiguration)
+        parallel: true
   - ${{ parameters.afterBuild }}
+  - ${{ if and(eq(parameters.agentOs, 'Windows'), eq(parameters.codeSign, 'true')) }}:
+    - task: MicroBuildCleanup@1
+      displayName: Cleanup MicroBuild tasks
+      condition: always()
 

--- a/.azure/templates/jobs/default-build.yml
+++ b/.azure/templates/jobs/default-build.yml
@@ -84,7 +84,6 @@ jobs:
         name: DotNetCore-Windows
   variables:
     AgentOsName: ${{ parameters.agentOs }}
-    ASPNETCORE_TEST_LOG_DIR: $(Build.ArtifactStagingDirectory)/testlogs
     DOTNET_HOME: $(Agent.WorkFolder)/.dotnet
     BuildScriptArgs: ${{ parameters.buildArgs }}
     BuildConfiguration: ${{ parameters.configuration }}
@@ -105,17 +104,9 @@ jobs:
         zipSources: false
   - ${{ parameters.beforeBuild }}
   - ${{ if eq(parameters.agentOs, 'Windows') }}:
-    - ${{ if eq(parameters.artifacts.publish, 'true') }}:
-      # Workaround for PublishBuildArtifacts failing when this folder does not exist
-      - powershell: mkdir $(ASPNETCORE_TEST_LOG_DIR)
-        displayName: Make test log directory
     - script: .\build.cmd -ci /p:Configuration=$(BuildConfiguration) $(BuildScriptArgs)
       displayName: Run build.cmd
   - ${{ if ne(parameters.agentOs, 'Windows') }}:
-    - ${{ if eq(parameters.artifacts.publish, 'true') }}:
-      # Workaround for PublishBuildArtifacts failing when this folder does not exist
-      - bash: mkdir $(ASPNETCORE_TEST_LOG_DIR)
-        displayName: Make test log directory
     - script: ./build.sh -ci -p:Configuration=$(BuildConfiguration) $(BuildScriptArgs)
       displayName: Run build.sh
   - task: PublishTestResults@2
@@ -137,13 +128,6 @@ jobs:
         ${{ if ne(parameters.artifacts.name, '') }}:
           artifactName: ${{ parameters.artifacts.name }}
         artifactType: Container
-        parallel: true
-    - task: PublishBuildArtifacts@1
-      displayName: Upload test logs
-      condition: succeededOrFailed()
-      inputs:
-        pathtoPublish: $(ASPNETCORE_TEST_LOG_DIR)
-        artifactName: testlogs-$(AgentOsName)-$(BuildConfiguration)
         parallel: true
   - ${{ parameters.afterBuild }}
   - ${{ if and(eq(parameters.agentOs, 'Windows'), eq(parameters.codeSign, 'true')) }}:

--- a/.azure/templates/project-ci.yml
+++ b/.azure/templates/project-ci.yml
@@ -11,11 +11,14 @@
 #       VSTS build and environment variables
 #   matrix: {}
 #       The matrix of configurations to run. By default, it runs a Debug and Release build on all platforms
+#   codeSign: boolean
+#       This build definition is enabled for code signing. (Only applies to Windows)
 
 parameters:
   buildArgs: ''
   beforeBuild: []
   afterBuild: []
+  codeSign: false
   variables: {}
   matrix:
     Release:
@@ -23,16 +26,17 @@ parameters:
     Debug:
       BuildConfiguration: Debug
 
-phases:
-- template: phases/default-build.yml
+jobs:
+- template: jobs/default-build.yml
   parameters:
     agentOs: Windows
     matrix: ${{ parameters.matrix }}
     buildArgs: ${{ parameters.buildArgs }}
     beforeBuild: ${{ parameters.beforeBuild }}
     afterBuild: ${{ parameters.afterBuild }}
+    codeSign: ${{ parameters.codeSign }}
     variables: ${{ parameters.variables }}
-- template: phases/default-build.yml
+- template: jobs/default-build.yml
   parameters:
     agentOs: macOS
     matrix: ${{ parameters.matrix }}
@@ -40,7 +44,7 @@ phases:
     beforeBuild: ${{ parameters.beforeBuild }}
     afterBuild: ${{ parameters.afterBuild }}
     variables: ${{ parameters.variables }}
-- template: phases/default-build.yml
+- template: jobs/default-build.yml
   parameters:
     agentOs: Linux
     matrix: ${{ parameters.matrix }}

--- a/.vsts-pipelines/templates/phases/default-build.yml
+++ b/.vsts-pipelines/templates/phases/default-build.yml
@@ -1,5 +1,5 @@
 #
-# Obsolete! New projects should use .azure/templates/phases/default-build.yml instead
+# Obsolete! New projects should use .azure/templates/jobs/default-build.yml instead
 #
 # TODO: remove this once templated projects have referenced the new location.
 #
@@ -81,6 +81,8 @@ phases:
     BuildConfiguration: ${{ parameters.configuration }}
     ${{ insert }}: ${{ parameters.variables }}
   steps:
+  - script: echo "This build template is obsolete and will be removed in the future. Please update your schema to use the  .azure/templates/jobs/default-build.yml template"
+    displayName: THIS TEMPLATE IS OBSOLETE
   - checkout: self
     clean: true
   - ${{ parameters.beforeBuild }}


### PR DESCRIPTION
Azure DevOps has made some syntax changes to YAML. This updates .azure/templates/project-ci.yml to the latest syntax and adds some features.

For compatibility, the old templates in .vsts-pipelines/templates/project-ci.yml remain untouched. Those will eventually be removed.

Changes:
* Add support for code signing tasks
* Update YAML syntax to 'jobs' instead of phases
* Update pool specification
* Add obsolete warning to old templates