### PR TITLE
Obsolete RepositoryRoot property, replace with RepoRoot

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,7 +13,7 @@
   <PropertyGroup>
     <RepositoryUrl>https://github.com/aspnet/BuildTools</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <RepositoryRoot>$(MSBuildThisFileDirectory)</RepositoryRoot>
+    <RepoRoot>$(MSBuildThisFileDirectory)</RepoRoot>
   </PropertyGroup>
 
   <ItemGroup>

--- a/build/repo.targets
+++ b/build/repo.targets
@@ -48,7 +48,7 @@
     <Error Text="Missing property: Version" Condition="'$(Version)' == ''" />
 
     <ItemGroup>
-      <Content Include="$(RepositoryRoot)files\KoreBuild\**\*" />
+      <Content Include="$(RepoRoot)files\KoreBuild\**\*" />
       <VersionFileLines Include="version:$(Version)" />
       <VersionFileLines Include="commithash:$(BUILD_SOURCEVERSION)" />
     </ItemGroup>
@@ -61,7 +61,7 @@
     <WriteLinesToFile File="$(_KoreBuildIntermediateDir).version" Lines="@(VersionFileLines)" Overwrite="true" />
 
     <ItemGroup>
-      <_ModuleProjects Include="$(RepositoryRoot)modules\%(KoreBuildModule.Identity)\%(Identity).*proj">
+      <_ModuleProjects Include="$(RepoRoot)modules\%(KoreBuildModule.Identity)\%(Identity).*proj">
         <AdditionalProperties>Version=$(Version);PublishDir=$(_KoreBuildIntermediateDir)modules\%(Identity)\</AdditionalProperties>
       </_ModuleProjects>
     </ItemGroup>
@@ -75,7 +75,7 @@
       <KoreBuildFiles Include="$(_KoreBuildIntermediateDir)**\*" />
     </ItemGroup>
 
-    <Copy SourceFiles="$(RepositoryRoot)scripts\UploadKoreBuild.ps1" DestinationFiles="$(KoreBuildUploadScriptFile)" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="$(RepoRoot)scripts\UploadKoreBuild.ps1" DestinationFiles="$(KoreBuildUploadScriptFile)" SkipUnchangedFiles="true" />
     <WriteLinesToFile File="$(KoreBuildLatestTxtFile)" Lines="@(VersionFileLines)" Overwrite="true"/>
     <WriteLinesToFile File="$(KoreBuildChannelTxtFile)" Lines="$(KoreBuildChannel)" Overwrite="true"/>
     <GenerateSvgBadge Label="version" Value="$(Version)" OutputPath="$(KoreBuildBadgeFile)" />

--- a/build/tasks/RepoTasks.csproj
+++ b/build/tasks/RepoTasks.csproj
@@ -1,5 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$(RepositoryRoot)files\KoreBuild\msbuild\KoreBuild.RepoTasks.Sdk\Sdk\Sdk.props" />
+  <Import Project="$(RepoRoot)files\KoreBuild\msbuild\KoreBuild.RepoTasks.Sdk\Sdk\Sdk.props" />
 
   <PropertyGroup>
     <TargetFramework Condition=" '$(MSBuildRuntimeType)' == 'core' ">netcoreapp3.0</TargetFramework>
@@ -19,5 +19,5 @@
     <Compile Include="..\..\modules\BuildTools.Tasks\RunDotNet.cs" />
   </ItemGroup>
 
-  <Import Project="$(RepositoryRoot)files\KoreBuild\msbuild\KoreBuild.RepoTasks.Sdk\Sdk\Sdk.targets" />
+  <Import Project="$(RepoRoot)files\KoreBuild\msbuild\KoreBuild.RepoTasks.Sdk\Sdk\Sdk.targets" />
 </Project>

--- a/docs/Logging.md
+++ b/docs/Logging.md
@@ -1,7 +1,7 @@
 Logging
 -------
 
-KoreBuild produces log files to $(RepositoryRoot)/artifacts/logs. The following log formats can be used:
+KoreBuild produces log files to $(RepoRoot)/artifacts/logs. The following log formats can be used:
 
 ## Binary Logger
 

