### PR TITLE
Add support for custom restore targets

### DIFF
--- a/files/KoreBuild/modules/projectbuild/module.targets
+++ b/files/KoreBuild/modules/projectbuild/module.targets
@@ -75,6 +75,19 @@ Executes /t:{Target} on all projects
           ItemName="_ProjectToRestoreWithNuGet" />
     </MSBuild>
 
+    <MSBuild Targets="_RequiresCustomRestore"
+             Projects="@(ProjectToBuild)"
+             BuildInParallel="true"
+             SkipNonexistentTargets="true"
+             SkipNonexistentProjects="true"
+             RemoveProperties="$(_BuildPropertiesToRemove);Platform"
+             Properties="$(BuildProperties);__BuildTarget=_RequiresCustomRestore">
+      <Output
+          TaskParameter="TargetOutputs"
+          ItemName="_ProjectWithCustomRestore" />
+    </MSBuild>
+
+
     <PropertyGroup>
       <!-- Normalize paths to avoid false warnings by NuGet about missing project references. -->
       <_ProjectToRestoreWithNuGetList>@(_ProjectToRestoreWithNuGet->'%(FullPath)')</_ProjectToRestoreWithNuGetList>
@@ -93,6 +106,15 @@ Executes /t:{Target} on all projects
              Properties="$(BuildProperties);__BuildTarget=Restore"
              RemoveProperties="$(_BuildPropertiesToRemove);Platform"
              BuildInParallel="%(_ProjectToRestoreDirectly.RestoreInParallel)" />
+
+    <!-- Adds support for running a target CustomRestore on projects that require restoring artifacts from other package managers like npm -->
+    <MSBuild Condition="@(_ProjectWithCustomRestore->Count()) != 0 and '%(Targets)' != '' "
+             Projects="@(_ProjectWithCustomRestore)"
+             Targets="%(Targets)"
+             Properties="$(BuildProperties);__BuildTarget=CustomRestore"
+             RemoveProperties="$(_BuildPropertiesToRemove);Platform"
+             BuildInParallel="false" />
+
     <!--
       Invoke NuGet.targets directly. This avoids redundant calls the restore task.
     -->
@@ -102,6 +124,7 @@ Executes /t:{Target} on all projects
              RemoveProperties="$(_BuildPropertiesToRemove)"
              BuildInParallel="$(BuildInParallel)" />
   </Target>
+
 
   <Target Name="CleanProjects" DependsOnTargets="ResolveProjects;_EnsureProjects">
     <!--

--- a/files/KoreBuild/modules/projectbuild/module.targets
+++ b/files/KoreBuild/modules/projectbuild/module.targets
@@ -75,18 +75,17 @@ Executes /t:{Target} on all projects
           ItemName="_ProjectToRestoreWithNuGet" />
     </MSBuild>
 
-    <MSBuild Targets="_RequiresCustomRestore"
+    <MSBuild Targets="_IsCustomRestoreTargetSupported"
              Projects="@(ProjectToBuild)"
              BuildInParallel="true"
              SkipNonexistentTargets="true"
              SkipNonexistentProjects="true"
              RemoveProperties="$(_BuildPropertiesToRemove);Platform"
-             Properties="$(BuildProperties);__BuildTarget=_RequiresCustomRestore">
+             Properties="$(BuildProperties);__BuildTarget=_IsCustomRestoreTargetSupported">
       <Output
           TaskParameter="TargetOutputs"
           ItemName="_ProjectWithCustomRestore" />
     </MSBuild>
-
 
     <PropertyGroup>
       <!-- Normalize paths to avoid false warnings by NuGet about missing project references. -->
@@ -124,7 +123,6 @@ Executes /t:{Target} on all projects
              RemoveProperties="$(_BuildPropertiesToRemove)"
              BuildInParallel="$(BuildInParallel)" />
   </Target>
-
 
   <Target Name="CleanProjects" DependsOnTargets="ResolveProjects;_EnsureProjects">
     <!--


### PR DESCRIPTION
* Allows projects to define custom targets that will run
  during the repository restore phase, for example; at the same time we restore npmproj files.
* These custom restore targets will run sequentially, so as to avoid issues with parallelism in the most common case (npm/yarn).
* Projects will define the custom restore targets to run by providing a target like the one below.
  ```
  <Target
    Name="_RequiresCustomRestore"
    Returns="@(CustomRestoreTargets)">

    <ItemGroup>
      <CustomRestoreTargets Include="$(MSbuildThisFile)">
        <Targets>YarnInstall</Targets>
      </CustomRestoreTargets>
    </ItemGroup>
  </Target>
  ```