### PR TITLE
Update SignCheck package version

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -4,7 +4,7 @@
     <MicroBuildCorePackageVersion>0.3.0</MicroBuildCorePackageVersion>
     <MicrosoftDotNetPlatformAbstractionsVersion>2.0.0</MicrosoftDotNetPlatformAbstractionsVersion>
     <MicrosoftDotNetSignToolPackageVersion>1.0.0-beta.19119.1</MicrosoftDotNetSignToolPackageVersion>
-    <MicrosoftDotNetSignCheckPackageVersion>1.0.0-beta.19119.1</MicrosoftDotNetSignCheckPackageVersion>
+    <MicrosoftDotNetSignCheckPackageVersion>1.0.0-beta.20569.8</MicrosoftDotNetSignCheckPackageVersion>
     <MicrosoftNETFrameworkReferenceAssembliesPackageVersion>1.0.0-preview.1</MicrosoftNETFrameworkReferenceAssembliesPackageVersion>
     <MicrosoftNETTestSdkPackageVersion>15.9.0</MicrosoftNETTestSdkPackageVersion>
     <MonoCecilPackageVersion>0.10.0-beta6</MonoCecilPackageVersion>


### PR DESCRIPTION
This is an arcade 3.x signcheck version that no longer verifies specific thumbprints. This avoids errors when certs are rotated.