--- a/files/KoreBuild/KoreBuild.Common.props
+++ b/files/KoreBuild/KoreBuild.Common.props
@@ -33,17 +33,19 @@ Default layout and configuration.
     <Configuration Condition="'$(CI)' == 'true'">Release</Configuration>
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
     <BuildProperties>$(BuildProperties);Configuration=$(Configuration)</BuildProperties>
-    <RepositoryRoot Condition="'$(RepositoryRoot)' == ''">$(MSBuildStartupDirectory)</RepositoryRoot>
-    <RepositoryRoot>$([MSBuild]::NormalizeDirectory('$(RepositoryRoot)'))</RepositoryRoot>
-    <ArtifactsDir>$([MSBuild]::NormalizeDirectory('$(RepositoryRoot)'))artifacts\</ArtifactsDir>
+    <RepoRoot Condition="'$(RepoRoot)' == ''">$(MSBuildStartupDirectory)</RepoRoot>
+    <RepoRoot>$([MSBuild]::NormalizeDirectory('$(RepoRoot)'))</RepoRoot>
+    <!-- Older targets using KoreBuild use RepositoryRoot. Update to use RepoRoot whenever possible as a part of migrating to Arcade. -->
+    <RepositoryRoot>$(RepoRoot)</RepositoryRoot>
+    <ArtifactsDir>$([MSBuild]::NormalizeDirectory('$(RepoRoot)'))artifacts\</ArtifactsDir>
     <BuildDir>$(ArtifactsDir)build\</BuildDir>
     <LogOutputDir Condition="'$(LogOutputDir)' == ''">$(ArtifactsDir)logs\</LogOutputDir>
-    <IntermediateDir Condition="'$(IntermediateDir)' == ''">$([MSBuild]::NormalizeDirectory('$(RepositoryRoot)'))obj\</IntermediateDir>
+    <IntermediateDir Condition="'$(IntermediateDir)' == ''">$([MSBuild]::NormalizeDirectory('$(RepoRoot)'))obj\</IntermediateDir>
 
     <NuGetPackageRoot Condition=" '$(NuGetPackageRoot)' == '' ">$(NUGET_PACKAGES)</NuGetPackageRoot>
     <NuGetPackageRoot Condition=" '$(NuGetPackageRoot)' == '' AND '$(USERPROFILE)' != '' ">$(USERPROFILE)\.nuget\packages\</NuGetPackageRoot>
     <NuGetPackageRoot Condition=" '$(NuGetPackageRoot)' == '' AND '$(HOME)' != '' ">$(HOME)\.nuget\packages\</NuGetPackageRoot>
-    <NuGetPackageRoot Condition=" '$(NuGetPackageRoot)' == '' ">$(RepositoryRoot)\.nuget\packages\</NuGetPackageRoot>
+    <NuGetPackageRoot Condition=" '$(NuGetPackageRoot)' == '' ">$(RepoRoot)\.nuget\packages\</NuGetPackageRoot>
     <NuGetPackageRoot>$([MSBuild]::NormalizeDirectory('$(NuGetPackageRoot)'))</NuGetPackageRoot>
   </PropertyGroup>
 

--- a/files/KoreBuild/KoreBuild.Common.targets
+++ b/files/KoreBuild/KoreBuild.Common.targets
@@ -19,7 +19,7 @@ after all other property imports.
 
     <PackageVersion Condition="'$(PackageVersion)' == '' AND '$(Version)' != '' ">$(Version)</PackageVersion>
     <BuildProperties>$(BuildProperties);RepoVersion=$(Version);RepoPackageVersion=$(PackageVersion)</BuildProperties>
-    <BuildProperties Condition=" ! Exists('$(RepositoryRoot)version.props') ">$(BuildProperties);VerifyVersion=false</BuildProperties>
+    <BuildProperties Condition=" ! Exists('$(RepoRoot)version.props') ">$(BuildProperties);VerifyVersion=false</BuildProperties>
   </PropertyGroup>
 
 <!--
