### PR TITLE
Add property to allow repos to control the NuGet package output path

### DIFF
--- a/.azure/templates/jobs/default-build.yml
+++ b/.azure/templates/jobs/default-build.yml
@@ -49,6 +49,7 @@ parameters:
   codeSign: false
   variables: {}
   dependsOn: ''
+  # buildSteps: [] - don't define an empty object default because there is no way in template expression yet to check "if isEmpty(parameters.buildSteps)"
   # jobName: '' - use agentOs by default.
   # jobDisplayName: '' - use agentOs by default.
   # matrix: {} - don't define an empty object default because there is no way in template expression yet to check "if isEmpty(parameters.matrix)"
@@ -93,7 +94,7 @@ jobs:
       TeamName: AspNetCore
       _SignType: real
     ${{ if ne(parameters.codeSign, 'true') }}:
-      _SignType: 
+      _SignType:
     ${{ insert }}: ${{ parameters.variables }}
   steps:
   - checkout: self
@@ -106,12 +107,15 @@ jobs:
         signType: $(_SignType)
         zipSources: false
   - ${{ parameters.beforeBuild }}
-  - ${{ if eq(parameters.agentOs, 'Windows') }}:
-    - script: .\build.cmd -ci /p:SignType=$(_SignType) /p:Configuration=$(BuildConfiguration) $(BuildScriptArgs)
-      displayName: Run build.cmd
-  - ${{ if ne(parameters.agentOs, 'Windows') }}:
-    - script: ./build.sh -ci -p:Configuration=$(BuildConfiguration) $(BuildScriptArgs)
-      displayName: Run build.sh
+  - ${{ if eq(parameters.buildSteps, '') }}:
+    - ${{ if eq(parameters.agentOs, 'Windows') }}:
+      - script: .\build.cmd -ci /p:SignType=$(_SignType) /p:Configuration=$(BuildConfiguration) $(BuildScriptArgs)
+        displayName: Run build.cmd
+    - ${{ if ne(parameters.agentOs, 'Windows') }}:
+      - script: ./build.sh -ci -p:Configuration=$(BuildConfiguration) $(BuildScriptArgs)
+        displayName: Run build.sh
+  - ${{ if ne(parameters.buildSteps, '') }}:
+    - ${{ parameters.buildSteps }}
   - task: PublishTestResults@2
     displayName: Publish test results
     condition: always()

--- a/files/KoreBuild/KoreBuild.Common.targets
+++ b/files/KoreBuild/KoreBuild.Common.targets
@@ -15,6 +15,8 @@ after all other property imports.
   </PropertyGroup>
 
   <PropertyGroup>
+    <BuildProperties Condition=" '$(OverridePackageOutputPath)' != 'false' ">$(BuildProperties);PackageOutputPath=$(BuildDir)</BuildProperties>
+
     <PackageVersion Condition="'$(PackageVersion)' == '' AND '$(Version)' != '' ">$(Version)</PackageVersion>
     <BuildProperties>$(BuildProperties);RepoVersion=$(Version);RepoPackageVersion=$(PackageVersion)</BuildProperties>
     <BuildProperties Condition=" ! Exists('$(RepositoryRoot)version.props') ">$(BuildProperties);VerifyVersion=false</BuildProperties>
@@ -91,7 +93,7 @@ extending the *DependsOn property
     <MSBuild Targets="GetArtifactInfo"
              Projects="@(ProjectToBuild)"
              Condition="@(ProjectToBuild->Count()) != 0"
-             Properties="$(BuildProperties);EnableApiCheck=false;NoBuild=true;RepositoryRoot=$(RepositoryRoot);PackageOutputPath=$(BuildDir);CustomAfterMicrosoftCommonTargets=$(_InspectionTargetsFile);CustomAfterMicrosoftCommonCrossTargetingTargets=$(_InspectionTargetsFile)"
+             Properties="$(BuildProperties);EnableApiCheck=false;NoBuild=true;RepositoryRoot=$(RepositoryRoot);CustomAfterMicrosoftCommonTargets=$(_InspectionTargetsFile);CustomAfterMicrosoftCommonCrossTargetingTargets=$(_InspectionTargetsFile)"
              BuildInParallel="$(BuildInParallel)"
              RemoveProperties="$(_BuildPropertiesToRemove)">
 

