### PR TITLE
[release/2.1] Remove `$(CommitHash)` settings

### DIFF
--- a/.azure/templates/jobs/default-build.yml
+++ b/.azure/templates/jobs/default-build.yml
@@ -78,10 +78,10 @@ jobs:
     ${{ if and(eq(parameters.poolName, ''), eq(parameters.agentOs, 'Linux')) }}:
       vmImage: ubuntu-18.04
     ${{ if and(eq(parameters.poolName, ''), eq(parameters.agentOs, 'Windows')) }}:
-      vmImage: windows-latest
+      vmImage: windows-2019
       ${{ if ne(variables['System.TeamProject'], 'public') }}:
         name: NetCore1ESPool-Svc-Internal
-        demands: ImageOverride -equals Build.Windows.10.Amd64.VS2017
+        demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019.svc
   variables:
     AgentOsName: ${{ parameters.agentOs }}
     ASPNETCORE_TEST_LOG_MAXPATH: "200" # Keep test log file name length low enough for artifact zipping

--- a/build/repo.targets
+++ b/build/repo.targets
@@ -36,6 +36,7 @@
       <RepositoryCommit Condition="'$(APPVEYOR_REPO_COMMIT)' != ''">$(APPVEYOR_REPO_COMMIT)</RepositoryCommit>
       <RepositoryCommit Condition="'$(BUILD_SOURCEVERSION)' != ''">$(BUILD_SOURCEVERSION)</RepositoryCommit>
       <RepositoryCommit Condition="'$(TRAVIS_COMMIT)' != ''">$(TRAVIS_COMMIT)</RepositoryCommit>
+      <!-- Read from CommitHash but note CommitHash is no longer _set_ or otherwise used in this repo. -->
       <RepositoryCommit Condition="'$(CommitHash)' != ''">$(CommitHash)</RepositoryCommit>
     </PropertyGroup>
 

--- a/modules/BuildTools.Tasks/module.targets
+++ b/modules/BuildTools.Tasks/module.targets
@@ -17,6 +17,7 @@
       <RepositoryCommit Condition="'$(APPVEYOR_REPO_COMMIT)' != ''">$(APPVEYOR_REPO_COMMIT)</RepositoryCommit>
       <RepositoryCommit Condition="'$(BUILD_SOURCEVERSION)' != ''">$(BUILD_SOURCEVERSION)</RepositoryCommit>
       <RepositoryCommit Condition="'$(TRAVIS_COMMIT)' != ''">$(TRAVIS_COMMIT)</RepositoryCommit>
+      <!-- Read from CommitHash but note CommitHash is no longer _set_ or otherwise used in this repo. -->
       <RepositoryCommit Condition="'$(CommitHash)' != ''">$(CommitHash)</RepositoryCommit>
     </PropertyGroup>
 
@@ -27,13 +28,6 @@
     </GetGitCommitHash>
 
     <PropertyGroup>
-      <!--
-        RepositoryCommit should be the same as CommitHash.
-        We use CommitHash for backwards compatibility with build scripts.
-        Setting RepositoryCommit enables NuGet features added in NuGet/NuGet.Client#2036.
-      -->
-      <CommitHash>$(RepositoryCommit)</CommitHash>
-      <BuildProperties Condition="'$(RepositoryCommit)' != ''">$(BuildProperties);CommitHash=$(RepositoryCommit)</BuildProperties>
       <BuildProperties Condition="'$(RepositoryCommit)' != ''">$(BuildProperties);RepositoryCommit=$(RepositoryCommit)</BuildProperties>
     </PropertyGroup>
   </Target>

--- a/src/Internal.AspNetCore.Sdk/build/Git.targets
+++ b/src/Internal.AspNetCore.Sdk/build/Git.targets
@@ -1,7 +1,6 @@
 ﻿<Project>
 
   <PropertyGroup>
-    <CommitHash Condition="'$(RepositoryCommit)' == ''">$(RepositoryCommit)</CommitHash>
     <GenerateCommitHashAttribute Condition="'$(GenerateCommitHashAttribute)'==''">true</GenerateCommitHashAttribute>
     <GeneratedCommitHashAttributeFile Condition="'$(GeneratedCommitHashAttributeFile)'==''">$(IntermediateOutputPath)$(AssemblyName).CommitHash$(DefaultLanguageSourceExtension)</GeneratedCommitHashAttributeFile>
     <SourceLinkDestination Condition="'$(SourceLinkDestination)' == ''">$(IntermediateOutputPath)sourcelink.json</SourceLinkDestination>
@@ -39,6 +38,7 @@
       <RepositoryCommit Condition="'$(APPVEYOR_REPO_COMMIT)' != ''">$(APPVEYOR_REPO_COMMIT)</RepositoryCommit>
       <RepositoryCommit Condition="'$(BUILD_SOURCEVERSION)' != ''">$(BUILD_SOURCEVERSION)</RepositoryCommit>
       <RepositoryCommit Condition="'$(TRAVIS_COMMIT)' != ''">$(TRAVIS_COMMIT)</RepositoryCommit>
+      <!-- Read from CommitHash but note CommitHash is no longer _set_ or otherwise used in this repo. -->
       <RepositoryCommit Condition="'$(CommitHash)' != ''">$(CommitHash)</RepositoryCommit>
     </PropertyGroup>
 
@@ -47,11 +47,6 @@
                       ContinueOnError="WarnAndContinue">
       <Output TaskParameter="CommitHash" PropertyName="RepositoryCommit" />
     </Sdk_GetGitCommitHash>
-
-    <PropertyGroup>
-      <!-- Set both CommitHash and RepositoryCommit. CommitHash was the property we started using at first. RepositoryCommit was introduced when NuGet started adding this to nuspec. -->
-      <CommitHash>$(RepositoryCommit)</CommitHash>
-    </PropertyGroup>
   </Target>
 
   <Target Name="CreateSourceLink"


### PR DESCRIPTION
- allow `$(CommitHash)` to set `$(RepositoryCommit)` but that's it
  - seemingly duplicate properties aren't adding value
  - `$(CommitHash)` was not set correctly in many cases anyhow