### PR TITLE
[release/2.1] Fix build break

### DIFF
--- a/.azure/templates/jobs/default-build.yml
+++ b/.azure/templates/jobs/default-build.yml
@@ -81,7 +81,7 @@ jobs:
       vmImage: windows-2019
       ${{ if ne(variables['System.TeamProject'], 'public') }}:
         name: NetCore1ESPool-Svc-Internal
-        demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019.svc
+        demands: ImageOverride -equals Build.Server.Amd64.VS2019
   variables:
     AgentOsName: ${{ parameters.agentOs }}
     ASPNETCORE_TEST_LOG_MAXPATH: "200" # Keep test log file name length low enough for artifact zipping


### PR DESCRIPTION
- correct `demand` for internal builds