### PR TITLE
add support for handling flaky tests

### DIFF
--- a/files/KoreBuild/modules/vstest/module.targets
+++ b/files/KoreBuild/modules/vstest/module.targets
@@ -94,9 +94,12 @@ Runs the VSTest on all projects in the ProjectToBuild itemgroup.
   <PropertyGroup>
     <TrxFileWithoutExtension>$(LogOutputDir)$(TestGroupName)-$(TargetFramework)-$(BuildNumber)</TrxFileWithoutExtension>
     <TrxFile>$(TrxFileWithoutExtension).trx</TrxFile>
+    <TrxFile Condition="'$(RunFlakyTests)' == 'true'">$(TrxFileWithoutExtension).flaky.trx</TrxFile>
     <TrxFileWildcard>$(TrxFileWithoutExtension)*.trx</TrxFileWildcard>
     <VSTestLogger Condition=" '$(VSTestLogger)' == '' AND '$(CI)' == 'true' ">trx;LogFileName=$(TrxFile)</VSTestLogger>
-    <VSTestDiagFile Condition=" '$(VSTestVerboseOutput)' == 'true'">$(LogOutputDir)$(TestGroupName)-$(TargetFramework)-$(BuildNumber).diag</VSTestDiagFile>
+    <VSTestDiagFileBase>$(LogOutputDir)$(TestGroupName)-$(TargetFramework)-$(BuildNumber)</VSTestDiagFileBase>
+    <VSTestDiagFile Condition=" '$(VSTestVerboseOutput)' == 'true'">$(VSTestDiagFileBase).diag</VSTestDiagFile>
+    <VSTestDiagFile Condition=" '$(VSTestVerboseOutput)' == 'true' And '$(RunFlakyTests)' == 'true'">$(VSTestDiagFileBase).flaky.diag</VSTestDiagFile>
     <!--
       Disable other test reporters if trx logging is enabled.
     -->
@@ -111,6 +114,12 @@ Runs the VSTest on all projects in the ProjectToBuild itemgroup.
 
     <PropertyGroup>
       <TestAdapterPath>%(TestAssemblies.RootDir)%(TestAssemblies.Directory)</TestAdapterPath>
+
+      <_TestFilter Condition="'$(RunFlakyTests)' != 'true'">Flaky:All!=true</_TestFilter>
+      <_TestFilter Condition="'$(RunFlakyTests)' == 'true'">Flaky:All=true</_TestFilter>
+
+      <_TestFilter Condition="'$(RunFlakyTests)' != 'true' And '$(AGENT_OS)' != ''">$(_TestFilter)&amp;Flaky:AzP:All!=true&amp;Flaky:AzP:OS:$(AGENT_OS)!=true</_TestFilter>
+      <_TestFilter Condition="'$(RunFlakyTests)' == 'true' And '$(AGENT_OS)' != ''">$(_TestFilter)|Flaky:AzP:All=true|Flaky:AzP:OS:$(AGENT_OS)=true</_TestFilter>
     </PropertyGroup>
 
     <ItemGroup>
@@ -122,6 +131,7 @@ Runs the VSTest on all projects in the ProjectToBuild itemgroup.
       <VSTestArgs Include="--Framework:$(TargetFrameworkIdentifier),Version=v$(TargetFrameworkVersion)" />
       <VSTestArgs Include="--Logger:$([MSBuild]::Escape($(VSTestLogger)))" Condition="'$(VSTestLogger)' != ''" />
       <VSTestArgs Include="--TestAdapterPath:$(TestAdapterPath)" Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' " />
+      <VSTestArgs Include="--TestCaseFilter:$(_TestFilter)" />
       <VSTestArgs Include="@(TestAssemblies)" />
       <VSTestArgs Include="--;RunConfiguration.NoAutoReporters=true" Condition="'$(VSTestAutoReporters)' != 'true'" />
     </ItemGroup>

--- a/files/KoreBuild/modules/vstest/module.targets
+++ b/files/KoreBuild/modules/vstest/module.targets
@@ -115,11 +115,17 @@ Runs the VSTest on all projects in the ProjectToBuild itemgroup.
     <PropertyGroup>
       <TestAdapterPath>%(TestAssemblies.RootDir)%(TestAssemblies.Directory)</TestAdapterPath>
 
-      <_TestFilter Condition="'$(RunFlakyTests)' != 'true'">Flaky:All!=true</_TestFilter>
-      <_TestFilter Condition="'$(RunFlakyTests)' == 'true'">Flaky:All=true</_TestFilter>
+      <_DefaultNonFlakyTestFilterExpression>Flaky:All!=true</_DefaultNonFlakyTestFilterExpression>
+      <_DefaultNonFlakyTestFilterExpression Condition="'$(AGENT_OS)' != ''">$(_DefaultNonFlakyTestFilterExpression)&amp;Flaky:AzP:All!=true&amp;Flaky:AzP:OS:$(AGENT_OS)!=true</_DefaultNonFlakyTestFilterExpression>
+      <_DefaultFlakyTestFilterExpression>Flaky:All=true</_DefaultFlakyTestFilterExpression>
+      <_DefaultFlakyTestFilterExpression Condition="'$(AGENT_OS)' != ''">$(_DefaultFlakyTestFilterExpression)|Flaky:AzP:All=true|Flaky:AzP:OS:$(AGENT_OS)=true</_DefaultFlakyTestFilterExpression>
 
