### PR TITLE
Support building projects which have custom implementations of 'Restore' and 'Test' targets

### DIFF
--- a/files/KoreBuild/modules/projectbuild/module.targets
+++ b/files/KoreBuild/modules/projectbuild/module.targets
@@ -47,11 +47,6 @@ Executes /t:{Target} on all projects
     <ConvertToAbsolutePath Paths="@(_Temp)">
       <Output TaskParameter="AbsolutePaths" ItemName="ProjectToBuild" />
     </ConvertToAbsolutePath>
-
-    <PropertyGroup>
-      <!-- Normalize paths to avoid false warnings by NuGet about missing project references. -->
-      <ProjectToBuildList>@(ProjectToBuild->'%(FullPath)')</ProjectToBuildList>
-    </PropertyGroup>
   </Target>
 
   <Target Name="_EnsureProjects">
@@ -59,12 +54,41 @@ Executes /t:{Target} on all projects
   </Target>
 
   <Target Name="RestoreProjects" DependsOnTargets="ResolveProjects;_EnsureProjects" Condition="'$(NoRestore)' != 'true'">
+    <!-- This finds which projects support restore via NuGet.targets. -->
+    <MSBuild Targets="_IsProjectRestoreSupported"
+             Projects="@(ProjectToBuild)"
+             BuildInParallel="true"
+             SkipNonexistentTargets="true"
+             SkipNonexistentProjects="true"
+             RemoveProperties="$(_BuildPropertiesToRemove)"
+             Properties="$(BuildProperties)">
+      <Output
+          TaskParameter="TargetOutputs"
+          ItemName="_ProjectToRestoreWithNuGet" />
+    </MSBuild>
+
+    <PropertyGroup>
+      <!-- Normalize paths to avoid false warnings by NuGet about missing project references. -->
+      <_ProjectToRestoreWithNuGetList>@(_ProjectToRestoreWithNuGet->'%(FullPath)')</_ProjectToRestoreWithNuGetList>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <_ProjectToRestoreDirectly Include="@(ProjectToBuild)"
+                                 Exclude="@(_ProjectToRestoreWithNuGet)" />
+    </ItemGroup>
+
+    <MSBuild Condition="@(_ProjectToRestoreDirectly->Count()) != 0"
+             Projects="@(_ProjectToRestoreDirectly)"
+             Targets="Restore"
+             Properties="$(BuildProperties);__BuildTarget=Restore"
+             RemoveProperties="$(_BuildPropertiesToRemove)"
+             BuildInParallel="$(BuildInParallel)" />
     <!--
       Invoke NuGet.targets directly. This avoids redundant calls the restore task.
     -->
-    <MSBuild Projects="$(NuGetRestoreTargets)"
+    <MSBuild Condition=" '$(_ProjectToRestoreWithNuGetList)' != '' " Projects="$(NuGetRestoreTargets)"
              Targets="Restore"
-             Properties="$(BuildProperties);RestoreGraphProjectInput=$(ProjectToBuildList);__BuildTarget=Restore"
+             Properties="$(BuildProperties);RestoreGraphProjectInput=$(_ProjectToRestoreWithNuGetList);__BuildTarget=Restore"
              RemoveProperties="$(_BuildPropertiesToRemove)"
              BuildInParallel="$(BuildInParallel)" />
   </Target>

--- a/files/KoreBuild/modules/projectbuild/module.targets
+++ b/files/KoreBuild/modules/projectbuild/module.targets
@@ -72,6 +72,7 @@ Executes /t:{Target} on all projects
       <_ProjectToRestoreWithNuGetList>@(_ProjectToRestoreWithNuGet->'%(FullPath)')</_ProjectToRestoreWithNuGetList>
     </PropertyGroup>
 
+    <!-- Invoke the 'Restore' target on projects which do not support NuGet. -->
     <ItemGroup>
       <_ProjectToRestoreDirectly Include="@(ProjectToBuild)"
                                  Exclude="@(_ProjectToRestoreWithNuGet)" />

--- a/files/KoreBuild/modules/projectbuild/module.targets
+++ b/files/KoreBuild/modules/projectbuild/module.targets
@@ -61,7 +61,7 @@ Executes /t:{Target} on all projects
              SkipNonexistentTargets="true"
              SkipNonexistentProjects="true"
              RemoveProperties="$(_BuildPropertiesToRemove)"
