### PR TITLE
Allow yml files to specify build directory

### DIFF
--- a/.azure/templates/jobs/default-build.yml
+++ b/.azure/templates/jobs/default-build.yml
@@ -129,7 +129,10 @@ jobs:
       displayName: Upload artifacts
       condition: eq(variables['system.pullrequest.isfork'], false)
       inputs:
-        pathtoPublish: ${{ parameters.buildDirectory }}\${{ parameters.artifacts.path }}
+        ${{ if eq(parameters.buildDirectory, '') }}:
+          pathtoPublish: ${{ parameters.artifacts.path }}
+        ${{ if ne(parameters.artifacts.name, '') }}:
+          pathtoPublish: ${{ parameters.buildDirectory }}\${{ parameters.artifacts.path }}
         ${{ if eq(parameters.artifacts.name, '') }}:
           artifactName: artifacts-$(AgentOsName)-$(BuildConfiguration)
         ${{ if ne(parameters.artifacts.name, '') }}:

--- a/.azure/templates/jobs/default-build.yml
+++ b/.azure/templates/jobs/default-build.yml
@@ -55,6 +55,7 @@ parameters:
   artifacts:
     publish: true
     path: 'artifacts/'
+  buildDirectory: ''
 
 jobs:
 - job: ${{ coalesce(parameters.jobName, parameters.agentOs) }}
@@ -88,6 +89,7 @@ jobs:
     DOTNET_HOME: $(Agent.WorkFolder)/.dotnet
     BuildScriptArgs: ${{ parameters.buildArgs }}
     BuildConfiguration: ${{ parameters.configuration }}
+    BuildDirectory: ${{ parameters.buildDirectory }}
     VSTS_OVERWRITE_TEMP: false # Workaround for https://github.com/dotnet/core-eng/issues/2812
     ${{ if eq(parameters.codeSign, 'true') }}:
       TeamName: AspNetCore
@@ -107,10 +109,10 @@ jobs:
         zipSources: false
   - ${{ parameters.beforeBuild }}
   - ${{ if eq(parameters.agentOs, 'Windows') }}:
-    - script: .\build.cmd -ci /p:SignType=$(_SignType) /p:Configuration=$(BuildConfiguration) $(BuildScriptArgs)
+    - script: .\$(BuildDirectory)\build.cmd -ci /p:SignType=$(_SignType) /p:Configuration=$(BuildConfiguration) $(BuildScriptArgs)
       displayName: Run build.cmd
   - ${{ if ne(parameters.agentOs, 'Windows') }}:
-    - script: ./build.sh -ci -p:Configuration=$(BuildConfiguration) $(BuildScriptArgs)
+    - script: ./$(BuildDirectory)/build.sh -ci -p:Configuration=$(BuildConfiguration) $(BuildScriptArgs)
       displayName: Run build.sh
   - task: PublishTestResults@2
     displayName: Publish test results

--- a/.azure/templates/jobs/default-build.yml
+++ b/.azure/templates/jobs/default-build.yml
@@ -33,6 +33,8 @@
 #     For fan-out/fan-in. https://docs.microsoft.com/en-us/vsts/pipelines/yaml-schema?view=vsts#phase
 #   codeSign: boolean
 #       This build definition is enabled for code signing. (Only applies to Windows)
+#   buildDirectory: string
+#       Specifies what directory to run build.sh/cmd
 
 #
 # See https://docs.microsoft.com/en-us/vsts/pipelines/yaml-schema for details

--- a/.azure/templates/jobs/default-build.yml
+++ b/.azure/templates/jobs/default-build.yml
@@ -97,7 +97,7 @@ jobs:
       TeamName: AspNetCore
       _SignType: real
     ${{ if ne(parameters.codeSign, 'true') }}:
-      _SignType: 
+      _SignType:
     ${{ insert }}: ${{ parameters.variables }}
   steps:
   - checkout: self
@@ -129,7 +129,7 @@ jobs:
       displayName: Upload artifacts
       condition: eq(variables['system.pullrequest.isfork'], false)
       inputs:
-        pathtoPublish: ${{ parameters.artifacts.path }}
+        pathtoPublish: ${{ parameters.buildDirectory }}\${{ parameters.artifacts.path }}
         ${{ if eq(parameters.artifacts.name, '') }}:
           artifactName: artifacts-$(AgentOsName)-$(BuildConfiguration)
         ${{ if ne(parameters.artifacts.name, '') }}:

--- a/.azure/templates/project-ci.yml
+++ b/.azure/templates/project-ci.yml
@@ -25,6 +25,7 @@ parameters:
       BuildConfiguration: Release
     Debug:
       BuildConfiguration: Debug
+  buildDirectory: ''
 
 jobs:
 - template: jobs/default-build.yml
@@ -36,6 +37,7 @@ jobs:
     afterBuild: ${{ parameters.afterBuild }}
     codeSign: ${{ parameters.codeSign }}
     variables: ${{ parameters.variables }}
+    buildDirectory: ${{ parameters.buildDirectory }}
 - template: jobs/default-build.yml
   parameters:
     agentOs: macOS
@@ -44,6 +46,7 @@ jobs:
     beforeBuild: ${{ parameters.beforeBuild }}
     afterBuild: ${{ parameters.afterBuild }}
     variables: ${{ parameters.variables }}
+    buildDirectory: ${{ parameters.buildDirectory }}
 - template: jobs/default-build.yml
   parameters:
     agentOs: Linux
@@ -52,4 +55,4 @@ jobs:
     beforeBuild: ${{ parameters.beforeBuild }}
     afterBuild: ${{ parameters.afterBuild }}
     variables: ${{ parameters.variables }}
-
+    buildDirectory: ${{ parameters.buildDirectory }}

--- a/.azure/templates/project-ci.yml
+++ b/.azure/templates/project-ci.yml
@@ -13,6 +13,8 @@
 #       The matrix of configurations to run. By default, it runs a Debug and Release build on all platforms
 #   codeSign: boolean
 #       This build definition is enabled for code signing. (Only applies to Windows)
+#   buildDirectory: string
+#       Specifies what directory to run build.sh/cmd
 
 parameters:
   buildArgs: ''


### PR DESCRIPTION
When running CI builds in aspnetcore, we need a way to run build.cmd inside of a subfolder.

I am open for suggestions to make this more robust.