### PR TITLE
Fix NU5123 when the package id for shared sources is long

### DIFF
--- a/files/KoreBuild/modules/sharedsources/sharedsources.csproj
+++ b/files/KoreBuild/modules/sharedsources/sharedsources.csproj
@@ -50,11 +50,11 @@
   <ItemGroup Condition="'$(NuspecBasePath)'!=''">
     <Compile Include="$(NuspecBasePath)**\*.cs" Exclude="$(DefaultExcludeItems)">
       <Pack>true</Pack>
-      <PackagePath>$(ContentTargetFolders)\cs\netstandard1.0\$(PackageId)\%(RecursiveDir)\</PackagePath>
+      <PackagePath>$(ContentTargetFolders)\cs\netstandard1.0\shared\%(RecursiveDir)\</PackagePath>
     </Compile>
     <EmbeddedResource Include="$(NuspecBasePath)**\*.resx" Exclude="$(DefaultExcludeItems)">
       <Pack>true</Pack>
-      <PackagePath>$(ContentTargetFolders)\any\any\$(PackageId)\%(RecursiveDir)\</PackagePath>
+      <PackagePath>$(ContentTargetFolders)\any\any\shared\%(RecursiveDir)\</PackagePath>
     </EmbeddedResource>
   </ItemGroup>
 


### PR DESCRIPTION
Cherry-pick's https://github.com/aspnet/BuildTools/commit/84dcc6f0eb5455a3c0305d6d238926defb050889 back to release/2.1 to resolve NU5123

Resolves https://github.com/aspnet/AspNetCore-Internal/issues/1477