@@ -46,7 +46,7 @@ extending the *DependsOn property
 
   <Target Name="GetRepoInfo" Returns="@(RepoInfo)">
     <ItemGroup>
-      <RepoInfo Include="$(RepositoryRoot)">
+      <RepoInfo Include="$(RepoRoot)">
         <Version>$(Version)</Version>
         <PackageVersion>$(PackageVersion)</PackageVersion>
         <BuildNumber>$(BuildNumber)</BuildNumber>
@@ -93,7 +93,7 @@ extending the *DependsOn property
     <MSBuild Targets="GetArtifactInfo"
              Projects="@(ProjectToBuild)"
              Condition="@(ProjectToBuild->Count()) != 0"
-             Properties="$(BuildProperties);DesignTimeBuild=true;NoBuild=true;RepositoryRoot=$(RepositoryRoot);CustomAfterMicrosoftCommonTargets=$(_InspectionTargetsFile);CustomAfterMicrosoftCommonCrossTargetingTargets=$(_InspectionTargetsFile)"
+             Properties="$(BuildProperties);DesignTimeBuild=true;NoBuild=true;RepoRoot=$(RepoRoot);RepositoryRoot=$(RepositoryRoot);CustomAfterMicrosoftCommonTargets=$(_InspectionTargetsFile);CustomAfterMicrosoftCommonCrossTargetingTargets=$(_InspectionTargetsFile)"
              BuildInParallel="$(BuildInParallel)"
              RemoveProperties="$(_BuildPropertiesToRemove)">
 

--- a/files/KoreBuild/KoreBuild.proj
+++ b/files/KoreBuild/KoreBuild.proj
@@ -10,20 +10,20 @@
 
   <!-- props -->
   <Import Project="$(CustomBeforeKoreBuildProps)" Condition="'$(CustomBeforeKoreBuildProps)' != '' AND Exists('$(CustomBeforeKoreBuildProps)')" />
-  <Import Project="$(RepositoryRoot)build\repo.beforecommon.props" Condition="Exists('$(RepositoryRoot)build\repo.beforecommon.props')" />
+  <Import Project="$(RepoRoot)build\repo.beforecommon.props" Condition="Exists('$(RepoRoot)build\repo.beforecommon.props')" />
   <Import Project="KoreBuild.Common.props" />
   <Import Project="modules\*\module.props" />
   <Import Project="$(CustomKoreBuildModulesPath)\*\module.props" Condition="Exists('$(CustomKoreBuildModulesPath)')" />
 
-  <Import Project="$(RepositoryRoot)version.props" Condition="Exists('$(RepositoryRoot)version.props')" />
-  <Import Project="$(RepositoryRoot)build\repo.props" Condition="Exists('$(RepositoryRoot)build\repo.props')" />
-  <Import Project="$(RepositoryRoot)build\tasks\*.tasks" Condition="Exists('$(RepositoryRoot)build\tasks\')" />
+  <Import Project="$(RepoRoot)version.props" Condition="Exists('$(RepoRoot)version.props')" />
+  <Import Project="$(RepoRoot)build\repo.props" Condition="Exists('$(RepoRoot)build\repo.props')" />
+  <Import Project="$(RepoRoot)build\tasks\*.tasks" Condition="Exists('$(RepoRoot)build\tasks\')" />
 
   <!-- targets -->
   <Import Project="KoreBuild.Common.targets" />
   <Import Project="modules\*\module.targets" />
   <Import Project="$(CustomKoreBuildModulesPath)\*\module.targets" Condition="Exists('$(CustomKoreBuildModulesPath)')" />
-  <Import Project="$(RepositoryRoot)build\repo.targets" Condition="Exists('$(RepositoryRoot)build\repo.targets')" />
+  <Import Project="$(RepoRoot)build\repo.targets" Condition="Exists('$(RepoRoot)build\repo.targets')" />
   <Import Project="KoreBuild.Overrides.targets" />
   <Import Project="$(CustomAfterKoreBuildTargets)" Condition="'$(CustomAfterKoreBuildTargets)' != '' AND Exists('$(CustomAfterKoreBuildTargets)')" />
   <Import Project="KoreBuild.Verify.targets" />

