### PR TITLE
Always set UseShellExecute false when stdout/err is redirected

### DIFF
--- a/modules/KoreBuild.Tasks/GetToolsets.cs
+++ b/modules/KoreBuild.Tasks/GetToolsets.cs
@@ -136,6 +136,7 @@ namespace KoreBuild.Tasks
                 FileName = nodePath,
                 Arguments = "--version",
                 RedirectStandardOutput = true,
+                UseShellExecute = false,
             });
             process.WaitForExit();
 

--- a/test/KoreBuild.FunctionalTests/SimpleRepoTests.cs
+++ b/test/KoreBuild.FunctionalTests/SimpleRepoTests.cs
@@ -143,7 +143,8 @@ namespace KoreBuild.FunctionalTests
         {
             var startInfo = new ProcessStartInfo("docker", @"version -f ""{{ .Server.Os }}""")
             {
-                RedirectStandardOutput = true
+                RedirectStandardOutput = true,
+                UseShellExecute = false,
             };
 
             using (var process = Process.Start(startInfo))
@@ -186,7 +187,8 @@ namespace KoreBuild.FunctionalTests
                 var startInfo = new ProcessStartInfo("docker", "--version")
                 {
                     RedirectStandardOutput = true,
-                    RedirectStandardError = true
+                    RedirectStandardError = true,
+                    UseShellExecute = false,
                 };
                 using (Process.Start(startInfo))
                 {

--- a/test/KoreBuild.FunctionalTests/Utilities/TestApp.cs
+++ b/test/KoreBuild.FunctionalTests/Utilities/TestApp.cs
@@ -77,6 +77,7 @@ namespace KoreBuild.FunctionalTests
                 Arguments = ArgumentEscaper.EscapeAndConcatenate(arguments),
                 RedirectStandardError = true,
                 RedirectStandardOutput = true,
+                UseShellExecute = false,
 
                 WorkingDirectory = WorkingDirectory,
             };
@@ -91,6 +92,7 @@ namespace KoreBuild.FunctionalTests
                 output.WriteLine(e.Data ?? string.Empty);
             }
 
+            psi.UseShellExecute = false;
             psi.RedirectStandardError = true;
             psi.RedirectStandardOutput = true;
             psi.Environment["PATH"] = Path.GetDirectoryName(Process.GetCurrentProcess().MainModule.FileName) + Path.PathSeparator + Environment.GetEnvironmentVariable("PATH");


### PR DESCRIPTION
Fixes https://github.com/aspnet/AspNetCore-Internal/issues/1468 for 2.1: this is required to run tasks on .NET Framework.