-             Properties="$(BuildProperties)">
+             Properties="$(BuildProperties);__BuildTarget=_IsProjectRestoreSupported">
       <Output
           TaskParameter="TargetOutputs"
           ItemName="_ProjectToRestoreWithNuGet" />

--- a/files/KoreBuild/modules/vstest/Project.Inspection.targets
+++ b/files/KoreBuild/modules/vstest/Project.Inspection.targets
@@ -9,9 +9,9 @@
     <VsTestSupported Condition="'$(VsTestSupported)' == '' AND ( '$(MSBuildProjectExtension)' == '.csproj' OR '$(MSBuildProjectExtension)' == '.vbproj' OR '$(MSBuildProjectExtension)' == '.fsproj' )">true</VsTestSupported>
   </PropertyGroup>
 
-  <Target Name="_IsKoreBuildVsTestSupported" Returns="@(_IsKoreBuildVsTestSupported)">
+  <Target Name="_IsVsTestSupported " Returns="@(_IsVsTestSupported )">
     <ItemGroup Condition="'$(VsTestSupported)' == 'true' ">
-      <_IsKoreBuildVsTestSupported Include="$(MSBuildProjectFullPath)" />
+      <_IsVsTestSupported  Include="$(MSBuildProjectFullPath)" />
     </ItemGroup>
   </Target>
 

--- a/files/KoreBuild/modules/vstest/Project.Inspection.targets
+++ b/files/KoreBuild/modules/vstest/Project.Inspection.targets
@@ -3,8 +3,17 @@
   <PropertyGroup>
     <GetTestAssemblyDependsOn Condition="'$(TargetFramework)' != ''">GetTargetPath</GetTestAssemblyDependsOn>
     <!-- TestGroupNamePrefix can be set externally when building multiple repos together -->
+    <TestGroupName Condition="'$(TestGroupName)' == '' and '$(RunTestAssembliesInParallel)' == 'false'">$(TestGroupNamePrefix)$(MSBuildProjectName)</TestGroupName>
     <TestGroupName Condition="'$(TestGroupName)' == ''">$(TestGroupNamePrefix)UnitTests</TestGroupName>
+
+    <VsTestSupported Condition="'$(VsTestSupported)' == '' AND ( '$(MSBuildProjectExtension)' == '.csproj' OR '$(MSBuildProjectExtension)' == '.vbproj' OR '$(MSBuildProjectExtension)' == '.fsproj' )">true</VsTestSupported>
   </PropertyGroup>
+
+  <Target Name="_IsKoreBuildVsTestSupported" Returns="@(_IsKoreBuildVsTestSupported)">
+    <ItemGroup Condition="'$(VsTestSupported)' == 'true' ">
+      <_IsKoreBuildVsTestSupported Include="$(MSBuildProjectFullPath)" />
+    </ItemGroup>
+  </Target>
 
   <Target Name="GetTestAssembly" DependsOnTargets="$(GetTestAssemblyDependsOn)" Returns="@(TestAssembly)">
     <ItemGroup Condition=" '$(SkipTests)' != 'true' AND ( '$(IsTestProject)' == 'true' OR ('$(IsTestProject)' == '' AND @(PackageReference->WithMetadataValue('Identity', 'Microsoft.NET.Test.Sdk')->Count()) != 0) )">

--- a/files/KoreBuild/modules/vstest/Project.Inspection.targets
+++ b/files/KoreBuild/modules/vstest/Project.Inspection.targets
@@ -9,9 +9,9 @@
     <VsTestSupported Condition="'$(VsTestSupported)' == '' AND ( '$(MSBuildProjectExtension)' == '.csproj' OR '$(MSBuildProjectExtension)' == '.vbproj' OR '$(MSBuildProjectExtension)' == '.fsproj' )">true</VsTestSupported>
   </PropertyGroup>
 
-  <Target Name="_IsVsTestSupported " Returns="@(_IsVsTestSupported )">
+  <Target Name="_IsVsTestSupported" Returns="@(_IsVsTestSupported)">
     <ItemGroup Condition="'$(VsTestSupported)' == 'true' ">
-      <_IsVsTestSupported  Include="$(MSBuildProjectFullPath)" />
+      <_IsVsTestSupported Include="$(MSBuildProjectFullPath)" />
     </ItemGroup>
   </Target>
 