--- a/files/KoreBuild/Project.Inspection.targets
+++ b/files/KoreBuild/Project.Inspection.targets
@@ -41,6 +41,7 @@
         <TargetFrameworks>$([MSBuild]::Escape($(TargetFrameworks)))</TargetFrameworks>
         <PackageType>$(PackageType)</PackageType>
         <RepositoryRoot>$(RepositoryRoot)</RepositoryRoot>
+        <RepoRoot>$(RepoRoot)</RepoRoot>
         <RepositoryUrl>$(RepositoryUrl)</RepositoryUrl>
         <Category>$(PackageArtifactCategory)</Category>
         <Certificate>$(PackageSigningCertName)</Certificate>
@@ -58,6 +59,7 @@
         <SourceIncluded>$(IncludeSource)</SourceIncluded>
         <PackageType>$(PackageType)</PackageType>
         <RepositoryRoot>$(RepositoryRoot)</RepositoryRoot>
+        <RepoRoot>$(RepoRoot)</RepoRoot>
         <RepositoryUrl>$(RepositoryUrl)</RepositoryUrl>
         <Category>$(PackageArtifactCategory)</Category>
         <Certificate>$(PackageSigningCertName)</Certificate>

--- a/files/KoreBuild/modules/projectbuild/module.targets
+++ b/files/KoreBuild/modules/projectbuild/module.targets
@@ -11,7 +11,7 @@ FYI: targets, properties, and items that begin with an underscore are meant to b
   </ItemDefinitionGroup>
 
   <ItemGroup Condition="'$(DisableDefaultItems)' != 'true' AND '$(BuildSolutions)' == 'false' ">
-    <ProjectToBuild Include="$(RepositoryRoot)**\*.csproj;$(RepositoryRoot)**\*.fsproj;$(RepositoryRoot)**\*.vbproj" Exclude="$(ProjectToExclude)" Condition=" '$(Projects)' == '' " />
+    <ProjectToBuild Include="$(RepoRoot)**\*.csproj;$(RepoRoot)**\*.fsproj;$(RepoRoot)**\*.vbproj" Exclude="$(ProjectToExclude)" Condition=" '$(Projects)' == '' " />
     <ProjectToBuild Include="$(Projects)" Exclude="$(ProjectToExclude)" Condition=" '$(Projects)' != '' " />
   </ItemGroup>
 
@@ -56,7 +56,7 @@ Executes /t:{Target} on all projects
   </Target>
 
   <Target Name="_EnsureProjects">
-    <Error Text="No solutions found to build in '$(RepositoryRoot)'" Condition="@(ProjectToBuild->Count()) == 0" />
+    <Error Text="No solutions found to build in '$(RepoRoot)'" Condition="@(ProjectToBuild->Count()) == 0" />
   </Target>
 
   <Target Name="RestoreProjects" DependsOnTargets="ResolveProjects;_EnsureProjects" Condition="'$(NoRestore)' != 'true'">

--- a/files/KoreBuild/modules/sharedsources/module.props
+++ b/files/KoreBuild/modules/sharedsources/module.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <SharedSourcesFolder Condition="'$(SharedSourcesFolder)' == ''">$(RepositoryRoot)shared/</SharedSourcesFolder>
+    <SharedSourcesFolder Condition="'$(SharedSourcesFolder)' == ''">$(RepoRoot)shared/</SharedSourcesFolder>
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(DisableSharedSources)' != 'true' ">

--- a/files/KoreBuild/modules/sharedsources/module.targets
+++ b/files/KoreBuild/modules/sharedsources/module.targets
@@ -3,7 +3,7 @@
 Target: PackSharedSources
 
 Creates a content files package for all each directory in
-that matches "$(RepositoryRoot)/shared/*.Sources".
+that matches "$(RepoRoot)/shared/*.Sources".
 ###################################################################
 -->
 <Project>
