### PR TITLE
Add flag to disable deterministic source root

### DIFF
--- a/src/Internal.AspNetCore.Sdk/build/Git.targets
+++ b/src/Internal.AspNetCore.Sdk/build/Git.targets
@@ -18,7 +18,7 @@
 
       Only set this in CI builds, otherwise it will mess up the debugger.
     -->
-    <DeterministicSourceRoot Condition=" '$(CI)' == 'true' AND '$(RepositoryRoot)' != '' ">/_/</DeterministicSourceRoot>
+    <DeterministicSourceRoot Condition=" '$(DisableDeterministicSourceRoot)' == 'true' AND '$(CI)' == 'true' AND '$(RepositoryRoot)' != '' ">/_/</DeterministicSourceRoot>
 
     <SourceLinkRoot Condition="'$(DeterministicSourceRoot)' != ''">$(DeterministicSourceRoot)</SourceLinkRoot>
     <SourceLinkRoot Condition="'$(SourceLinkRoot)' == '' AND '$(RepositoryRoot)' != ''">$([MSBuild]::NormalizeDirectory($(RepositoryRoot)))</SourceLinkRoot>


### PR DESCRIPTION
This can lead to test failures which require reading symbols and mapping to source, like aspnet/AspNetCore/src/MusicStore.