### PR TITLE
Switch to 1ES servicing pools on release/2.1

### DIFF
--- a/.azure/templates/jobs/default-build.yml
+++ b/.azure/templates/jobs/default-build.yml
@@ -80,8 +80,8 @@ jobs:
     ${{ if and(eq(parameters.poolName, ''), eq(parameters.agentOs, 'Windows')) }}:
       vmImage: vs2017-win2016
       ${{ if ne(variables['System.TeamProject'], 'public') }}:
-        name: NetCoreInternal-Pool
-        queue: BuildPool.Windows.10.Amd64.VS2017
+        name: NetCore1ESPool-Svc-Internal
+        demands: ImageOverride -equals Build.Windows.10.Amd64.VS2017
   variables:
     AgentOsName: ${{ parameters.agentOs }}
     ASPNETCORE_TEST_LOG_MAXPATH: "200" # Keep test log file name length low enough for artifact zipping


### PR DESCRIPTION
Tracking issue: https://github.com/dotnet/core-eng/issues/14276