### PR TITLE
Replace 'master' with 'main'

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -2,6 +2,7 @@
 trigger:
   branches:
     include:
+    - main
     - master
     - release/*
 

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -3,7 +3,6 @@ trigger:
   branches:
     include:
     - main
-    - master
     - release/*
 
 # Trigger builds for PRs to any branch

--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -74,7 +74,7 @@ jobs:
     ${{ if ne(parameters.poolName, '') }}:
       name: ${{ parameters.poolName }}
     ${{ if and(eq(parameters.poolName, ''), eq(parameters.agentOs, 'macOS')) }}:
-      vmImage: macOS-10.13
+      vmImage: macOS-10.15
     ${{ if and(eq(parameters.poolName, ''), eq(parameters.agentOs, 'Linux')) }}:
       vmImage: ubuntu-16.04
     ${{ if and(eq(parameters.poolName, ''), eq(parameters.agentOs, 'Windows')) }}:

--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -68,7 +68,7 @@ jobs:
       maxParallel: 8
       matrix: ${{ parameters.matrix }}
   # Map friendly OS names to the right queue
-  # See https://github.com/dotnet/arcade/blob/master/Documentation/ChoosingAMachinePool.md and
+  # See https://github.com/dotnet/arcade/blob/main/Documentation/ChoosingAMachinePool.md and
   # https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops&tabs=yaml#use-a-microsoft-hosted-agent
   pool:
     ${{ if ne(parameters.poolName, '') }}:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
 Contributing
 ======
 
-Information on contributing to this repo is in the [Contributing Guide](https://github.com/dotnet/AspNetCore/blob/main/CONTRIBUTING.md) in the AspNetCore repo.
+Information on contributing to this repo is in the [Contributing Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) in the AspNetCore repo.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
 Contributing
 ======
 
-Information on contributing to this repo is in the [Contributing Guide](https://github.com/aspnet/AspNetCore/blob/master/CONTRIBUTING.md) in the AspNetCore repo.
+Information on contributing to this repo is in the [Contributing Guide](https://github.com/dotnet/AspNetCore/blob/main/CONTRIBUTING.md) in the AspNetCore repo.

--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@ See [docs/README.md](./docs/README.md).
 
 Channel        | Latest Build
 ---------------|:---------------
-master         | ![badge][master-badge]
+main         | ![badge][main-badge]
 release/2.2    | ![badge][rel-2.2-badge]
 release/2.1    | ![badge][rel-2.1-badge]
 release/2.0    | ![badge][rel-2.0-badge]
 
-[master-badge]: https://aspnetcore.blob.core.windows.net/buildtools/korebuild/channels/master/badge.svg
+[main-badge]: https://aspnetcore.blob.core.windows.net/buildtools/korebuild/channels/main/badge.svg
 [rel-2.2-badge]: https://aspnetcore.blob.core.windows.net/buildtools/korebuild/channels/release/2.2/badge.svg
 [rel-2.1-badge]: https://aspnetcore.blob.core.windows.net/buildtools/korebuild/channels/release/2.1/badge.svg
 [rel-2.0-badge]: https://aspnetcore.blob.core.windows.net/buildtools/korebuild/channels/release/2.0/badge.svg

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <!--
-    Attempt to keep these mostly aligned with https://github.com/dotnet/toolset/blob/master/env/Versions.props
+    Attempt to keep these mostly aligned with https://github.com/dotnet/toolset/blob/main/env/Versions.props
     and with the version of MSBuild used by KoreBuild.
     MSBuild will prefer the assemblies that ship in the .NET Core SDK and MSbuild. The dependency versions here don't matter
     as long as the version we compile for is binary compatible with what the .NET Core SDK uses.

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <!--
-    Attempt to keep these mostly aligned with https://github.com/dotnet/toolset/blob/main/env/Versions.props
+    Attempt to keep these mostly aligned with https://github.com/dotnet/toolset/blob/master/eng/Versions.props
     and with the version of MSBuild used by KoreBuild.
     MSBuild will prefer the assemblies that ship in the .NET Core SDK and MSbuild. The dependency versions here don't matter
     as long as the version we compile for is binary compatible with what the .NET Core SDK uses.

--- a/build/sources.props
+++ b/build/sources.props
@@ -7,6 +7,7 @@
       $(RestoreSources);
       https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json;
       https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json;
+      https://dnceng.pkgs.visualstudio.com/public/_packaging/nuget-build/nuget/v3/index.json;
     </RestoreSources>
   </PropertyGroup>
 </Project>

--- a/build/sources.props
+++ b/build/sources.props
@@ -6,9 +6,7 @@
     <RestoreSources Condition="'$(DotNetBuildOffline)' != 'true'">
       $(RestoreSources);
       https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json;
-      https://dotnet.myget.org/F/msbuild/api/v3/index.json;
-      https://dotnet.myget.org/F/nuget-build/api/v3/index.json;
-      https://api.nuget.org/v3/index.json;
+      https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json;
     </RestoreSources>
   </PropertyGroup>
 </Project>

--- a/docs/KoreBuild.md
+++ b/docs/KoreBuild.md
@@ -34,10 +34,10 @@ Example:
 
 {
   // add this for editor auto-completion :)
-  "$schema": "https://raw.githubusercontent.com/aspnet/BuildTools/master/tools/korebuild.schema.json",
+  "$schema": "https://raw.githubusercontent.com/aspnet/BuildTools/main/tools/korebuild.schema.json",
 
   // specifies the channel used to update KoreBuild to new versions when you attempt to upgrade KoreBuild
-  "channel": "master",
+  "channel": "main",
 
   "toolsets": {
       // All toolsets listed in this section are treated as required toolsets

--- a/docs/Signing.md
+++ b/docs/Signing.md
@@ -137,4 +137,4 @@ For example,
 content/*.js;Microsoft.DotNet.Web.Spa.ProjectTemplates.*.nupkg; Exclude JavaScript files from codesigning in project templates
 ```
 
-See https://github.com/dotnet/arcade/tree/master/src/SignCheck for more details on SignCheck.
+See https://github.com/dotnet/arcade/tree/main/src/SignCheck for more details on SignCheck.

--- a/files/KoreBuild/scripts/dotnet-install.ps1
+++ b/files/KoreBuild/scripts/dotnet-install.ps1
@@ -17,7 +17,7 @@
     - 2-part version in a format A.B - represents a specific release
           examples: 2.0; 1.0
     - Branch name
-          examples: release/2.0.0; Master
+          examples: release/2.0.0; main
 .PARAMETER Version
     Default: latest
     Represents a build version on specific channel. Possible values:

--- a/files/KoreBuild/scripts/dotnet-install.sh
+++ b/files/KoreBuild/scripts/dotnet-install.sh
@@ -928,7 +928,7 @@ do
             echo "          - 2-part version in a format A.B - represents a specific release"
             echo "              examples: 2.0; 1.0"
             echo "          - Branch name"
-            echo "              examples: release/2.0.0; Master"
+            echo "              examples: release/2.0.0; main"
             echo "  -v,--version <VERSION>         Use specific VERSION, Defaults to \`$version\`."
             echo "      -Version"
             echo "          Possible values:"

--- a/korebuild.json
+++ b/korebuild.json
@@ -1,4 +1,4 @@
 {
   "$schema": "./tools/korebuild.schema.json",
-  "channel": "master"
+  "channel": "main"
 }

--- a/modules/KoreBuild.Tasks/module.props
+++ b/modules/KoreBuild.Tasks/module.props
@@ -61,7 +61,7 @@
       Specifies a required .NET Core SDK.
 
       Examples:
-        <DotNetCoreSdk Include="coherent" Channel="master" InstallDir="$(RepoRoot)\.siteextension\" />
+        <DotNetCoreSdk Include="coherent" Channel="main" InstallDir="$(RepoRoot)\.siteextension\" />
     -->
     <DotNetCoreSdk>
       <Arch>$(DefaultDotNetAssetArch)</Arch>

--- a/scripts/bootstrapper/run.ps1
+++ b/scripts/bootstrapper/run.ps1
@@ -52,8 +52,8 @@ in the file are overridden by command line parameters.
 Example config file:
 ```json
 {
-  "$schema": "https://raw.githubusercontent.com/aspnet/BuildTools/master/tools/korebuild.schema.json",
-  "channel": "master",
+  "$schema": "https://raw.githubusercontent.com/aspnet/BuildTools/main/tools/korebuild.schema.json",
+  "channel": "main",
   "toolsSource": "https://aspnetcore.blob.core.windows.net/buildtools"
 }
 ```
@@ -193,7 +193,7 @@ if (!$DotNetHome) {
         else { Join-Path $PSScriptRoot '.dotnet'}
 }
 
-if (!$Channel) { $Channel = 'master' }
+if (!$Channel) { $Channel = 'main' }
 if (!$ToolsSource) { $ToolsSource = 'https://aspnetcore.blob.core.windows.net/buildtools' }
 
 # Execute

--- a/scripts/bootstrapper/run.sh
+++ b/scripts/bootstrapper/run.sh
@@ -251,7 +251,7 @@ if [ -f "$config_file" ]; then
 fi
 
 [ -z "${DOTNET_HOME:-}" ] && DOTNET_HOME="$HOME/.dotnet"
-[ -z "$channel" ] && channel='master'
+[ -z "$channel" ] && channel='main'
 [ -z "$tools_source" ] && tools_source='https://aspnetcore.blob.core.windows.net/buildtools'
 
 get_korebuild

--- a/testassets/RepoThatShouldFailToBuild/korebuild.json
+++ b/testassets/RepoThatShouldFailToBuild/korebuild.json
@@ -1,4 +1,4 @@
 {
-  "$schema": "https://raw.githubusercontent.com/aspnet/BuildTools/master/tools/korebuild.schema.json",
-  "channel": "master"
+  "$schema": "https://raw.githubusercontent.com/aspnet/BuildTools/main/tools/korebuild.schema.json",
+  "channel": "main"
 }

--- a/testassets/SimpleRepo/korebuild.json
+++ b/testassets/SimpleRepo/korebuild.json
@@ -1,4 +1,4 @@
 {
-  "$schema": "https://raw.githubusercontent.com/aspnet/BuildTools/master/tools/korebuild.schema.json",
-  "channel": "master"
+  "$schema": "https://raw.githubusercontent.com/aspnet/BuildTools/main/tools/korebuild.schema.json",
+  "channel": "main"
 }

--- a/tools/korebuild.schema.json
+++ b/tools/korebuild.schema.json
@@ -109,9 +109,9 @@
     "channel": {
       "description": "The channel of KoreBuild used to select a version when korebuild-lock.txt is not present.",
       "type": "string",
-      "default": "master",
+      "default": "main",
       "enum": [
-        "master",
+        "main",
         "release/2.2",
         "release/2.1",
         "release/2.0"

--- a/version.props
+++ b/version.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <KoreBuildChannel>master</KoreBuildChannel>
+    <KoreBuildChannel>main</KoreBuildChannel>
     <VersionPrefix>3.0.0</VersionPrefix>
     <VersionSuffix>build</VersionSuffix>
     <BuildNumber Condition="'$(BuildNumber)' == ''">t000</BuildNumber>


### PR DESCRIPTION
Is there something we need to configure to ensure the necessary drop share channels (not darc channels) are configured? I'm not sure if it's completely controlled by the settings in this repo.