### PR TITLE
Prep for branding & baselines

### DIFF
--- a/.azure/templates/jobs/default-build.yml
+++ b/.azure/templates/jobs/default-build.yml
@@ -76,7 +76,7 @@ jobs:
     ${{ if and(eq(parameters.poolName, ''), eq(parameters.agentOs, 'macOS')) }}:
       vmImage: macOS-10.14
     ${{ if and(eq(parameters.poolName, ''), eq(parameters.agentOs, 'Linux')) }}:
-      vmImage: ubuntu-16.04
+      vmImage: ubuntu-18.04
     ${{ if and(eq(parameters.poolName, ''), eq(parameters.agentOs, 'Windows')) }}:
       vmImage: vs2017-win2016
       ${{ if ne(variables['System.TeamProject'], 'public') }}:
@@ -88,6 +88,9 @@ jobs:
     DOTNET_HOME: $(Agent.BuildDirectory)/.dotnet
     BuildScriptArgs: ${{ parameters.buildArgs }}
     BuildConfiguration: ${{ parameters.configuration }}
+    LC_ALL: 'en_US.UTF-8'
+    LANG: 'en_US.UTF-8'
+    LANGUAGE: 'en_US.UTF-8'
     TeamName: AspNetCore
     ${{ if and(eq(parameters.codeSign, 'true'), eq(variables['System.TeamProject'], 'internal'), ne(variables['Build.Reason'], 'PullRequest')) }}:
       _SignType: real

--- a/build/repo.targets
+++ b/build/repo.targets
@@ -32,6 +32,12 @@
   </ItemGroup>
 
   <Target Name="ResolveRepositoryCommit" Condition="'$(RepositoryCommit)'==''" BeforeTargets="Prepare">
+    <PropertyGroup>
+      <RepositoryCommit Condition="'$(APPVEYOR_REPO_COMMIT)' != ''">$(APPVEYOR_REPO_COMMIT)</RepositoryCommit>
+      <RepositoryCommit Condition="'$(BUILD_SOURCEVERSION)' != ''">$(BUILD_SOURCEVERSION)</RepositoryCommit>
+      <RepositoryCommit Condition="'$(TRAVIS_COMMIT)' != ''">$(TRAVIS_COMMIT)</RepositoryCommit>
+      <RepositoryCommit Condition="'$(CommitHash)' != ''">$(CommitHash)</RepositoryCommit>
+    </PropertyGroup>
 
     <GetGitCommitInfo WorkingDirectory="$(RepositoryRoot)"
                       Condition="'$(RepositoryCommit)' == ''">

--- a/modules/BuildTools.Tasks/module.targets
+++ b/modules/BuildTools.Tasks/module.targets
@@ -15,6 +15,7 @@
   <Target Name="ResolveCommitHash" Condition="'$(RepositoryCommit)' == ''">
     <PropertyGroup>
       <RepositoryCommit Condition="'$(APPVEYOR_REPO_COMMIT)' != ''">$(APPVEYOR_REPO_COMMIT)</RepositoryCommit>
+      <RepositoryCommit Condition="'$(BUILD_SOURCEVERSION)' != ''">$(BUILD_SOURCEVERSION)</RepositoryCommit>
       <RepositoryCommit Condition="'$(TRAVIS_COMMIT)' != ''">$(TRAVIS_COMMIT)</RepositoryCommit>
       <RepositoryCommit Condition="'$(CommitHash)' != ''">$(CommitHash)</RepositoryCommit>
     </PropertyGroup>

--- a/src/Internal.AspNetCore.Sdk/build/Git.targets
+++ b/src/Internal.AspNetCore.Sdk/build/Git.targets
@@ -35,9 +35,9 @@
   </Target>
 
   <Target Name="ResolveCommitHash" Condition="'$(RepositoryCommit)'==''">
-
     <PropertyGroup>
       <RepositoryCommit Condition="'$(APPVEYOR_REPO_COMMIT)' != ''">$(APPVEYOR_REPO_COMMIT)</RepositoryCommit>
+      <RepositoryCommit Condition="'$(BUILD_SOURCEVERSION)' != ''">$(BUILD_SOURCEVERSION)</RepositoryCommit>
       <RepositoryCommit Condition="'$(TRAVIS_COMMIT)' != ''">$(TRAVIS_COMMIT)</RepositoryCommit>
       <RepositoryCommit Condition="'$(CommitHash)' != ''">$(CommitHash)</RepositoryCommit>
     </PropertyGroup>

--- a/test/KoreBuild.Tasks.Tests/InstallDotNetTests.cs
+++ b/test/KoreBuild.Tasks.Tests/InstallDotNetTests.cs
@@ -30,7 +30,7 @@ namespace KoreBuild.Tasks.Tests
                 Directory.Delete(path, recursive: true);
             }
 
-            var request = new TaskItem("1.0.5", new Hashtable
+            var request = new TaskItem("2.1.26", new Hashtable
             {
                 ["Runtime"] = "dotnet",
                 ["InstallDir"] = path
@@ -47,7 +47,7 @@ namespace KoreBuild.Tasks.Tests
                 InstallScript = script,
             };
 
-            var expected = Path.Combine(path, "shared", "Microsoft.NETCore.App", "1.0.5", ".version");
+            var expected = Path.Combine(path, "shared", "Microsoft.NETCore.App", "2.1.26", ".version");
             Assert.False(File.Exists(expected), "Test folder should have been deleted");
 
             Assert.True(task.Execute(), "Task should pass");


### PR DESCRIPTION
- use `$(BUILD_SOURCEVERSION)` to determine SHA
    - support AzDO CI a bit more directly
  nit: use CI properties in repo.targets too
- use Ubuntu 18.04 build agents