--- a/files/KoreBuild/modules/projectbuild/module.targets
+++ b/files/KoreBuild/modules/projectbuild/module.targets
@@ -107,14 +107,13 @@ Executes /t:Pack on all projects matching src/*/*.csproj.
 -->
   <Target Name="PackProjects" DependsOnTargets="ResolveProjects">
     <PropertyGroup>
-      <PackProperties>$(BuildProperties);PackageOutputPath=$(BuildDir);</PackProperties>
       <PackProperties Condition="'$(_ProjectsWereBuilt)' == 'true'">$(PackProperties);NoBuild=true;BuildProjectReferences=false</PackProperties>
     </PropertyGroup>
 
     <MSBuild Condition="@(ProjectToBuild->Count()) != 0"
              Projects="@(ProjectToBuild)"
              Targets="Pack"
-             Properties="$(PackProperties)"
+             Properties="$(BuildProperties);$(PackProperties)"
              BuildInParallel="$(BuildInParallel)"
              RemoveProperties="$(_BuildPropertiesToRemove)" />
   </Target>

--- a/files/KoreBuild/modules/sharedsources/module.targets
+++ b/files/KoreBuild/modules/sharedsources/module.targets
@@ -36,8 +36,11 @@ that matches "$(RepositoryRoot)/shared/*.Sources".
 
   <Target Name="_GetSharedSourcesProjects">
     <PropertyGroup>
-      <_SharedSourcesPackageProperties>
+      <_SharedSourcesPackageProperties Condition=" '$(OverridePackageOutputPath)' != 'false' ">
         PackageOutputPath=$(BuildDir);
+      </_SharedSourcesPackageProperties>
+      <_SharedSourcesPackageProperties>
+        $(_SharedSourcesPackageProperties);
         RepositoryRoot=$(RepositoryRoot);
         ImportDirectoryBuildProps=false;
         BuildNumber=$(BuildNumber);

--- a/files/KoreBuild/modules/sharedsources/module.targets
+++ b/files/KoreBuild/modules/sharedsources/module.targets
@@ -36,15 +36,15 @@ that matches "$(RepositoryRoot)/shared/*.Sources".
 
   <Target Name="_GetSharedSourcesProjects">
     <PropertyGroup>
-      <_SharedSourcesPackageProperties Condition=" '$(OverridePackageOutputPath)' != 'false' ">
-        PackageOutputPath=$(BuildDir);
-      </_SharedSourcesPackageProperties>
       <_SharedSourcesPackageProperties>
-        $(_SharedSourcesPackageProperties);
         RepositoryRoot=$(RepositoryRoot);
         ImportDirectoryBuildProps=false;
         BuildNumber=$(BuildNumber);
         RepositoryCommit=$(RepositoryCommit)
+      </_SharedSourcesPackageProperties>
+      <_SharedSourcesPackageProperties Condition=" '$(OverridePackageOutputPath)' != 'false' ">
+        $(_SharedSourcesPackageProperties);
+        PackageOutputPath=$(BuildDir)
       </_SharedSourcesPackageProperties>
     </PropertyGroup>
 

--- a/files/KoreBuild/modules/solutionbuild/module.targets
+++ b/files/KoreBuild/modules/solutionbuild/module.targets
@@ -118,7 +118,7 @@ Executes /t:Pack on all projects matching src/*/*.csproj.
 -->
   <Target Name="PackageProjectsToPack" DependsOnTargets="ResolveSolutions">
     <PropertyGroup>
-      <PackProperties>$(BuildProperties);$(SolutionProperties);PackageOutputPath=$(BuildDir);</PackProperties>
+      <PackProperties>$(BuildProperties);$(SolutionProperties)</PackProperties>
       <PackProperties Condition="'$(_SolutionWasBuilt)' == 'true'">$(PackProperties);NoBuild=true;BuildProjectReferences=false</PackProperties>
     </PropertyGroup>
 