--- a/files/KoreBuild/modules/vstest/module.targets
+++ b/files/KoreBuild/modules/vstest/module.targets
@@ -39,7 +39,7 @@ Runs the VSTest on all projects in the ProjectToBuild itemgroup.
   <Target Name="_ShowTestPlan" DependsOnTargets="GetTestAssemblies">
     <!-- Detect which tests support running via the VSTest target. -->
     <MSBuild Projects="@(ProjectToBuild)"
-      Targets="_IsKoreBuildVsTestSupported"
+      Targets="_IsVsTestSupported "
       Properties="$(BuildProperties);CustomAfterMicrosoftCommonTargets=$(_InspectionTargetsFile);CustomAfterMicrosoftCommonCrossTargetingTargets=$(_InspectionTargetsFile);%(ProjectToBuild.AdditionalProperties)"
       Condition="@(ProjectToBuild->Count()) != 0"
       SkipNonexistentTargets="true"
@@ -67,23 +67,26 @@ Runs the VSTest on all projects in the ProjectToBuild itemgroup.
     </PropertyGroup>
 
     <ItemGroup>
-      <TestGroups Include="$(MSBuildProjectFullPath)" Condition="'%(TestAssembly.TestGroupName)' != ''">
+      <!-- This runs test assemblies through VSTest. -->
+      <_TestGroups Include="$(MSBuildProjectFullPath)" Condition="'%(TestAssembly.TestGroupName)' != ''">
+        <Targets>_ExecuteTestAssemblies</Targets>
+        <SkipNonexistentTargets>false</SkipNonexistentTargets>
         <AdditionalProperties>Assemblies=@(TestAssembly);TestGroupName=%(TestAssembly.TestGroupName);TargetFramework=%(TestAssembly.TargetFramework);TargetFrameworkIdentifier=%(TestAssembly.TargetFrameworkIdentifier);TargetFrameworkVersion=%(TestAssembly.TargetFrameworkVersion)</AdditionalProperties>
-      </TestGroups>
+      </_TestGroups>
+
+      <!-- This runs the 'Test' target on projects which do not support VSTest, if that target exists. -->
+      <_TestGroups Include="@(_ProjectToTestDirectly)">
+        <Targets>Test</Targets>
+        <SkipNonexistentTargets>true</SkipNonexistentTargets>
+        <AdditionalProperties>$(BuildProperties)</AdditionalProperties>
+      </_TestGroups>
     </ItemGroup>
 
-    <MSBuild Condition="@(TestGroups->Count()) != 0"
-             Projects="@(TestGroups)"
-             Targets="_ExecuteTestAssemblies"
+    <MSBuild Condition="@(_TestGroups->Count()) != 0"
+             Projects="@(_TestGroups)"
+             Targets="%(_TestGroups.Targets)"
+             SkipNonexistentTargets="%(_TestGroups.SkipNonexistentTargets)"
              BuildInParallel="false"
-             ContinueOnError="$(_TestContinueOnError)" />
-
-    <MSBuild Condition="@(_ProjectToTestDirectly->Count()) != 0"
-             Projects="@(_ProjectToTestDirectly)"
-             Targets="Test"
-             SkipNonexistentTargets="true"
-             BuildInParallel="false"
-             Properties="$(BuildProperties)"
              ContinueOnError="$(_TestContinueOnError)" />
   </Target>
 

--- a/files/KoreBuild/modules/vstest/module.targets
+++ b/files/KoreBuild/modules/vstest/module.targets
@@ -83,6 +83,7 @@ Runs the VSTest on all projects in the ProjectToBuild itemgroup.
              Targets="Test"
              SkipNonexistentTargets="true"
              BuildInParallel="false"
+             Properties="$(BuildProperties)"
              ContinueOnError="$(_TestContinueOnError)" />
   </Target>
 

--- a/files/KoreBuild/modules/vstest/module.targets
+++ b/files/KoreBuild/modules/vstest/module.targets
@@ -22,6 +22,7 @@ Runs the VSTest on all projects in the ProjectToBuild itemgroup.
       Targets="GetTestAssembly"
       Properties="$(BuildProperties);CustomAfterMicrosoftCommonTargets=$(_InspectionTargetsFile);CustomAfterMicrosoftCommonCrossTargetingTargets=$(_InspectionTargetsFile);%(ProjectToBuild.AdditionalProperties)"
       Condition="@(ProjectToBuild->Count()) != 0"
+      SkipNonexistentTargets="true"
       BuildInParallel="true"
       RemoveProperties="$(_BuildPropertiesToRemove)">
       <Output TaskParameter="TargetOutputs" ItemName="TestAssembly" />
