### PR TITLE
Fix max path issue with testlog artifacts

### DIFF
--- a/.azure/templates/jobs/default-build.yml
+++ b/.azure/templates/jobs/default-build.yml
@@ -84,6 +84,7 @@ jobs:
         name: DotNetCore-Windows
   variables:
     AgentOsName: ${{ parameters.agentOs }}
+    ASPNETCORE_TEST_LOG_MAXPATH: "200" # Keep test log file name length low enough for artifact zipping
     DOTNET_HOME: $(Agent.WorkFolder)/.dotnet
     BuildScriptArgs: ${{ parameters.buildArgs }}
     BuildConfiguration: ${{ parameters.configuration }}

--- a/.vsts-pipelines/templates/phases/default-build.yml
+++ b/.vsts-pipelines/templates/phases/default-build.yml
@@ -76,6 +76,7 @@ phases:
   variables:
     AgentOsName: ${{ parameters.agentOs }}
     ASPNETCORE_TEST_LOG_DIR: ${{ format('{0}/logs/testlogs', parameters.artifacts.path) }}
+    ASPNETCORE_TEST_LOG_MAXPATH: "200" # Keep test log file name length low enough for artifact zipping
     DOTNET_HOME: $(Agent.WorkFolder)/.dotnet
     BuildScriptArgs: ${{ parameters.buildArgs }}
     BuildConfiguration: ${{ parameters.configuration }}


### PR DESCRIPTION
Should I update the deprecated template too?

This can go in before https://github.com/aspnet/Logging/pull/904 assuming we're happy with the variable