-      <_TestFilter Condition="'$(RunFlakyTests)' != 'true' And '$(AGENT_OS)' != ''">$(_TestFilter)&amp;Flaky:AzP:All!=true&amp;Flaky:AzP:OS:$(AGENT_OS)!=true</_TestFilter>
-      <_TestFilter Condition="'$(RunFlakyTests)' == 'true' And '$(AGENT_OS)' != ''">$(_TestFilter)|Flaky:AzP:All=true|Flaky:AzP:OS:$(AGENT_OS)=true</_TestFilter>
+      <FlakyTestFilterExpression Condition="'$(FlakyTestFilterExpression)' == ''">$(_DefaultFlakyTestFilterExpression)</FlakyTestFilterExpression>
+      <NonFlakyTestFilterExpression Condition="'$(NonFlakyTestFilterExpression)' == ''">$(_DefaultNonFlakyTestFilterExpression)</NonFlakyTestFilterExpression>
+
+      <!-- If $(RunFlakyTests) = 'include' then we will do *neither* of these and we'll include flaky tests in the run -->
+      <TestFilterExpression Condition="'$(TestFilterExpression)' == '' And '$(RunFlakyTests)' != 'true' And '$(RunFlakyTests)' != 'include'">$(NonFlakyTestFilterExpression)</TestFilterExpression>
+      <TestFilterExpression Condition="'$(TestFilterExpression)' == '' And '$(RunFlakyTests)' == 'true'">$(FlakyTestFilterExpression)</TestFilterExpression>
     </PropertyGroup>
 
     <ItemGroup>
@@ -131,7 +137,7 @@ Runs the VSTest on all projects in the ProjectToBuild itemgroup.
       <VSTestArgs Include="--Framework:$(TargetFrameworkIdentifier),Version=v$(TargetFrameworkVersion)" />
       <VSTestArgs Include="--Logger:$([MSBuild]::Escape($(VSTestLogger)))" Condition="'$(VSTestLogger)' != ''" />
       <VSTestArgs Include="--TestAdapterPath:$(TestAdapterPath)" Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' " />
-      <VSTestArgs Include="--TestCaseFilter:$(_TestFilter)" />
+      <VSTestArgs Include="--TestCaseFilter:$(TestFilterExpression)" Condition="'$(TestFilterExpression)' != ''" />
       <VSTestArgs Include="@(TestAssemblies)" />
       <VSTestArgs Include="--;RunConfiguration.NoAutoReporters=true" Condition="'$(VSTestAutoReporters)' != 'true'" />
     </ItemGroup>

--- a/files/KoreBuild/scripts/KoreBuild.psm1
+++ b/files/KoreBuild/scripts/KoreBuild.psm1
@@ -125,7 +125,7 @@ function Invoke-RepositoryBuild(
         }
         else {
             [string[]]$repoTasksArgs = $MSBuildArgs | Where-Object { ($_ -like '-p:*') -or ($_ -like '/p:*') -or ($_ -like '-property:') -or ($_ -like '/property:') }
-            $repoTasksArgs += ,"@$msBuildLogRspFile"
+            $repoTasksArgs += , "@$msBuildLogRspFile"
             __build_task_project $Path $repoTasksArgs
         }
 
@@ -288,9 +288,17 @@ function Set-KoreBuildSettings(
     if (!$DotNetHome) {
         $DotNetHome = if ($env:DOTNET_HOME) { $env:DOTNET_HOME } `
             elseif ($CI) { Join-Path $RepoPath '.dotnet'}
-            elseif ($env:USERPROFILE) { Join-Path $env:USERPROFILE '.dotnet'} `
+        elseif ($env:USERPROFILE) { Join-Path $env:USERPROFILE '.dotnet'} `
             elseif ($env:HOME) {Join-Path $env:HOME '.dotnet'}`
             else { Join-Path $RepoPath '.dotnet'}
+    }
+
+    # Normalize RepoPath to a native File System path so other tools can use it properly
+    $RepoPath = Convert-Path $RepoPath
+
+    if ($RepoPath.EndsWith("/") -or $RepoPath.EndsWith("\")) {
+        # Remove trailing slash, we add it ourselves
+        $RepoPath = $RepoPath.Substring(0, $RepoPath.Length - 1);
     }
 
     if (!$ToolsSource) { $ToolsSource = 'https://aspnetcore.blob.core.windows.net/buildtools' }


### PR DESCRIPTION
This configures KoreBuild to skip all tests marked with the relevant `[Flaky]` attribute when `RunFlakyTests` is not set. Similarly, it configures it to *only* run the relevant flaky tests when `RunFlakyTests` **is** set.

Once this is flowing through to AspNetCore, we'll configure the AzP yaml to do two test passes, one without `RunFlakyTest` that we care about and one with `RunFlakyTests` that we ignore failures in.

Separate TRX files are generated for each run and we'll still publish all the failing tests. If RaaS is configured to "triage" successful builds, it'll be able to see these failing flaky tests and update Issues as needed.