@@ -33,15 +34,37 @@ Runs the VSTest on all projects in the ProjectToBuild itemgroup.
     </ItemGroup>
   </Target>
 
-  <Target Name="TestProjects" DependsOnTargets="GetTestAssemblies">
+  <Target Name="TestProjects" DependsOnTargets="GetTestAssemblies;_ShowTestPlan;_RunTests" />
+
+  <Target Name="_ShowTestPlan" DependsOnTargets="GetTestAssemblies">
+    <!-- Detect which tests support running via the VSTest target. -->
+    <MSBuild Projects="@(ProjectToBuild)"
+      Targets="_IsKoreBuildVsTestSupported"
+      Properties="$(BuildProperties);CustomAfterMicrosoftCommonTargets=$(_InspectionTargetsFile);CustomAfterMicrosoftCommonCrossTargetingTargets=$(_InspectionTargetsFile);%(ProjectToBuild.AdditionalProperties)"
+      Condition="@(ProjectToBuild->Count()) != 0"
+      SkipNonexistentTargets="true"
+      BuildInParallel="true"
+      RemoveProperties="$(_BuildPropertiesToRemove)">
+      <Output TaskParameter="TargetOutputs" ItemName="_ProjectWithSupportVsTest" />
+    </MSBuild>
+
+    <ItemGroup>
+      <!-- Projects which do not support vstest can still run tests if they implement a 'Test' target. -->
+      <_ProjectToTestDirectly Include="@(ProjectToBuild)" Exclude="@(_ProjectWithSupportVsTest)" />
+    </ItemGroup>
+
+    <Message Text="%0ATest plan:" Importance="High" />
+    <Message Text="  VSTest:" Importance="High" Condition="@(TestAssembly->Count()) != 0" />
+    <Message Text="  - %(TestAssembly.TestGroupName)/%(TestAssembly.TargetFramework)%0A    - @(TestAssembly->'%(FileName)', '%0A    - ')" Importance="High" Condition="@(TestAssembly->Count()) != 0" />
+    <Message Text="  - (No test projects found)" Importance="High" Condition="@(TestAssembly->Count()) == 0"  />
+    <Message Text="  Test:%0A    - @(_ProjectToTestDirectly, '%0A    - ')" Importance="High" Condition="@(_ProjectToTestDirectly->Count()) != 0" />
+  </Target>
+
+  <Target Name="_RunTests">
     <PropertyGroup>
       <_TestContinueOnError Condition="'$(IgnoreFailingTestProjects)' == 'true'">ErrorAndContinue</_TestContinueOnError>
       <_TestContinueOnError Condition="'$(IgnoreFailingTestProjects)' != 'true'">ErrorAndStop</_TestContinueOnError>
     </PropertyGroup>
-
-    <Message Text="%0ATest plan:" Importance="High" />
-    <Message Text="  - %(TestAssembly.TestGroupName)/%(TestAssembly.TargetFramework)%0A    - @(TestAssembly->'%(FileName)', '%0A    - ')" Importance="High" Condition="@(TestAssembly->Count()) != 0" />
-    <Message Text="  - (No test projects found)" Importance="High" Condition="@(TestAssembly->Count()) == 0"  />
 
     <ItemGroup>
       <TestGroups Include="$(MSBuildProjectFullPath)" Condition="'%(TestAssembly.TestGroupName)' != ''">
@@ -49,9 +72,16 @@ Runs the VSTest on all projects in the ProjectToBuild itemgroup.
       </TestGroups>
     </ItemGroup>
 
-    <MSBuild Projects="@(TestGroups)"
+    <MSBuild Condition="@(TestGroups->Count()) != 0"
+             Projects="@(TestGroups)"
              Targets="_ExecuteTestAssemblies"
-             Condition="@(TestGroups->Count()) != 0"
+             BuildInParallel="false"
+             ContinueOnError="$(_TestContinueOnError)" />
+
+    <MSBuild Condition="@(_ProjectToTestDirectly->Count()) != 0"
+             Projects="@(_ProjectToTestDirectly)"
+             Targets="Test"
+             SkipNonexistentTargets="true"
              BuildInParallel="false"
              ContinueOnError="$(_TestContinueOnError)" />
   </Target>


### PR DESCRIPTION
Support building projects which don't fit the vanilla C# template.

Examples:
 - C++
 - Wixproj
 - Custom projects, like shims projects that invoke another build system like npm