@@ -40,6 +40,7 @@ that matches "$(RepositoryRoot)/shared/*.Sources".
     <PropertyGroup>
       <_SharedSourcesPackageProperties>
         RepositoryRoot=$(RepositoryRoot);
+        RepoRoot=$(RepoRoot);
         ImportDirectoryBuildProps=false;
       </_SharedSourcesPackageProperties>
       <_SharedSourcesPackageProperties Condition=" '$(OverridePackageOutputPath)' != 'false' ">

--- a/files/KoreBuild/modules/sharedsources/sharedsources.csproj
+++ b/files/KoreBuild/modules/sharedsources/sharedsources.csproj
@@ -13,23 +13,23 @@
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
   <Target Name="VerifyProperties">
-    <Error Text="Missing property: RepositoryRoot" Condition="'$(RepositoryRoot)'==''"/>
+    <Error Text="Missing property: RepoRoot" Condition="'$(RepoRoot)'==''"/>
     <Error Text="Missing property: PackageId" Condition="'$(PackageId)'==''"/>
     <Error Text="Missing property: NuspecBasePath" Condition="'$(NuspecBasePath)'==''"/>
   </Target>
 
-  <Import Project="$(RepositoryRoot)build\common.props" Condition="Exists('$(RepositoryRoot)build\common.props')" />
+  <Import Project="$(RepoRoot)build\common.props" Condition="Exists('$(RepoRoot)build\common.props')" />
   <Import Project="$(NuspecBasePath)sharedsources.props" Condition="Exists('$(NuspecBasePath)sharedsources.props')" />
 
   <Target Name="WarnIfNoCommonProps" BeforeTargets="Pack">
-    <Warning Text="Expected a props file in '$(RepositoryRoot)build\common.props' or '$(DirBuildPropsInRepo)')'. The package $(PackageId) may be missing the right version number when this is left out."
-             Condition="!Exists('$(RepositoryRoot)build\common.props') And !Exists('$(DirBuildPropsInRepo)')"/>
+    <Warning Text="Expected a props file in '$(RepoRoot)build\common.props' or '$(DirBuildPropsInRepo)')'. The package $(PackageId) may be missing the right version number when this is left out."
+             Condition="!Exists('$(RepoRoot)build\common.props') And !Exists('$(DirBuildPropsInRepo)')"/>
   </Target>
 
   <PropertyGroup>
     <IsPackable>true</IsPackable>
     <NoBuild>true</NoBuild>
-    <PackageOutputPath Condition="'$(PackageOutputPath)'==''">$(RepositoryRoot)artifacts\build</PackageOutputPath>
+    <PackageOutputPath Condition="'$(PackageOutputPath)'==''">$(RepoRoot)artifacts\build</PackageOutputPath>
     <TargetFramework>netstandard1.0</TargetFramework>
     <EnableDefaultItems>false</EnableDefaultItems>
     <PackageId Condition=" '$(PackageId)' == '' ">$(ProjectDirName)</PackageId>
@@ -78,6 +78,7 @@
         <Version>$(NormalizedPackageVersion)</Version>
         <TargetFramework>$(TargetFramework)</TargetFramework>
         <RepositoryRoot>$(RepositoryRoot)</RepositoryRoot>
+        <RepoRoot>$(RepoRoot)</RepoRoot>
         <RepositoryUrl>$(RepositoryUrl)</RepositoryUrl>
         <Category>$(PackageArtifactCategory)</Category>
         <IsContainer>true</IsContainer>

--- a/files/KoreBuild/modules/solutionbuild/module.targets
+++ b/files/KoreBuild/modules/solutionbuild/module.targets
@@ -9,14 +9,14 @@ FYI: targets, properties, and items that begin with an underscore are meant to b
   </PropertyGroup>
 
   <ItemGroup Condition="'$(DisableDefaultItems)' != 'true' AND '$(BuildSolutions)' == 'true' ">
