### PR TITLE
Fix parsing of vswhere output

### DIFF
--- a/files/KoreBuild/scripts/KoreBuild.psm1
+++ b/files/KoreBuild/scripts/KoreBuild.psm1
@@ -488,7 +488,7 @@ function Get-MSBuildPath() {
 
     Write-Verbose "vswhere = $vswherePath $vswhereArgs"
 
-    $installations = & $vswherePath @vswhereArgs | ConvertFrom-Json
+    $installations = & $vswherePath @vswhereArgs | Out-String | ConvertFrom-Json
 
     $latest = $null
     if ($installations) {


### PR DESCRIPTION
The output from vswhere may be stored as a list of lines, so the JSON parsing will fail since it operates on each line separately. By piping in `Out-String`, the result will be forced into a single string which will then be processed as a whole.

This fixes #903 and will work on Windows 8.1 with PowerShell 4. I haven’t verified this on other systems yet though although there should be no negative impact from `Out-String`.

/cc @natemcmaster 