--- a/modules/NuGetPackageVerifier/module.targets
+++ b/modules/NuGetPackageVerifier/module.targets
@@ -17,21 +17,24 @@ repository root.
 ###################################################################
 -->
   <PropertyGroup>
-    <NuGetVerifierRuleFile>$(RepositoryRoot)NuGetPackageVerifier.json</NuGetVerifierRuleFile>
+    <NuGetVerifierRuleFile Condition=" '$(NuGetVerifierRuleFile)' == '' ">$(RepositoryRoot)NuGetPackageVerifier.json</NuGetVerifierRuleFile>
   </PropertyGroup>
 
-  <Target Name="VerifyPackages" Condition="Exists('$(NuGetVerifierRuleFile)')">
+  <ItemGroup>
+    <PackageVerifierDirectory Include="$(BuildDir)" Condition=" '$(OverridePackageOutputPath)' != 'false' " />
+  </ItemGroup>
+
+  <Target Name="VerifyPackages" Condition="Exists('$(NuGetVerifierRuleFile)') AND @(PackageVerifierDirectory->Count()) != 0">
+
     <ItemGroup>
-      <Packages Include="$(BuildDir)*.nupkg" />
+      <_ExistentPackageVerifierDirectory Include="@(PackageVerifierDirectory)"  Condition=" Exists('%(Identity)') " />
     </ItemGroup>
 
-    <Warning Text="No nupkg found in '$(BuildDir)'." Condition="$(Packages -> Count()) == 0" />
-    <Warning Text="Skipping nuget package verification because artifacts directory could not be found"
-      Condition="!Exists('$(BuildDir)')" />
+    <Warning Text="Skipping nuget package verification because no package output directories were found: @(PackageVerifierDirectory, ', ')." Condition="@(_ExistentPackageVerifierDirectory->Count()) == 0" />
 
-    <VerifyPackages ArtifactDirectory="$(BuildDir)"
+    <VerifyPackages ArtifactDirectory="@(_ExistentPackageVerifierDirectory)"
       RuleFile="$(NuGetVerifierRuleFile)"
-      Condition="Exists('$(BuildDir)')" />
+      Condition="@(_ExistentPackageVerifierDirectory->Count()) != 0" />
   </Target>
 
 </Project>

--- a/modules/NuGetPackageVerifier/msbuild/VerifyPackages.cs
+++ b/modules/NuGetPackageVerifier/msbuild/VerifyPackages.cs
@@ -23,7 +23,7 @@ namespace NuGetPackagerVerifier
         public string RuleFile { get; set; }
 
         [Required]
-        public string ArtifactDirectory { get; set; }
+        public string[] ArtifactDirectory { get; set; }
 
         public string[] ExcludedRules { get; set; }
 
@@ -35,9 +35,9 @@ namespace NuGetPackagerVerifier
                 return false;
             }
 
-            if (string.IsNullOrEmpty(ArtifactDirectory) || !Directory.Exists(ArtifactDirectory))
+            if (ArtifactDirectory == null || ArtifactDirectory.Length == 0)
             {
-                Log.LogError($"ArtifactDirectory '{ArtifactDirectory}' does not exist");
+                Log.LogError($"At least one ArtifactDirectory must exist.");
                 return false;
             }
 
@@ -54,7 +54,6 @@ namespace NuGetPackagerVerifier
                 toolPath,
                 "--rule-file",
                 RuleFile,
-                ArtifactDirectory,
             };
 
             foreach (var rule in ExcludedRules ?? Enumerable.Empty<string>())
@@ -62,6 +61,8 @@ namespace NuGetPackagerVerifier
                 arguments.Add("--excluded-rule");
                 arguments.Add(rule);
             }
+
+            arguments.AddRange(ArtifactDirectory);
 
             var psi = new ProcessStartInfo
             {


### PR DESCRIPTION
KoreBuild currently enforces PackageOutputPath on all repos it packs. This allows repos to control the location of NuGet package output.

For example, this will be useful in 2.2 to allow us to organize packages into different folders based on package category.