### PR TITLE
Upgrade SignCheck to 1.0.0-beta.18559.6

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -3,8 +3,8 @@
     <HtmlAgilityPackPackageVersion>1.5.1</HtmlAgilityPackPackageVersion>
     <MicroBuildCorePackageVersion>0.3.0</MicroBuildCorePackageVersion>
     <MicrosoftDotNetPlatformAbstractionsVersion>2.0.0</MicrosoftDotNetPlatformAbstractionsVersion>
-    <MicrosoftDotNetSignToolPackageVersion>1.0.0-beta.18558.2</MicrosoftDotNetSignToolPackageVersion>
-    <MicrosoftDotNetSignCheckPackageVersion>1.0.0-beta.18558.2</MicrosoftDotNetSignCheckPackageVersion>
+    <MicrosoftDotNetSignToolPackageVersion>1.0.0-beta.18559.6</MicrosoftDotNetSignToolPackageVersion>
+    <MicrosoftDotNetSignCheckPackageVersion>1.0.0-beta.18559.6</MicrosoftDotNetSignCheckPackageVersion>
     <MicrosoftNETTestSdkPackageVersion>15.9.0</MicrosoftNETTestSdkPackageVersion>
     <MonoCecilPackageVersion>0.10.0-beta6</MonoCecilPackageVersion>
     <MoqPackageVersion>4.7.99</MoqPackageVersion>

--- a/modules/KoreBuild.Tasks/CodeSign.targets
+++ b/modules/KoreBuild.Tasks/CodeSign.targets
@@ -69,7 +69,7 @@
 
     <ItemGroup>
       <SignCheckArgs Remove="@(SignCheckArgs)" />
-      <SignCheckArgs Include="--verbosity;Detailed" />
+      <SignCheckArgs Include="--error-log-file;$(LogOutputDir)signcheck.errors.log" />
       <SignCheckArgs Include="--generate-exclusions-file;$(LogOutputDir)signcheck.exclusions.g.txt" />
       <SignCheckArgs Include="--input-files;$(SignCheckWorkingDir)" />
       <SignCheckArgs Include="--recursive" />
@@ -80,7 +80,7 @@
 
     <Message Text="Running signcheck on $(SignCheckWorkingDir)" Importance="high" />
 
-    <Run FileName="$(SignCheckToolPath)" Arguments="@(SignCheckArgs)" StandardOutputImportance="Normal" />
+    <Run FileName="$(SignCheckToolPath)" Arguments="@(SignCheckArgs)" />
   </Target>
 
 </Project>

--- a/modules/KoreBuild.Tasks/KoreBuild.Tasks.csproj
+++ b/modules/KoreBuild.Tasks/KoreBuild.Tasks.csproj
@@ -12,8 +12,8 @@
     <Compile Include="..\..\shared\Utilities\MSBuildListSplitter.cs" />
     <Compile Include="..\..\tools\KoreBuildSettings.cs" />
     <Content Include="$(VSWhereDir)vswhere.exe" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest" />
-    <Content Include="$(PkgMicrosoft_DotNet_SignTool)\tools\**\*" Link="SignTool\tools\%(RecursiveDir)%(FileName)%(Extension)" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest" />
     <Content Include="$(PkgMicrosoft_DotNet_SignCheck)\tools\**\*" Link="SignCheck\tools\%(RecursiveDir)%(FileName)%(Extension)" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest" />
+    <Content Include="$(PkgMicrosoft_DotNet_SignTool)\tools\**\*" Link="SignTool\tools\%(RecursiveDir)%(FileName)%(Extension)" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest" />
     <Content Include="$(PkgMicrosoft_DotNet_SignTool)\build\**\*" Link="SignTool\build\%(RecursiveDir)%(FileName)%(Extension)" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest" />
     <Content Include="$(MSBuildThisFileDirectory)SkipStrongNames.xml" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest" />
  </ItemGroup>


### PR DESCRIPTION
Includes two important fixes to SignCheck which caused build failures and required disabling this temporarily.