### PR TITLE
Remove the 'Platform' property during restore to avoid double-restore

### DIFF
--- a/files/KoreBuild/modules/projectbuild/module.targets
+++ b/files/KoreBuild/modules/projectbuild/module.targets
@@ -62,7 +62,7 @@ Executes /t:{Target} on all projects
   <Target Name="RestoreProjects" DependsOnTargets="ResolveProjects;_EnsureProjects" Condition="'$(NoRestore)' != 'true'">
     <!-- This finds which projects support restore via NuGet.targets. -->
 
-    <!-- Remove the Platform project property to avoid duplicate restores. NuGet restore does not changing dependencies based on project platform. -->
+    <!-- Remove the Platform project property to avoid duplicate restores. NuGet restore does not support changing dependencies based on project platform. -->
     <MSBuild Targets="_IsProjectRestoreSupported"
              Projects="@(ProjectToBuild)"
              BuildInParallel="true"
@@ -86,7 +86,7 @@ Executes /t:{Target} on all projects
                                  Exclude="@(_ProjectToRestoreWithNuGet)" />
     </ItemGroup>
 
-    <!-- Remove the Platform project property to avoid duplicate restores. NuGet restore does not changing dependencies based on project platform. -->
+    <!-- Remove the Platform project property to avoid duplicate restores. NuGet restore does not support changing dependencies based on project platform. -->
     <MSBuild Condition="@(_ProjectToRestoreDirectly->Count()) != 0"
              Projects="@(_ProjectToRestoreDirectly)"
              Targets="Restore"

--- a/files/KoreBuild/modules/projectbuild/module.targets
+++ b/files/KoreBuild/modules/projectbuild/module.targets
@@ -61,12 +61,14 @@ Executes /t:{Target} on all projects
 
   <Target Name="RestoreProjects" DependsOnTargets="ResolveProjects;_EnsureProjects" Condition="'$(NoRestore)' != 'true'">
     <!-- This finds which projects support restore via NuGet.targets. -->
+
+    <!-- Remove the Platform project property to avoid duplicate restores. NuGet restore does not changing dependencies based on project platform. -->
     <MSBuild Targets="_IsProjectRestoreSupported"
              Projects="@(ProjectToBuild)"
              BuildInParallel="true"
              SkipNonexistentTargets="true"
              SkipNonexistentProjects="true"
-             RemoveProperties="$(_BuildPropertiesToRemove)"
+             RemoveProperties="$(_BuildPropertiesToRemove);Platform"
              Properties="$(BuildProperties);__BuildTarget=_IsProjectRestoreSupported">
       <Output
           TaskParameter="TargetOutputs"
@@ -84,11 +86,12 @@ Executes /t:{Target} on all projects
                                  Exclude="@(_ProjectToRestoreWithNuGet)" />
     </ItemGroup>
 
+    <!-- Remove the Platform project property to avoid duplicate restores. NuGet restore does not changing dependencies based on project platform. -->
     <MSBuild Condition="@(_ProjectToRestoreDirectly->Count()) != 0"
              Projects="@(_ProjectToRestoreDirectly)"
              Targets="Restore"
              Properties="$(BuildProperties);__BuildTarget=Restore"
-             RemoveProperties="$(_BuildPropertiesToRemove)"
+             RemoveProperties="$(_BuildPropertiesToRemove);Platform"
              BuildInParallel="%(_ProjectToRestoreDirectly.RestoreInParallel)" />
     <!--
       Invoke NuGet.targets directly. This avoids redundant calls the restore task.

--- a/files/KoreBuild/scripts/KoreBuild.psm1
+++ b/files/KoreBuild/scripts/KoreBuild.psm1
@@ -95,7 +95,7 @@ function Invoke-RepositoryBuild(
 /verbosity:minimal
 /p:KoreBuildVersion=$koreBuildVersion
 /p:SuppressNETCoreSdkPreviewMessage=true
-/p:RepositoryRoot="$Path/"
+/p:RepositoryRoot="$Path\\"
 "$msBuildLogArgument"
 "$makeFileProj"
 "@


### PR DESCRIPTION
Resolves https://github.com/aspnet/AspNetCore-Internal/issues/1694

These projects are included twice in the 'ProjectToBuild' list because they need to build twice for different platforms. This PR should prevent these projects for getting restored twice.

Also, this makes sure the RepositoryRoot property ends with the correct slashes for Windows builds. Mixing slashes can break MSBuild item include/excludes.

https://github.com/aspnet/AspNetCore/blob/e004e5aab29dc26beaafaed49c7aa4b780b6e98f/build/repo.props#L82-L89