-    <Solutions Include="$(RepositoryRoot)*.sln" Exclude="@(ExcludeSolutions)" />
-    <ProjectsToPack Include="$(RepositoryRoot)src\*\*.csproj" Exclude="@(ExcludeFromPack)" />
+    <Solutions Include="$(RepoRoot)*.sln" Exclude="@(ExcludeSolutions)" />
+    <ProjectsToPack Include="$(RepoRoot)src\*\*.csproj" Exclude="@(ExcludeFromPack)" />
 
     <!-- put unit test projects ahead of functional tests -->
-    <_FunctionalTests Include="$(RepositoryRoot)test\*\*FunctionalTest*.csproj" Exclude="@(ExcludeFromTest)" />
-    <ProjectsToTest Include="$(RepositoryRoot)test\*\*.csproj" Exclude="@(_FunctionalTests);@(ExcludeFromTest)" />
+    <_FunctionalTests Include="$(RepoRoot)test\*\*FunctionalTest*.csproj" Exclude="@(ExcludeFromTest)" />
+    <ProjectsToTest Include="$(RepoRoot)test\*\*.csproj" Exclude="@(_FunctionalTests);@(ExcludeFromTest)" />
     <ProjectsToTest Include="@(_FunctionalTests)"  />
-    <BenchmarksToValidate Include="$(RepositoryRoot)benchmarks\*\*.csproj" />
+    <BenchmarksToValidate Include="$(RepoRoot)benchmarks\*\*.csproj" />
 
   </ItemGroup>
 
@@ -59,7 +59,7 @@ Executes /t:{Target} on all solutions
   </Target>
 
   <Target Name="_EnsureSolutions">
-    <Error Text="No solutions found to build in '$(RepositoryRoot)'" Condition="@(Solutions->Count()) == 0" />
+    <Error Text="No solutions found to build in '$(RepoRoot)'" Condition="@(Solutions->Count()) == 0" />
   </Target>
 
   <Target Name="RestoreSolutions" DependsOnTargets="ResolveSolutions;_EnsureSolutions" Condition="'$(NoRestore)' != 'true'">

