### PR TITLE
Add System.Net.Http everywhere

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -18,6 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="$(MicrosoftNETFrameworkReferenceAssembliesPackageVersion)" PrivateAssets="All" />
+    <PackageReference Include="System.Net.Http" Version="$(SystemNetHttpPackageVersion)" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/modules/KoreBuild.Tasks/KoreBuild.Tasks.csproj
+++ b/modules/KoreBuild.Tasks/KoreBuild.Tasks.csproj
@@ -26,7 +26,6 @@
     <PackageReference Include="vswhere" Version="$(VSWherePackageVersion)" PrivateAssets="All" />
     <PackageReference Include="Microsoft.DotNet.SignTool" Version="$(MicrosoftDotNetSignToolPackageVersion)" ExcludeAssets="All" PrivateAssets="All" />
     <PackageReference Include="Microsoft.DotNet.SignCheck" Version="$(MicrosoftDotNetSignCheckPackageVersion)" ExcludeAssets="All" PrivateAssets="All" />
-    <PackageReference Include="System.Net.Http" Version="$(SystemNetHttpPackageVersion)" ExcludeAssets="All" PrivateAssets="All" />
   </ItemGroup>
 
   <Target Name="PublishGeneratedProps" BeforeTargets="Publish">


### PR DESCRIPTION
https://github.com/aspnet/BuildTools/pull/1008 didn't resolve the CompGov bug about System.Net.Http 4.1.0. I can't reproduce it locally (building the repo does not restore that package), so I'm trying the hammer approach - just add a PackageRef to 4.3.4 to all projects in the repo. This branch doesn't matter anyways (only 2.1), so we could also consider just untracking it in CompGov.