### PR TITLE
Update sign tools to 1.0.0-beta.19073.4

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -3,8 +3,8 @@
     <HtmlAgilityPackPackageVersion>1.5.1</HtmlAgilityPackPackageVersion>
     <MicroBuildCorePackageVersion>0.3.0</MicroBuildCorePackageVersion>
     <MicrosoftDotNetPlatformAbstractionsVersion>2.0.0</MicrosoftDotNetPlatformAbstractionsVersion>
-    <MicrosoftDotNetSignToolPackageVersion>1.0.0-beta.18603.2</MicrosoftDotNetSignToolPackageVersion>
-    <MicrosoftDotNetSignCheckPackageVersion>1.0.0-beta.18603.2</MicrosoftDotNetSignCheckPackageVersion>
+    <MicrosoftDotNetSignToolPackageVersion>1.0.0-beta.19073.4</MicrosoftDotNetSignToolPackageVersion>
+    <MicrosoftDotNetSignCheckPackageVersion>1.0.0-beta.19073.4</MicrosoftDotNetSignCheckPackageVersion>
     <MicrosoftNETFrameworkReferenceAssembliesPackageVersion>1.0.0-alpha-004</MicrosoftNETFrameworkReferenceAssembliesPackageVersion>
     <MicrosoftNETTestSdkPackageVersion>15.9.0</MicrosoftNETTestSdkPackageVersion>
     <MonoCecilPackageVersion>0.10.0-beta6</MonoCecilPackageVersion>


### PR DESCRIPTION
Contains a fix to signcheck which will properly interpret exclusions