### PR TITLE
Fix powershell

### DIFF
--- a/files/KoreBuild/scripts/KoreBuild.psm1
+++ b/files/KoreBuild/scripts/KoreBuild.psm1
@@ -125,7 +125,7 @@ function Invoke-RepositoryBuild(
         }
         else {
             [string[]]$repoTasksArgs = $MSBuildArgs | Where-Object { ($_ -like '-p:*') -or ($_ -like '/p:*') -or ($_ -like '-property:') -or ($_ -like '/property:') }
-            $repoTasksArgs += ,"@$msBuildLogRspFile"
+            $repoTasksArgs += , "@$msBuildLogRspFile"
             __build_task_project $Path $repoTasksArgs
         }
 
@@ -227,7 +227,7 @@ function Install-Tools(
     # Currently, the only way to configure the NuGetSdkResolver is with NuGet.config, which is not generally used in aspnet org projects.
     # This project is restored so that it pre-populates the NuGet cache with SDK packages.
     $restorerfile = "$PSScriptRoot/../modules/BundledPackages/BundledPackageRestorer.csproj"
-    $restorerfilelock="$env:NUGET_PACKAGES/internal.aspnetcore.sdk/$(Get-KoreBuildVersion)/korebuild.sentinel"
+    $restorerfilelock = "$env:NUGET_PACKAGES/internal.aspnetcore.sdk/$(Get-KoreBuildVersion)/korebuild.sentinel"
     if ((Test-Path $restorerfile) -and -not (Test-Path $restorerfilelock)) {
         New-Item -ItemType Directory $(Split-Path -Parent $restorerfilelock) -ErrorAction Ignore | Out-Null
         New-Item -ItemType File $restorerfilelock -ErrorAction Ignore | Out-Null
@@ -301,7 +301,7 @@ function Set-KoreBuildSettings(
     if (!$DotNetHome) {
         $DotNetHome = if ($env:DOTNET_HOME) { $env:DOTNET_HOME } `
             elseif ($CI) { Join-Path $RepoPath '.dotnet'}
-            elseif ($env:USERPROFILE) { Join-Path $env:USERPROFILE '.dotnet'} `
+        elseif ($env:USERPROFILE) { Join-Path $env:USERPROFILE '.dotnet'} `
             elseif ($env:HOME) {Join-Path $env:HOME '.dotnet'}`
             else { Join-Path $RepoPath '.dotnet'}
     }
@@ -489,7 +489,7 @@ function Get-MSBuildPath() {
 
     Write-Verbose "vswhere = $vswherePath $vswhereArgs"
 
-    $installations = & $vswherePath @vswhereArgs | ConvertFrom-Json
+    $installations = & $vswherePath @vswhereArgs > ConvertFrom-Json
 
     $latest = $null
     if ($installations) {


### PR DESCRIPTION
Some versions of powershell don't work with `& $vswherePath @vswhereArgs | ConvertFrom-Json`, but they do work with `& $vswherePath @vswhereArgs > ConvertFrom-Json`.