### PR TITLE
Run signcheck on all artifacts after code signing

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -3,7 +3,8 @@
     <HtmlAgilityPackPackageVersion>1.5.1</HtmlAgilityPackPackageVersion>
     <MicroBuildCorePackageVersion>0.3.0</MicroBuildCorePackageVersion>
     <MicrosoftDotNetPlatformAbstractionsVersion>2.0.0</MicrosoftDotNetPlatformAbstractionsVersion>
-    <MicrosoftDotNetSignToolPackageVersion>1.0.0-beta.18557.3</MicrosoftDotNetSignToolPackageVersion>
+    <MicrosoftDotNetSignToolPackageVersion>1.0.0-beta.18558.2</MicrosoftDotNetSignToolPackageVersion>
+    <MicrosoftDotNetSignCheckPackageVersion>1.0.0-beta.18558.2</MicrosoftDotNetSignCheckPackageVersion>
     <MicrosoftNETTestSdkPackageVersion>15.9.0</MicrosoftNETTestSdkPackageVersion>
     <MonoCecilPackageVersion>0.10.0-beta6</MonoCecilPackageVersion>
     <MoqPackageVersion>4.7.99</MoqPackageVersion>

--- a/docs/Signing.md
+++ b/docs/Signing.md
@@ -114,3 +114,27 @@ these elements to the `build/repo.props` file. (See also [KoreBuild.md](./KoreBu
   <FilesToExcludeFromSigning Include="$(ArtifactsDir)my.test.dll" Certificate="3PartySHA2" />
 </ItemGroup>
 ```
+
+## Sign check
+
+When real-signing is enabled, KoreBuild also runs a check after the build is complete to ensure everything in the `artifacts/` directory
+is code signed.
+
+Exclusions can be added to `build/signcheck.exclusions.txt`. The format of this file is
+
+* One line per exclusion
+
+* Each line in the file takes the format:
+
+  ```
+  <FilePath>;<ContainerPath>;<Optional comment>
+  ```
+
+* Both FilePath and ContainerPath can contain wildcards.
+
+For example,
+```
+content/*.js;Microsoft.DotNet.Web.Spa.ProjectTemplates.*.nupkg; Exclude JavaScript files from codesigning in project templates
+```
+
+See https://github.com/dotnet/arcade/tree/master/src/SignCheck for more details on SignCheck.

--- a/modules/KoreBuild.Tasks/CodeSign.targets
+++ b/modules/KoreBuild.Tasks/CodeSign.targets
@@ -4,6 +4,11 @@
   <PropertyGroup>
     <DisableCodeSigning Condition=" '$(OS)' != 'Windows_NT' ">true</DisableCodeSigning>
 
+    <!-- This file can be used to exclude something files from signcheck. -->
+    <SignCheckExclusionsFile Condition=" '$(SignCheckExclusionsFile)' == '' ">$(RepositoryRoot)build\signcheck.exclusions.txt</SignCheckExclusionsFile>
+
+    <SignCheckWorkingDir Condition=" '$(SignCheckWorkingDir)' == '' ">$(ArtifactsDir)</SignCheckWorkingDir>
+
     <!-- Relative paths in SignToolData.json are relative to this path -->
     <SignToolDataWorkingDir Condition=" '$(SignToolDataWorkingDir)' == '' ">$(RepositoryRoot)</SignToolDataWorkingDir>
 
@@ -52,6 +57,30 @@
       LogDir="$(LogOutputDir)"
       MSBuildPath="$(MSBuildx86Path)"
       MicroBuildCorePath="$(NuGetPackageRoot)microbuild.core\$(MicroBuildCorePackageVersion)" />
+  </Target>
+
+  <Target Name="SignCheck"
+          Condition=" '$(DisableCodeSigning)' != 'true' AND '$(SignToolDryRun)' != 'true' AND '$(DisableSignCheck)' != 'true' "
+          AfterTargets="CodeSign">
+
+    <PropertyGroup>
+      <SignCheckToolPath>$(MSBuildThisFileDirectory)SignCheck\tools\Microsoft.DotNet.SignCheck.exe</SignCheckToolPath>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <SignCheckArgs Remove="@(SignCheckArgs)" />
+      <SignCheckArgs Include="--verbosity;Detailed" />
+      <SignCheckArgs Include="--generate-exclusions-file;$(LogOutputDir)signcheck.exclusions.g.txt" />
+      <SignCheckArgs Include="--input-files;$(SignCheckWorkingDir)" />
+      <SignCheckArgs Include="--recursive" />
+      <SignCheckArgs Include="--verify-jar" />
+      <SignCheckArgs Include="--verify-strongname" Condition=" '$(DisableSignCheckStrongName)' != 'true' " />
+      <SignCheckArgs Include="--exclusions-file;$(SignCheckExclusionsFile)" Condition="Exists('$(SignCheckExclusionsFile)')" />
+    </ItemGroup>
+
+    <Message Text="Running signcheck on $(SignCheckWorkingDir)" Importance="high" />
+
+    <Run FileName="$(SignCheckToolPath)" Arguments="@(SignCheckArgs)" StandardOutputImportance="Normal" />
   </Target>
 
 </Project>

--- a/modules/KoreBuild.Tasks/KoreBuild.Tasks.csproj
+++ b/modules/KoreBuild.Tasks/KoreBuild.Tasks.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <AssemblyName>Internal.AspNetCore.KoreBuild.Tasks</AssemblyName>
-    <SignToolDir>$(NuGetPackageRoot)/microsoft.dotnet.signtool/$(MicrosoftDotNetSignToolPackageVersion)/</SignToolDir>
  </PropertyGroup>
 
   <ItemGroup>
@@ -13,8 +12,9 @@
     <Compile Include="..\..\shared\Utilities\MSBuildListSplitter.cs" />
     <Compile Include="..\..\tools\KoreBuildSettings.cs" />
     <Content Include="$(VSWhereDir)vswhere.exe" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest" />
-    <Content Include="$(SignToolDir)tools\**\*" Link="SignTool\tools\%(RecursiveDir)%(FileName)%(Extension)" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest" />
-    <Content Include="$(SignToolDir)build\**\*" Link="SignTool\build\%(RecursiveDir)%(FileName)%(Extension)" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest" />
+    <Content Include="$(PkgMicrosoft_DotNet_SignTool)\tools\**\*" Link="SignTool\tools\%(RecursiveDir)%(FileName)%(Extension)" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest" />
+    <Content Include="$(PkgMicrosoft_DotNet_SignCheck)\tools\**\*" Link="SignCheck\tools\%(RecursiveDir)%(FileName)%(Extension)" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest" />
+    <Content Include="$(PkgMicrosoft_DotNet_SignTool)\build\**\*" Link="SignTool\build\%(RecursiveDir)%(FileName)%(Extension)" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest" />
     <Content Include="$(MSBuildThisFileDirectory)SkipStrongNames.xml" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest" />
  </ItemGroup>
 
@@ -28,6 +28,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="$(Tooling_NewtonsoftJsonPackageVersion)" PrivateAssets="All" />
     <PackageReference Include="vswhere" Version="$(VSWherePackageVersion)" PrivateAssets="All" />
     <PackageReference Include="Microsoft.DotNet.SignTool" Version="$(MicrosoftDotNetSignToolPackageVersion)" ExcludeAssets="All" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.DotNet.SignCheck" Version="$(MicrosoftDotNetSignCheckPackageVersion)" ExcludeAssets="All" PrivateAssets="All" />
   </ItemGroup>
 
   <Target Name="PublishGeneratedProps" BeforeTargets="Publish">

--- a/modules/KoreBuild.Tasks/Utilities/VsInstallation.cs
+++ b/modules/KoreBuild.Tasks/Utilities/VsInstallation.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.IO;
+using System.Linq;
 
 namespace KoreBuild.Tasks.Utilities
 {
@@ -10,26 +11,24 @@ namespace KoreBuild.Tasks.Utilities
     /// </summary>
     internal class VsInstallation
     {
+        private static readonly string[] Versions = { "Current", "15.0", "16.0" };
+
         public string DisplayName { get; set; }
         public string InstallationPath { get; set; }
 
         // Add methods for additional info inferred from the vswhere.exe output.
         public string GetMSBuildx86SubPath()
         {
-            var path = Path.Combine(InstallationPath, "MSBuild", "15.0", "Bin", "MSBuild.exe");
-
-            return File.Exists(path)
-                ? path
-                : null;
+            return Versions
+                .Select(v => Path.Combine(InstallationPath, "MSBuild", v, "Bin", "MSBuild.exe"))
+                .FirstOrDefault(File.Exists);
         }
 
         public string GetMSBuildx64SubPath()
         {
-            var path = Path.Combine(InstallationPath, "MSBuild", "15.0", "Bin", "amd64", "MSBuild.exe");
-
-            return File.Exists(path)
-                ? path
-                : null;
+            return Versions
+                .Select(v => Path.Combine(InstallationPath, "MSBuild", v, "Bin", "amd64", "MSBuild.exe"))
+                .FirstOrDefault(File.Exists);
         }
     }
 }


### PR DESCRIPTION
Changes:

* Enables the use of https://github.com/dotnet/arcade/tree/master/src/SignCheck on real-signed builds.
* Update the "Find MSBuild" logic to work when VS 2019 is installed.