--- a/files/KoreBuild/scripts/KoreBuild.psm1
+++ b/files/KoreBuild/scripts/KoreBuild.psm1
@@ -94,7 +94,7 @@ function Invoke-RepositoryBuild(
 /verbosity:minimal
 /p:KoreBuildVersion=$koreBuildVersion
 /p:SuppressNETCoreSdkPreviewMessage=true
-/p:RepositoryRoot="$Path\\"
+/p:RepoRoot="$Path\\"
 "$msBuildLogArgument"
 "$makeFileProj"
 "@

--- a/files/KoreBuild/scripts/invoke-repository-build.sh
+++ b/files/KoreBuild/scripts/invoke-repository-build.sh
@@ -94,7 +94,7 @@ cat > "$msbuild_response_file" <<ENDMSBUILDARGS
 /nodeReuse:false
 /p:KoreBuildVersion=$korebuild_version
 /p:SuppressNETCoreSdkPreviewMessage=true
-/p:RepositoryRoot="$repo_path/"
+/p:RepoRoot="$repo_path/"
 "$msbuild_log_argument"
 "$korebuild_proj"
 ENDMSBUILDARGS

--- a/modules/BuildTools.Tasks/module.targets
+++ b/modules/BuildTools.Tasks/module.targets
@@ -8,7 +8,7 @@ Generates resource files
 ###################################################################
 -->
   <Target Name="Resx" DependsOnTargets="ResolveSolutions">
-    <Warning Text="No solutions found to build in '$(RepositoryRoot)'" Condition="'@(Solutions)' == ''" />
+    <Warning Text="No solutions found to build in '$(RepoRoot)'" Condition="'@(Solutions)' == ''" />
 
     <PropertyGroup>
       <_ResxTargets>$(MSBuildThisFileDirectory)Project.CSharp.Resx.targets</_ResxTargets>

--- a/modules/KoreBuild.Tasks/CodeSign.props
+++ b/modules/KoreBuild.Tasks/CodeSign.props
@@ -5,12 +5,12 @@
     <DisableCodeSigning Condition=" '$(OS)' != 'Windows_NT' ">true</DisableCodeSigning>
 
     <!-- This file can be used to exclude something files from signcheck. -->
-    <SignCheckExclusionsFile Condition=" '$(SignCheckExclusionsFile)' == '' ">$(RepositoryRoot)build\signcheck.exclusions.txt</SignCheckExclusionsFile>
+    <SignCheckExclusionsFile Condition=" '$(SignCheckExclusionsFile)' == '' ">$(RepoRoot)build\signcheck.exclusions.txt</SignCheckExclusionsFile>
 
     <SignCheckWorkingDir Condition=" '$(SignCheckWorkingDir)' == '' ">$(ArtifactsDir)</SignCheckWorkingDir>
 
     <!-- Relative paths in SignToolData.json are relative to this path -->
-    <SignToolDataWorkingDir Condition=" '$(SignToolDataWorkingDir)' == '' ">$(RepositoryRoot)</SignToolDataWorkingDir>
+    <SignToolDataWorkingDir Condition=" '$(SignToolDataWorkingDir)' == '' ">$(RepoRoot)</SignToolDataWorkingDir>
 
     <!-- Dry run checks signing config without applying authenticode signatures to files. -->
     <SignToolDryRun Condition=" '$(SignType)' != 'real' AND '$(SignType)' != 'test' ">true</SignToolDryRun>

--- a/modules/KoreBuild.Tasks/module.props
+++ b/modules/KoreBuild.Tasks/module.props
@@ -61,7 +61,7 @@
       Specifies a required .NET Core SDK.
 
       Examples:
-        <DotNetCoreSdk Include="coherent" Channel="master" InstallDir="$(RepositoryRoot)\.siteextension\" />
+        <DotNetCoreSdk Include="coherent" Channel="master" InstallDir="$(RepoRoot)\.siteextension\" />
     -->
     <DotNetCoreSdk>
       <Arch>$(DefaultDotNetAssetArch)</Arch>

--- a/modules/KoreBuild.Tasks/module.targets
+++ b/modules/KoreBuild.Tasks/module.targets
@@ -5,8 +5,8 @@
     <PrepareDependsOn Condition=" '$(DisableDefaultTargets)' != 'true' ">GetToolsets;$(PrepareDependsOn)</PrepareDependsOn>
     <RestoreDependsOn Condition=" '$(DisableDefaultTargets)' != 'true' ">InstallDotNet;$(RestoreDependsOn)</RestoreDependsOn>
 
-    <KoreBuildConfigFile Condition="'$(KoreBuildConfigFile)' == ''">$(RepositoryRoot)korebuild.json</KoreBuildConfigFile>
-    <DependencyVersionsFile Condition="'$(DependencyVersionsFile)' == ''">$(RepositoryRoot)build\dependencies.props</DependencyVersionsFile>
+    <KoreBuildConfigFile Condition="'$(KoreBuildConfigFile)' == ''">$(RepoRoot)korebuild.json</KoreBuildConfigFile>
+    <DependencyVersionsFile Condition="'$(DependencyVersionsFile)' == ''">$(RepoRoot)build\dependencies.props</DependencyVersionsFile>
   </PropertyGroup>
 
 <!--

--- a/modules/NuGetPackageVerifier/module.targets
+++ b/modules/NuGetPackageVerifier/module.targets
@@ -17,7 +17,7 @@ repository root.
 ###################################################################
 -->
   <PropertyGroup>
-    <NuGetVerifierRuleFile Condition=" '$(NuGetVerifierRuleFile)' == '' ">$(RepositoryRoot)NuGetPackageVerifier.json</NuGetVerifierRuleFile>
+    <NuGetVerifierRuleFile Condition=" '$(NuGetVerifierRuleFile)' == '' ">$(RepoRoot)NuGetPackageVerifier.json</NuGetVerifierRuleFile>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Part of https://github.com/aspnet/AspNetCore/issues/7280 - Arcade uses RepoRoot, not RepositoryRoot, to mean the same thing. This upgrades code to use RepoRoot. RepositoryRoot is still defined to the same value for any old targets or repos still using this property.