### PR TITLE
Pass through AdditionalProperties for _ProjectToTestDirectly

### DIFF
--- a/files/KoreBuild/modules/vstest/module.targets
+++ b/files/KoreBuild/modules/vstest/module.targets
@@ -75,10 +75,10 @@ Runs the VSTest on all projects in the ProjectToBuild itemgroup.
       </_TestGroups>
 
       <!-- This runs the 'Test' target on projects which do not support VSTest, if that target exists. -->
-      <_TestGroups Include="@(_ProjectToTestDirectly)">
+      <_TestGroups Include="%(_ProjectToTestDirectly.Identity)">
         <Targets>Test</Targets>
         <SkipNonexistentTargets>true</SkipNonexistentTargets>
-        <AdditionalProperties>$(BuildProperties)</AdditionalProperties>
+        <AdditionalProperties>%(_ProjectToTestDirectly.AdditionalProperties);$(BuildProperties)</AdditionalProperties>
       </_TestGroups>
     </ItemGroup>
 


### PR DESCRIPTION
This fixes the test failures seen in https://dev.azure.com/dnceng/public/_build/results?buildId=87094&view=logs where x64 is being built, but win32 is trying to be tested.

Reproed the issue locally and manually edited the korebuild files with this fix to verify.